### PR TITLE
feat: 文件名模板可配置化

### DIFF
--- a/backend/apps/automation/services/sms/document_attachment_service.py
+++ b/backend/apps/automation/services/sms/document_attachment_service.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 
+from apps.core.services.filename_template_service import FilenameTemplateService
+
 if TYPE_CHECKING:
     from apps.automation.models import CourtSMS
     from apps.core.interfaces import ICaseService
@@ -306,9 +308,7 @@ class DocumentAttachmentService:
 
     def _get_unique_filepath(self, target_dir: str, filename: str) -> tuple[str, str]:
         """
-        获取唯一的文件路径，如果文件已存在则在"收"字后面添加数字后缀
-
-        格式：标题（案件名称）_YYYYMMDD收.pdf -> 标题（案件名称）_YYYYMMDD收1.pdf
+        获取唯一的文件路径，如果文件已存在则自动追加数字后缀
 
         Args:
             target_dir: 目标目录
@@ -317,46 +317,7 @@ class DocumentAttachmentService:
         Returns:
             tuple: (完整路径, 新文件名)
         """
-        # 尝试在"收"字后面添加数字
-        # 匹配模式：xxx收.pdf 或 xxx收N.pdf
-        match = re.match(r"^(.+收)(\d*)\.(.+)$", filename)
-
-        if match:
-            base_name = match.group(1)  # xxx收
-            existing_num = match.group(2)  # 可能为空或数字
-            ext = match.group(3)  # pdf
-
-            counter = 1
-            if existing_num:
-                counter = int(existing_num) + 1
-
-            while True:
-                new_filename = f"{base_name}{counter}.{ext}"
-                new_path = str(Path(target_dir) / new_filename)
-                if not Path(new_path).exists():
-                    return new_path, new_filename
-                counter += 1
-                if counter > 100:  # 防止无限循环
-                    break
-
-        # 降级方案：在扩展名前添加数字
-        p = Path(filename)
-        name_part, ext = p.stem, p.suffix
-        counter = 1
-        while True:
-            new_filename = f"{name_part}_{counter}{ext}"
-            new_path = str(Path(target_dir) / new_filename)
-            if not Path(new_path).exists():
-                return new_path, new_filename
-            counter += 1
-            if counter > 100:
-                # 最后的降级：使用时间戳
-                import time
-
-                timestamp = int(time.time())
-                new_filename = f"{name_part}_{timestamp}{ext}"
-                new_path = str(Path(target_dir) / new_filename)
-                return new_path, new_filename
+        return FilenameTemplateService.get_unique_filepath(target_dir, filename)
 
     def fix_filename_format(self, filename: str, sms: "CourtSMS") -> str:
         """
@@ -410,8 +371,9 @@ class DocumentAttachmentService:
                 if not title:
                     title = "司法文书"
 
-            # 生成正确格式的文件名
-            fixed_filename = f"{title}（{case_name}）_{date_str}收.pdf"
+            # 使用模板服务生成正确格式的文件名
+            rendered = FilenameTemplateService.render_court_doc(title=title, case_name=case_name, date=date_str)
+            fixed_filename = f"{rendered}.pdf"
 
             logger.info(f"文件名格式修正: {filename} -> {fixed_filename}")
             return fixed_filename
@@ -423,7 +385,10 @@ class DocumentAttachmentService:
             fallback_title = self._sanitize_filename_part(name_without_ext) or "司法文书"
             case_name = sms.case.name if sms.case else "未知案件"
             date_str = sms.received_at.strftime("%Y%m%d")
-            return f"{fallback_title}（{case_name}）_{date_str}收.pdf"
+            rendered = FilenameTemplateService.render_court_doc(
+                title=fallback_title, case_name=case_name, date=date_str
+            )
+            return f"{rendered}.pdf"
 
     def _sanitize_filename_part(self, text: str) -> str:
         """

--- a/backend/apps/automation/services/sms/document_renamer.py
+++ b/backend/apps/automation/services/sms/document_renamer.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from apps.automation.services.document.document_processing import extract_document_content
 from apps.core.config import get_config
 from apps.core.exceptions import ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 
 logger = logging.getLogger(__name__)
 
@@ -300,10 +301,10 @@ class DocumentRenamer:
         # 格式化日期
         date_str = received_date.strftime("%Y%m%d")
 
-        # 生成文件名：使用中文括号
-        filename = f"{title}（{case_name}）_{date_str}收.pdf"
+        # 使用模板服务生成文件名
+        filename = FilenameTemplateService.render_court_doc(title=title, case_name=case_name, date=date_str)
 
