### PR TITLE
fix: smoke_check admin 页面跟随重定向

### DIFF
--- a/backend/apps/automation/management/commands/smoke_check.py
+++ b/backend/apps/automation/management/commands/smoke_check.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
     def _check_admin_pages(self, client: Client) -> None:
         paths: list[Any] = ["/admin/", "/admin/cases/case/", "/admin/contracts/contract/"]
         for p in paths:
-            resp = client.get(p, HTTP_HOST="localhost")
+            resp = client.get(p, follow=True, HTTP_HOST="localhost")
             if resp.status_code != 200:
                 raise CommandError(f"Admin 冒烟失败:GET {p} -> {resp.status_code}")
 


### PR DESCRIPTION
## Summary
- 修复 `backend-e2e-nightly` CI 失败：`/admin/` 返回 302（重定向到提醒日历页）
- `/admin/cases/case/` 也会因默认过滤器 `?status__exact=active` 而重定向
- 使用 `follow=True` 跟随重定向后再检查最终状态码

## Test plan
- [x] 本地运行 `smoke_check --skip-websocket --skip-q` 通过
- [x] 本地运行 `make ci` 全部通过