### PR TITLE
fix: 测试日期硬编码改为动态 + 清理 CI workflow debug 语句

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -178,9 +178,6 @@ jobs:
           PYTHONPATH: "apiSystem:."
         run: |
           set -euo pipefail
-          echo "PWD=$(pwd)"
-          uv run python -c "import os; print('PYTHONPATH=' + os.environ.get('PYTHONPATH', ''))"
-          uv run python -c "import importlib; m=importlib.import_module('apiSystem.settings'); print(m.__file__)"
           base=""
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
             git fetch origin "${GITHUB_BASE_REF}" --depth=1
@@ -201,7 +198,6 @@ jobs:
             exit 0
           fi
           printf '%s\n' "${files[@]}"
-          uv run python -c "import importlib; m=importlib.import_module('apiSystem.settings'); print(m.__file__)"
           uv run mypy --config-file=mypy.ini --follow-imports=silent "${files[@]}"
 
       - name: Type check (mypy, curated gate)

--- a/backend/tests/ci/unit/automation/test_court_sms_document_attachment_service.py
+++ b/backend/tests/ci/unit/automation/test_court_sms_document_attachment_service.py
@@ -25,11 +25,12 @@ def test_add_single_attachment_passes_original_file_path_to_case_service(tmp_pat
 
     result = service._add_single_attachment(sms, str(source_file))
 
+    expected_date = timezone.now().strftime("%Y%m%d")
     assert result is True
     case_service.add_case_log_attachment_internal.assert_called_once_with(
         case_log_id=88,
         file_path=str(source_file),
-        file_name="source（测试案件）_20260514收.pdf",
+        file_name=f"source（测试案件）_{expected_date}收.pdf",
         source_scene="court_sms_attachment",
         recommendation_file_name="source.pdf",
     )
@@ -55,11 +56,12 @@ def test_add_single_attachment_prefers_original_recommendation_name(tmp_path: Pa
         recommendation_file_name="对方证据目录.pdf",
     )
 
+    expected_date = timezone.now().strftime("%Y%m%d")
     assert result is True
     case_service.add_case_log_attachment_internal.assert_called_once_with(
         case_log_id=88,
         file_path=str(source_file),
-        file_name="renamed（测试案件）_20260514收.pdf",
+        file_name=f"renamed（测试案件）_{expected_date}收.pdf",
         source_scene="court_sms_attachment",
         recommendation_file_name="对方证据目录.pdf",
     )


### PR DESCRIPTION
## Summary

- 修复 `test_court_sms_document_attachment_service.py` 中两个测试将日期硬编码为 `20260514` 的问题，改为 `timezone.now().strftime("%Y%m%d")` 动态生成，避免跨天 CI 失败
- 移除 `backend-ci.yml` 中 mypy 步骤遗留的 debug 语句（`echo PWD`、`importlib` import 检查）

## Test plan

- [x] 本地 `pytest tests/ci/unit/automation/test_court_sms_document_attachment_service.py` 全部通过
- [ ] 等待 GitHub CI 全绿