-        return filename
+        return f"{filename}.pdf"
 
     def _sanitize_filename_part(self, text: str) -> str:
         """
@@ -359,19 +360,9 @@ class DocumentRenamer:
             # 生成新文件名
             new_filename = self.generate_filename(title, case_name, received_date)
 
-            # 构建新文件路径
+            # 构建新文件路径（通用碰撞处理）
             original_path = Path(document_path)
-            new_path = original_path.parent / new_filename
-
-            # 如果新文件名已存在，在"收"字后面添加数字（带括号）
-            counter = 1
-            while new_path.exists():
-                # 格式：xxx收(1).pdf, xxx收(2).pdf
-                base_filename = new_filename.replace("收.pdf", f"收({counter}).pdf")
-                new_path = original_path.parent / base_filename
-                counter += 1
-                if counter > 100:  # 防止无限循环
-                    break
+            new_path, _ = FilenameTemplateService.get_unique_filepath(original_path.parent, new_filename)
 
             # 重命名文件
             original_path.rename(new_path)
@@ -417,16 +408,7 @@ class DocumentRenamer:
                 fallback_filename = self.generate_filename(fallback_title, case_name, received_date)
 
                 original_path = Path(document_path)
-                fallback_path = original_path.parent / fallback_filename
-
-                # 避免文件名冲突，在"收"字后面添加数字（带括号）
-                counter = 1
-                while fallback_path.exists():
-                    base_filename = fallback_filename.replace("收.pdf", f"收({counter}).pdf")
-                    fallback_path = original_path.parent / base_filename
-                    counter += 1
-                    if counter > 100:
-                        break
+                fallback_path, _ = FilenameTemplateService.get_unique_filepath(original_path.parent, fallback_filename)
 
                 original_path.rename(fallback_path)
                 logger.info(f"使用降级方案重命名成功: {document_path} -> {fallback_path}")

--- a/backend/apps/contracts/services/archive/generation/document_generator.py
+++ b/backend/apps/contracts/services/archive/generation/document_generator.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from apps.contracts.models import Contract
 from apps.contracts.models.finalized_material import FinalizedMaterial, MaterialCategory
+from apps.core.services.filename_template_service import FilenameTemplateService
 
 from ..category_mapping import get_archive_category
 from ..constants import ARCHIVE_CHECKLIST, ChecklistItem
@@ -185,8 +186,12 @@ def _generate_filename(contract: Contract, item: ChecklistItem) -> str:
     contract_name = contract.name or "未命名合同"
     item_name = item["name"]
     today_str = date.today().strftime("%Y%m%d")
-
-    return f"{item_name}（{contract_name}）_{today_str}.docx"
+    return (
+        FilenameTemplateService.render_generated_doc(
+            doc_type=item_name, case_name=contract_name, version="1", date=today_str
+        )
+        + ".docx"
+    )
 
 
 def _save_as_material(

--- a/backend/apps/contracts/services/archive/generation/document_generator.py
+++ b/backend/apps/contracts/services/archive/generation/document_generator.py
@@ -29,11 +29,18 @@ def preview_archive_template(contract_id: int, template_subtype: str) -> dict[st
 
     from apps.documents.services.generation.pipeline import DocxPreviewService, PipelineContextBuilder
 
-    case = contract.cases.select_related(
-        "contract",
-    ).prefetch_related(
-        "supervising_authorities", "case_numbers", "assignments__lawyer", "parties__client",
-    ).first()
+    case = (
+        contract.cases.select_related(
+            "contract",
+        )
+        .prefetch_related(
+            "supervising_authorities",
+            "case_numbers",
+            "assignments__lawyer",
+            "parties__client",
+        )
+        .first()
+    )
 
     context_builder = PipelineContextBuilder()
     context = context_builder.build_archive_context(contract, case)
@@ -58,11 +65,18 @@ def generate_archive_documents(
 ) -> list[dict[str, Any]]:
     """批量生成归档文书。"""
     if case is None:
-        case = contract.cases.select_related(
-            "contract",
-        ).prefetch_related(
-            "supervising_authorities", "case_numbers", "assignments__lawyer", "parties__client",
-        ).first()
+        case = (
+            contract.cases.select_related(
+                "contract",
+            )
+            .prefetch_related(
+                "supervising_authorities",
+                "case_numbers",
+                "assignments__lawyer",
+                "parties__client",
+            )
+            .first()
+        )
 
     archive_category = get_archive_category(contract.case_type)
     checklist_items = ARCHIVE_CHECKLIST.get(archive_category, [])
@@ -99,11 +113,18 @@ def generate_single_archive_document(
         return {"template_subtype": None, "error": "该检查项不支持模板生成"}
 
     if case is None:
-        case = contract.cases.select_related(
-            "contract",
-        ).prefetch_related(
-            "supervising_authorities", "case_numbers", "assignments__lawyer", "parties__client",
-        ).first()
+        case = (
+            contract.cases.select_related(
+                "contract",
+            )
+            .prefetch_related(
+                "supervising_authorities",
+                "case_numbers",
+                "assignments__lawyer",
+                "parties__client",
+            )
+            .first()
+        )
 
     return _generate_single_document(contract, target_item, case)
 

--- a/backend/apps/core/admin/_system_config_data/__init__.py
+++ b/backend/apps/core/admin/_system_config_data/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from ._email_configs import get_email_configs
 from ._env_mappings import get_env_mappings
 from ._feishu_configs import get_dingtalk_configs, get_feishu_configs, get_telegram_configs, get_wechat_work_configs
+from ._filename_template_configs import get_filename_template_configs
 from ._general_configs import get_general_configs
 from ._service_configs import (
     get_ai_configs,
@@ -28,5 +29,6 @@ def get_default_configs() -> list[dict[str, Any]]:
         + get_scraper_configs()
         + get_ocr_configs()
         + get_email_configs()
+        + get_filename_template_configs()
     )
     return configs

--- a/backend/apps/core/admin/_system_config_data/_filename_template_configs.py
+++ b/backend/apps/core/admin/_system_config_data/_filename_template_configs.py
@@ -1,0 +1,32 @@
+"""文件名模板配置数据"""
+
+from typing import Any
+
+__all__ = ["get_filename_template_configs"]
+
+
+def get_filename_template_configs() -> list[dict[str, Any]]:
+    """获取文件名模板配置项"""
+    return [
+        {
+            "key": "FILENAME_TEMPLATE_COURT_DOC",
+            "category": "court_sms",
+            "description": (
+                "法院文书文件名模板。可用占位符：{title}=文书标题, {case_name}=案件名, {date}=日期(YYYYMMDD)。"
+                "示例：{title}（{case_name}）_{date}收"
+            ),
+            "value": "{title}（{case_name}）_{date}收",
+            "is_secret": False,
+        },
+        {
+            "key": "FILENAME_TEMPLATE_GENERATED_DOC",
+            "category": "general",
+            "description": (
+                "生成文档文件名模板（合同/诉讼/证据等）。"
+                "可用占位符：{doc_type}=文档类型, {case_name}=案件名, {version}=版本号, {date}=日期(YYYYMMDD)。"
+                "示例：{doc_type}（{case_name}）V{version}_{date}"
+            ),
+            "value": "{doc_type}（{case_name}）V{version}_{date}",
+            "is_secret": False,
+        },
+    ]

--- a/backend/apps/core/services/filename_template_service.py
+++ b/backend/apps/core/services/filename_template_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from apps.core.interfaces import ISystemConfigService
@@ -26,12 +26,12 @@ def _get_system_config_service() -> ISystemConfigService:
 # 法院文书模板
 COURT_DOC_KEY = "FILENAME_TEMPLATE_COURT_DOC"
 COURT_DOC_DEFAULT = "{title}（{case_name}）_{date}收"
-COURT_DOC_PLACEHOLDERS: ClassVar[set[str]] = {"title", "case_name", "date"}
+COURT_DOC_PLACEHOLDERS: set[str] = {"title", "case_name", "date"}
 
 # 生成文档模板
 GENERATED_DOC_KEY = "FILENAME_TEMPLATE_GENERATED_DOC"
 GENERATED_DOC_DEFAULT = "{doc_type}（{case_name}）V{version}_{date}"
-GENERATED_DOC_PLACEHOLDERS: ClassVar[set[str]] = {"doc_type", "case_name", "version", "date"}
+GENERATED_DOC_PLACEHOLDERS: set[str] = {"doc_type", "case_name", "version", "date"}
 
 
 class FilenameTemplateService:

--- a/backend/apps/core/services/filename_template_service.py
+++ b/backend/apps/core/services/filename_template_service.py
@@ -1,0 +1,149 @@
+"""文件名模板服务
+
+提供可配置的文件名模板渲染和通用碰撞处理。
+模板通过 SystemConfig 存储，用户可在 admin 页面自定义。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from apps.core.interfaces import ISystemConfigService
+
+logger = logging.getLogger(__name__)
+
+
+def _get_system_config_service() -> ISystemConfigService:
+    from apps.core.interfaces import ServiceLocator
+
+    return ServiceLocator.get_system_config_service()
+
+
+# 法院文书模板
+COURT_DOC_KEY = "FILENAME_TEMPLATE_COURT_DOC"
+COURT_DOC_DEFAULT = "{title}（{case_name}）_{date}收"
+COURT_DOC_PLACEHOLDERS: ClassVar[set[str]] = {"title", "case_name", "date"}
+
+# 生成文档模板
+GENERATED_DOC_KEY = "FILENAME_TEMPLATE_GENERATED_DOC"
+GENERATED_DOC_DEFAULT = "{doc_type}（{case_name}）V{version}_{date}"
+GENERATED_DOC_PLACEHOLDERS: ClassVar[set[str]] = {"doc_type", "case_name", "version", "date"}
+
+
+class FilenameTemplateService:
+    """文件名模板服务
+
+    负责：
+    1. 从 SystemConfig 读取模板配置
+    2. 渲染模板（替换占位符）
+    3. 通用碰撞处理（不依赖特定字符）
+    """
+
+    _system_config_service: ISystemConfigService | None = None
+
+    @classmethod
+    def _config_service(cls) -> ISystemConfigService:
+        if cls._system_config_service is None:
+            cls._system_config_service = _get_system_config_service()
+        return cls._system_config_service
+
+    @classmethod
+    def get_template(cls, key: str, default: str) -> str:
+        """获取模板配置值，数据库无记录时返回 default"""
+        return str(cls._config_service().get_value(key, default=default) or default)
+
+    @classmethod
+    def render_court_doc(cls, *, title: str, case_name: str, date: str) -> str:
+        """渲染法院文书文件名（不含扩展名）
+
+        Args:
+            title: 文书标题
+            case_name: 案件名称
+            date: 日期字符串（YYYYMMDD）
+
+        Returns:
+            渲染后的文件名（不含 .pdf）
+        """
+        template = cls.get_template(COURT_DOC_KEY, COURT_DOC_DEFAULT)
+        return cls._render(template, COURT_DOC_PLACEHOLDERS, title=title, case_name=case_name, date=date)
+
+    @classmethod
+    def render_generated_doc(cls, *, doc_type: str, case_name: str, version: str, date: str) -> str:
+        """渲染生成文档文件名（不含扩展名）
+
+        Args:
+            doc_type: 文档类型（如"起诉状"、"合同"）
+            case_name: 案件名称
+            version: 版本号（纯数字，如 "1"）
+            date: 日期字符串（YYYYMMDD）
+
+        Returns:
+            渲染后的文件名（不含 .docx）
+        """
+        template = cls.get_template(GENERATED_DOC_KEY, GENERATED_DOC_DEFAULT)
+        return cls._render(
+            template, GENERATED_DOC_PLACEHOLDERS, doc_type=doc_type, case_name=case_name, version=version, date=date
+        )
+
+    @classmethod
+    def _render(cls, template: str, valid_placeholders: set[str], **kwargs: str) -> str:
+        """渲染模板，替换占位符
+
+        无效占位符保留原文并 warn。
+        """
+        # 检查无效占位符
+        found = re.findall(r"\{(\w+)\}", template)
+        for ph in found:
+            if ph not in valid_placeholders:
+                logger.warning("文件名模板中包含无效占位符: {%s}，将保留原文", ph)
+
+        # 替换有效占位符
+        result = template
+        for key, value in kwargs.items():
+            result = result.replace(f"{{{key}}}", value)
+
+        return result
+
+    @classmethod
+    def get_unique_filepath(cls, target_dir: str | Path, filename: str) -> tuple[str, str]:
+        """获取唯一的文件路径，文件名冲突时自动追加数字后缀
+
+        通用碰撞处理，不依赖文件名中的特定字符（如"收"）。
+        策略：在扩展名前追加 _1、_2、... 直到无冲突。
+
+        Args:
+            target_dir: 目标目录
+            filename: 原始文件名
+
+        Returns:
+            (完整路径, 新文件名)
+        """
+        target = Path(target_dir)
+        p = Path(filename)
+        stem, ext = p.stem, p.suffix
+
+        # 直接尝试原始文件名
+        filepath = target / filename
+        if not filepath.exists():
+            return str(filepath), filename
+
+        # 追加数字后缀
+        counter = 1
+        while counter <= 100:
+            new_filename = f"{stem}_{counter}{ext}"
+            filepath = target / new_filename
+            if not filepath.exists():
+                return str(filepath), new_filename
+            counter += 1
+
+        # 最终降级：时间戳
+        import time
+
+        timestamp = int(time.time())
+        new_filename = f"{stem}_{timestamp}{ext}"
+        filepath = target / new_filename
+        return str(filepath), new_filename

