### PR TITLE
chore: bump version to 26.48.10, update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [26.48.10] - 2026-05-15
+
+### 后端
+
+#### 新功能
+
+- **Playwright 浏览器公共服务**：新增 `apps/core/services/browser/` 模块，统一管理浏览器生命周期。支持原生 launch、CDP 连接、持久化登录态（session_id）、反检测（stealth）、多 Profile 配置。所有业务模块禁止直接调用 `sync_playwright()` / `async_playwright()`，必须通过 `create_browser()` / `create_browser_async()` 调用
+- **一张网立案流程增强**：优化表单填写步骤（filing_steps.py）、表单工具（form_utils.py）、当事人信息处理（party_info_handler.py），提升立案自动化稳定性
+- **文件名模板可配置化**：新增 `FilenameTemplateService` 统一文件名渲染引擎，支持通过 SystemConfig 自定义文件名模板（`FILENAME_TEMPLATE_COURT_DOC` / `FILENAME_TEMPLATE_GENERATED_DOC`），覆盖法院文书重命名 + 生成文书共 15+ 个调用点。碰撞处理统一为通用 `_1`、`_2` 后缀逻辑
+
+#### 优化
+
+- **多模块迁移至浏览器公共服务**：gsxt、court_filing、scraper、wechat_mp、message_hub、finance 等模块的浏览器调用统一迁移到公共服务
+
+#### 分支策略
+
+- **main + community 双分支**：`main` 为作者维护原始逻辑，`community` 接受所有外部 PR。外部贡献者请将 PR 提交到 `community` 分支
+
 ## [26.48.9] - 2026-05-13
 
 ### 后端

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "26.48.9",
+  "version": "26.48.10",
   "packageManager": "pnpm@10.28.2",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- 版本号升级至 26.48.10
- CHANGELOG 记录今日 main 分支的三项变更：Playwright 浏览器公共服务、一张网立案流程增强、文件名模板可配置化

## Test plan

- [x] 无 PII 泄露
- [x] 工作目录干净