### PR TITLE
chore: ruff 格式化 + 软著资料加入 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ playwright-report/
 
 # Animation (MG动画素材)
 .animation/
+
+# 软件著作权申请资料（含个人信息，不入库）
+软件著作权申请资料/

--- a/backend/apps/core/api/ninja_llm_api.py
+++ b/backend/apps/core/api/ninja_llm_api.py
@@ -234,6 +234,4 @@ def list_available_models(request: Any) -> Any:
     from apps.core.llm.config import LLMConfig
 
     models = LLMConfig.get_available_models()
-    return ModelListResponse(
-        models=[ModelInfo(id=m["id"], name=m["name"], backend=m["backend"]) for m in models]
-    )
+    return ModelListResponse(models=[ModelInfo(id=m["id"], name=m["name"], backend=m["backend"]) for m in models])

--- a/backend/apps/reminders/api/reminder_api.py
+++ b/backend/apps/reminders/api/reminder_api.py
@@ -99,9 +99,7 @@ def get_target_options(request: Any, q: str = "") -> Any:
     if keyword:
         contract_qs = contract_qs.filter(name__icontains=keyword)
         case_qs = case_qs.filter(name__icontains=keyword)
-        case_log_qs = case_log_qs.filter(
-            Q(case__name__icontains=keyword) | Q(content__icontains=keyword)
-        )
+        case_log_qs = case_log_qs.filter(Q(case__name__icontains=keyword) | Q(content__icontains=keyword))
 
     groups: list[dict[str, object]] = []
 
@@ -125,7 +123,9 @@ def get_target_options(request: Any, q: str = "") -> Any:
         if len(preview) > 24:
             preview = f"{preview[:24]}..."
         label = f"#{item.id} {item.case.name}｜{preview or str(_('无内容'))}"
-        case_log_items.append({"id": item.id, "name": label, "target_type": "case_log", "target_type_label": str(_("案件日志"))})
+        case_log_items.append(
+            {"id": item.id, "name": label, "target_type": "case_log", "target_type_label": str(_("案件日志"))}
+        )
     if case_log_items:
         groups.append({"key": "case_log", "label": str(_("案件日志")), "items": case_log_items})
 


### PR DESCRIPTION
## Summary
- Ruff 格式化：ninja_llm_api.py、reminder_api.py 代码风格统一
- .gitignore：软件著作权申请资料目录加入忽略（含个人信息）