--- a/backend/apps/document_recognition/services/recognition_service.py
+++ b/backend/apps/document_recognition/services/recognition_service.py
@@ -13,6 +13,7 @@ from typing import Any
 from django.utils.translation import gettext_lazy as _
 
 from apps.core.exceptions import RecognitionTimeoutError, ServiceUnavailableError, ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 
 from .data_classes import BindingResult, DocumentType, RecognitionResponse, RecognitionResult
 
@@ -346,20 +347,11 @@ class CourtDocumentRecognitionService:
                 title=title, case_name=case_name, received_date=date.today()
             )
 
-            # 构建新文件路径
+            # 构建新文件路径（通用碰撞处理）
             from pathlib import Path
 
             original_path = Path(file_path)
-            new_path = original_path.parent / new_filename
-
-            # 如果新文件名已存在，添加数字后缀
-            counter = 1
-            while new_path.exists():
-                base_filename = new_filename.replace("收.pdf", f"收{counter}.pdf")
-                new_path = original_path.parent / base_filename
-                counter += 1
-                if counter > 100:
-                    break
+            new_path, _ = FilenameTemplateService.get_unique_filepath(original_path.parent, new_filename)
 
             # 重命名文件
             original_path.rename(new_path)

--- a/backend/apps/document_recognition/usecases/court_document_recognition/recognize_document.py
+++ b/backend/apps/document_recognition/usecases/court_document_recognition/recognize_document.py
@@ -8,6 +8,7 @@ from datetime import date
 from typing import Any
 
 from apps.core.exceptions import RecognitionTimeoutError, ServiceUnavailableError, ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.document_recognition.services.data_classes import (
     BindingResult,
     DocumentType,
@@ -135,14 +136,7 @@ class RecognizeCourtDocumentUsecase:
             from apps.core.utils.path import Path
 
             original_path = Path(file_path)
-            new_path = original_path.parent / new_filename
-            counter = 1
-            while new_path.exists():
-                base_filename = new_filename.replace("收.pdf", f"收{counter}.pdf")
-                new_path = original_path.parent / base_filename
-                counter += 1
-                if counter > 100:
-                    break
+            new_path, _ = FilenameTemplateService.get_unique_filepath(original_path.parent, new_filename)
             original_path.rename(new_path)
             logger.info(
                 "文书重命名成功",

--- a/backend/apps/documents/services/generation/authorization_material_generation_service.py
+++ b/backend/apps/documents/services/generation/authorization_material_generation_service.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from apps.core.exceptions import NotFoundError, ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.core.utils.path import Path
 from apps.documents.models import DocumentTemplate, DocumentTemplateType
 from apps.documents.services.generation.path_utils import resolve_media_path, safe_arcname, safe_name
@@ -538,32 +539,54 @@ class AuthorizationMaterialGenerationService:
 
     def _build_authority_letter_filename(self, *, case_name: str) -> str:
         date_str = timezone.now().strftime("%Y%m%d")
-        template_name = "所函"
         safe_case_name = case_name or "案件"
-        return f"{template_name}({safe_case_name})V1_{date_str}.docx"
+        return (
+            FilenameTemplateService.render_generated_doc(
+                doc_type="所函", case_name=safe_case_name, version="1", date=date_str
+            )
+            + ".docx"
+        )
 
     def _build_legal_rep_certificate_filename(self, *, company_name: str) -> str:
         date_str = timezone.now().strftime("%Y%m%d")
-        template_name = "法定代表人身份证明书"
         safe_company_name = company_name or "公司"
-        return f"{template_name}({safe_company_name})V1_{date_str}.docx"
+        return (
+            FilenameTemplateService.render_generated_doc(
+                doc_type="法定代表人身份证明书", case_name=safe_company_name, version="1", date=date_str
+            )
+            + ".docx"
+        )
 
     def _build_power_of_attorney_filename(
         self, *, case: Any, selected_clients: list[Any], combined: bool = False
     ) -> str:
         date_str = timezone.now().strftime("%Y%m%d")
-        template_name = "授权委托书"
         case_name = getattr(case, "name", "") or "案件"
 
         if combined:
-            return f"{template_name}({case_name})V1_{date_str}.docx"
+            return (
+                FilenameTemplateService.render_generated_doc(
+                    doc_type="授权委托书", case_name=case_name, version="1", date=date_str
+                )
+                + ".docx"
+            )
 
         if self._count_our_parties(case) <= 1:
-            return f"{template_name}({case_name})V1_{date_str}.docx"
+            return (
+                FilenameTemplateService.render_generated_doc(
+                    doc_type="授权委托书", case_name=case_name, version="1", date=date_str
+                )
+                + ".docx"
+            )
 
         client = selected_clients[0] if selected_clients else None
         client_name = getattr(client, "name", "") or "委托人"
-        return f"{template_name}({client_name})({case_name})V1_{date_str}.docx"
+        return (
+            FilenameTemplateService.render_generated_doc(
+                doc_type=f"授权委托书（{client_name}）", case_name=case_name, version="1", date=date_str
+            )
+            + ".docx"
+        )
 
     def _count_our_parties(self, case: Any) -> int:
         try:

--- a/backend/apps/documents/services/generation/folder_generation_service.py
+++ b/backend/apps/documents/services/generation/folder_generation_service.py
@@ -19,6 +19,7 @@ from django.utils.translation import gettext_lazy as _
 
 from apps.core.exceptions import NotFoundError, ValidationException
 from apps.core.models.enums import CaseType
+from apps.core.services.filename_template_service import FilenameTemplateService
 
 if TYPE_CHECKING:
     from apps.core.interfaces import IContractService
@@ -468,7 +469,12 @@ class FolderGenerationService:
                         from django.utils import timezone
 
                         date_str = timezone.now().strftime("%Y%m%d")
-                        filename = f"法定代表人身份证明书({party.client.name})V1_{date_str}.docx"
+                        filename = (
+                            FilenameTemplateService.render_generated_doc(
+                                doc_type="法定代表人身份证明书", case_name=party.client.name, version="1", date=date_str
+                            )
+                            + ".docx"
+                        )
                         documents.append((folder_path, content, filename))
                         logger.info(
                             "案件文件夹 - 法定代表人身份证明书已生成: %s → %s",
@@ -576,7 +582,12 @@ class FolderGenerationService:
                 else:
                     date_str = timezone.now().strftime("%Y%m%d")
                 case_name = case.name or "案件"
-                filename = f"{template.name}({case_name})V1_{date_str}.docx"
+                filename = (
+                    FilenameTemplateService.render_generated_doc(
+                        doc_type=template.name, case_name=case_name, version="1", date=date_str
+                    )
+                    + ".docx"
+                )
                 documents.append((folder_path, content, filename))
                 logger.info(
                     "案件文件夹 - 文书生成成功: %s → %s",

--- a/backend/apps/documents/services/generation/pipeline/naming.py
+++ b/backend/apps/documents/services/generation/pipeline/naming.py
@@ -5,18 +5,41 @@ from __future__ import annotations
 import re
 from datetime import date
 
+from apps.core.services.filename_template_service import FilenameTemplateService
+
 
 def _today_compact() -> str:
     return date.today().strftime("%Y%m%d")
 
 
+def _normalize_version(version: str) -> str:
+    """将 'V1' 或 'V1.0' 等格式转为纯数字 '1'"""
+    return re.sub(r"^V", "", version, flags=re.IGNORECASE)
+
+
 def contract_docx_filename(*, template_name: str, contract_name: str, version: str = "V1") -> str:
     template_prefix = re.sub(r"\.(docx?|doc)$", "", template_name or "合同", flags=re.IGNORECASE)
     contract_display = contract_name or "未命名合同"
-    return f"{template_prefix}（{contract_display}）{version}_{_today_compact()}.docx"
+    return (
+        FilenameTemplateService.render_generated_doc(
+            doc_type=template_prefix,
+            case_name=contract_display,
+            version=_normalize_version(version),
+            date=_today_compact(),
+        )
+        + ".docx"
+    )
 
 
 def supplementary_agreement_docx_filename(*, agreement_name: str, contract_name: str, version: str = "V1") -> str:
     agreement_display = agreement_name or "补充协议"
     contract_display = contract_name or "未命名合同"
-    return f"{agreement_display}({contract_display}){version}_{_today_compact()}.docx"
+    return (
+        FilenameTemplateService.render_generated_doc(
+            doc_type=agreement_display,
+            case_name=contract_display,
+            version=_normalize_version(version),
+            date=_today_compact(),
+        )
+        + ".docx"
+    )

--- a/backend/apps/documents/services/generation/preservation_materials_generation_service.py
+++ b/backend/apps/documents/services/generation/preservation_materials_generation_service.py
@@ -13,6 +13,8 @@ from typing import Any, cast
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+
+from apps.core.services.filename_template_service import FilenameTemplateService
 from docxtpl import DocxTemplate
 
 from apps.core.exceptions import NotFoundError, ValidationException
@@ -151,7 +153,12 @@ class PreservationMaterialsGenerationService:
         missing_clue_respondents = self.property_clue_service.get_respondents_without_clues(case_id)
         now = timezone.now()
         case_name = getattr(case, "name", "") or "案件"
-        zip_filename = f"全套保全材料({case_name})V1_{now.strftime('%Y%m%d')}.zip"
+        zip_filename = (
+            FilenameTemplateService.render_generated_doc(
+                doc_type="全套保全材料", case_name=case_name, version="1", date=now.strftime("%Y%m%d")
+            )
+            + ".zip"
+        )
         buffer = io.BytesIO()
         with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
             try:
@@ -326,4 +333,9 @@ class PreservationMaterialsGenerationService:
         """
         date_str = timezone.now().strftime("%Y%m%d")
         case_name = getattr(case, "name", "") or "案件"
-        return f"{template_name}({case_name})V1_{date_str}.docx"
+        return (
+            FilenameTemplateService.render_generated_doc(
+                doc_type=template_name, case_name=case_name, version="1", date=date_str
+            )
+            + ".docx"
+        )

--- a/backend/apps/documents/services/generation/preservation_materials_generation_service.py
+++ b/backend/apps/documents/services/generation/preservation_materials_generation_service.py
@@ -13,11 +13,10 @@ from typing import Any, cast
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-
-from apps.core.services.filename_template_service import FilenameTemplateService
 from docxtpl import DocxTemplate
 
 from apps.core.exceptions import NotFoundError, ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.core.utils.path import Path
 from apps.documents.services.infrastructure.wiring import get_case_service, get_document_service
 from apps.documents.services.placeholders import EnhancedContextBuilder

--- a/backend/apps/documents/services/placeholders/litigation/filename_service.py
+++ b/backend/apps/documents/services/placeholders/litigation/filename_service.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from apps.core.exceptions import NotFoundError
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.documents.services.infrastructure.wiring import get_case_service
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,12 @@ class FilenameService:
         date_str = self._format_date()
 
         # 生成文件名:起诉状(案件名称)V1_日期.docx
-        filename = f"起诉状（{case_name}）V1_{date_str}.docx"
+        filename = (
+            FilenameTemplateService.render_generated_doc(
+                doc_type="起诉状", case_name=case_name, version="1", date=date_str
+            )
+            + ".docx"
+        )
 
         logger.info("生成起诉状文件名: %s", filename)
 
@@ -91,7 +97,12 @@ class FilenameService:
         date_str = self._format_date()
 
         # 生成文件名:答辩状(案件名称)V1_日期.docx
-        filename = f"答辩状（{case_name}）V1_{date_str}.docx"
+        filename = (
+            FilenameTemplateService.render_generated_doc(
+                doc_type="答辩状", case_name=case_name, version="1", date=date_str
+            )
+            + ".docx"
+        )
 
         logger.info("生成答辩状文件名: %s", filename)
 

--- a/backend/apps/evidence/services/admin/evidence_admin_service.py
+++ b/backend/apps/evidence/services/admin/evidence_admin_service.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from django.utils import timezone
 
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.evidence.services.core.evidence_service import EvidenceService
 from apps.evidence.services.export.evidence_export_service import EvidenceExportService
 from apps.evidence.services.infrastructure.pdf_merge_service import PDFMergeService
@@ -210,7 +211,12 @@ class EvidenceAdminService:
         version = evidence_list.export_version
 
         # 格式:证据明细{序号}({案件名称})V{版本号}_{日期}.pdf
-        filename = f"证据明细{list_suffix}({case_name})V{version}_{date_str}.pdf"
+        filename = (
+            FilenameTemplateService.render_generated_doc(
+                doc_type=f"证据明细{list_suffix}", case_name=case_name, version=str(version), date=date_str
+            )
+            + ".pdf"
+        )
 
         return filename
 

--- a/backend/apps/evidence/services/export/evidence_export_service.py
+++ b/backend/apps/evidence/services/export/evidence_export_service.py
@@ -16,6 +16,7 @@ from docx.shared import Cm
 from docxtpl import DocxTemplate
 
 from apps.core.exceptions import NotFoundError, ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.documents.services.placeholders.fallback import build_docx_render_context
 from apps.evidence.models import EvidenceItem, EvidenceList
 
@@ -423,18 +424,23 @@ class EvidenceExportService:
 
         # 根据文档类型生成文件名
         if doc_type == "证据清单":
-            # 格式:{证据清单名称}({案件名称})V{版本号}_{日期}.docx
-            filename = f"{evidence_list.title}({case_name})V{version}_{date_str}.docx"
+            doc_type_display = evidence_list.title
         else:
-            # 格式:证据明细{清单序号}({案件名称})V{版本号}_{日期}.docx
             # 从证据清单标题中提取序号部分(如"证据清单一"提取"一")
             list_suffix = ""
             title = evidence_list.title
             if title.startswith("证据清单"):
-                list_suffix = title[4:]  # 提取"证据清单"后面的部分
+                list_suffix = title[4:]
             elif title.startswith("补充证据清单"):
-                list_suffix = title[6:]  # 提取"补充证据清单"后面的部分
-            filename = f"证据明细{list_suffix}({case_name})V{version}_{date_str}.docx"
+                list_suffix = title[6:]
+            doc_type_display = f"证据明细{list_suffix}"
+
+        filename = (
+            FilenameTemplateService.render_generated_doc(
+                doc_type=doc_type_display, case_name=case_name, version=str(version), date=date_str
+            )
+            + ".docx"
+        )
 
         return filename
 

--- a/backend/apps/evidence/services/export/evidence_export_service.py
+++ b/backend/apps/evidence/services/export/evidence_export_service.py
@@ -158,7 +158,11 @@ class EvidenceExportService:
         Raises:
             NotFoundError: 模板不存在
         """
-        from apps.evidence.models import DocumentCaseFileSubType, DocumentTemplate, DocumentTemplateType  # type: ignore[attr-defined]
+        from apps.evidence.models import (  # type: ignore[attr-defined]
+            DocumentCaseFileSubType,
+            DocumentTemplate,
+            DocumentTemplateType,
+        )
 
         try:
             return DocumentTemplate.objects.get(

--- a/backend/apps/evidence/services/infrastructure/pdf_merge_service.py
+++ b/backend/apps/evidence/services/infrastructure/pdf_merge_service.py
@@ -13,6 +13,8 @@ from django.core.files.base import ContentFile
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from apps.core.services.filename_template_service import FilenameTemplateService
+
 from apps.core.exceptions import BusinessException, ValidationException
 from apps.evidence.models import EvidenceList
 
@@ -147,7 +149,12 @@ class PDFMergeWorkflow:
         elif title.startswith("补充证据清单"):
             list_suffix = title[6:]
         version = evidence_list.export_version
-        filename = f"证据明细{list_suffix}({case_name})V{version}_{date_str}.pdf"
+        filename = (
+            FilenameTemplateService.render_generated_doc(
+                doc_type=f"证据明细{list_suffix}", case_name=case_name, version=str(version), date=date_str
+            )
+            + ".pdf"
+        )
         return filename
 
     def get_pdf_page_count(self, pdf_input: Any) -> int:

--- a/backend/apps/evidence/services/infrastructure/pdf_merge_service.py
+++ b/backend/apps/evidence/services/infrastructure/pdf_merge_service.py
@@ -13,9 +13,8 @@ from django.core.files.base import ContentFile
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from apps.core.services.filename_template_service import FilenameTemplateService
-
 from apps.core.exceptions import BusinessException, ValidationException
+from apps.core.services.filename_template_service import FilenameTemplateService
 from apps.evidence.models import EvidenceList
 
 


### PR DESCRIPTION
## Summary

- 新增 `FilenameTemplateService` 统一文件名渲染引擎，支持通过 SystemConfig 自定义文件名模板
- 注册 `FILENAME_TEMPLATE_COURT_DOC` 和 `FILENAME_TEMPLATE_GENERATED_DOC` 两个配置项
- 覆盖法院文书重命名 + 生成文书共 15+ 个调用点
- 碰撞处理统一为通用 `_1`、`_2` 后缀逻辑

## Test plan

- [x] `make ci` 全绿（13/13 通过）
- [ ] admin 页面能看到 `FILENAME_TEMPLATE_COURT_DOC` 和 `FILENAME_TEMPLATE_GENERATED_DOC` 两个配置项
- [ ] 点击「Init Defaults」后配置正确写入
- [ ] 不点击时服务使用硬编码默认值正常工作
- [ ] 修改模板后生成的文书文件名按新模板变化