### PR TITLE
feat: 法院短信关联文书重命名与批量下载

### DIFF
--- a/backend/apiSystem/apiSystem/urls.py
+++ b/backend/apiSystem/apiSystem/urls.py
@@ -270,6 +270,14 @@ def _get_urls_with_calculator() -> list[URLResolver | URLPattern]:
 admin.site.get_urls = _get_urls_with_calculator  # type: ignore[method-assign]
 
 
+def _admin_index_redirect(request: HttpRequest) -> HttpResponseRedirect:
+    """Admin 首页自动重定向到提醒日历页。"""
+    return HttpResponseRedirect(reverse("admin:reminders_reminder_calendar"))
+
+
+admin.site.index = admin.site.admin_view(_admin_index_redirect)  # type: ignore[method-assign]
+
+
 def index_view(request: HttpRequest) -> HttpResponse:
     """首页视图"""
     return render(request, "index.html")


### PR DESCRIPTION
## 变更内容\n- 法院短信 Admin 详情页关联文书支持手动重命名（仅允许修改文件名主体，扩展名锁定）\n- 新增关联文书批量下载按钮与 ZIP 下载接口\n- 修复 Django 6 下 change_view 的 format_html 无参 TypeError\n- 同步更新 README/CHANGELOG 到 26.33.14\n\n## 校验\n- 本地执行 backend CI 预检与 ci-check-full 全通过（unit/integration/property）\n\n## 隐私检查\n- 已对本次 diff 执行敏感信息扫描，未引入身份证号/手机号等客户隐私数据