### PR TITLE
fix: 当事人表单/案件admin/合同创建案件多项修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [26.48.15] - 2026-05-19
+
+### 前端
+
+#### 修复
+
+- **当事人表单「我方当事人」开关缺失**：`ClientForm` 的 zod schema 定义了 `is_our_client` 字段但表单 JSX 中缺少对应输入控件，导致新建时默认为 `true` 且无法切换。在地址字段下方添加 Switch 开关
+
+### 后端
+
+#### 修复
+
+- **新建案件 CaseContactInline 未保存实例报错**：`CaseContactInlineForm.clean()` 中用未保存的 Case 实例（无 pk）查询 `SupervisingAuthority`，触发 `ValueError: Model instances passed to related filters must be saved`。增加 `case.pk` 守卫
+
+- **新建案件 CaseAssignment 唯一约束冲突**：`save_model()` 中 `sync_assignments_from_contract()` 从合同同步律师指派后，`save_formset()` 处理 inline 表单时用户选了相同律师导致 `IntegrityError`。在 `save_formset()` 中对 `CaseAssignment` 增加去重检查
+
+- **合同非在办状态仍可点击「保存并创建案件」**：合同 change form 模板中 `updateCreateCaseButton()` 只检查合同类型未检查状态，已归档合同点击后后端抛 `CONTRACT_INACTIVE`。现在归档合同禁用该按钮
+
+- **未签约合同无法创建案件**：`validate_contract_active()` 仅允许 `active` 状态，`unsigned`（未签约）合同也被拒绝。改为 `active` 和 `unsigned` 均允许，仅 `archived` 不可创建
+
+- **CaseAssignmentInline 显示溢出**：未配置 `fields` 导致冗余的 `case` 父 FK 和巨大的 `lawyer` 下拉框同时显示。隐藏 `case` 字段并启用 `lawyer` autocomplete
+
+- **CasePartyInline 末行重复显示当事人**：`extra = 1` 在页面加载时渲染空表单，JS 的 `updateClientOptions` 操作所有 select 时污染该空行。改为 `extra = 0`
+
 ## [26.48.14] - 2026-05-19
 
 ### 后端

--- a/backend/apps/cases/admin/case_admin.py
+++ b/backend/apps/cases/admin/case_admin.py
@@ -112,6 +112,8 @@ class CasePartyInline(BaseTabularInline):
 class CaseAssignmentInline(BaseTabularInline):
     model = CaseAssignment
     extra = 1
+    fields = ("lawyer",)
+    autocomplete_fields = ("lawyer",)
 
 
 class SupervisingAuthorityInline(BaseTabularInline):

--- a/backend/apps/cases/admin/case_admin.py
+++ b/backend/apps/cases/admin/case_admin.py
@@ -46,7 +46,7 @@ class CasePartyInline(BaseTabularInline):
     model = CaseParty
     form = CasePartyInlineForm
     formset = CasePartyInlineFormSet
-    extra = 1
+    extra = 0
     fields = ("client", "legal_status")
     autocomplete_fields = ("client",)
     classes = ["contract-party-inline"]

--- a/backend/apps/cases/admin/mixins/save.py
+++ b/backend/apps/cases/admin/mixins/save.py
@@ -180,7 +180,9 @@ class CaseAdminSaveMixin(CaseAdminServiceMixin):
             try:
                 obj.delete()
             except Exception:
-                logger.warning("删除关联对象失败: %s pk=%s", type(obj).__name__, getattr(obj, "pk", None), exc_info=True)
+                logger.warning(
+                    "删除关联对象失败: %s pk=%s", type(obj).__name__, getattr(obj, "pk", None), exc_info=True
+                )
 
 
 __all__: list[str] = ["CaseAdminSaveMixin"]

--- a/backend/apps/cases/admin/mixins/save.py
+++ b/backend/apps/cases/admin/mixins/save.py
@@ -14,7 +14,7 @@ from django.forms import ModelForm
 from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
-from apps.cases.models import Case, CaseLog
+from apps.cases.models import Case, CaseAssignment, CaseLog
 
 from .service import CaseAdminServiceMixin
 
@@ -171,6 +171,9 @@ class CaseAdminSaveMixin(CaseAdminServiceMixin):
                 user_id = getattr(request.user, "id", None)
                 if user_id is not None:
                     obj.actor_id = user_id
+            if isinstance(obj, CaseAssignment) and not obj.pk and obj.case_id and obj.lawyer_id:
+                if CaseAssignment.objects.filter(case_id=obj.case_id, lawyer_id=obj.lawyer_id).exists():
+                    continue
             obj.save()
         formset.save_m2m()
         for obj in formset.deleted_objects:

--- a/backend/apps/contacts/admin.py
+++ b/backend/apps/contacts/admin.py
@@ -53,7 +53,7 @@ class CaseContactAdminForm(forms.ModelForm[CaseContact]):
         cleaned = super().clean() or {}
         authority_name = cleaned.pop("authority_name", "").strip()
         case = cleaned.get("case")
-        if authority_name and case:
+        if authority_name and case and case.pk:
             from apps.cases.models import SupervisingAuthority
 
             authority, _created = SupervisingAuthority.objects.get_or_create(
@@ -96,7 +96,7 @@ class CaseContactInlineForm(forms.ModelForm[CaseContact]):
         cleaned = super().clean() or {}
         authority_name = cleaned.pop("authority_name", "").strip()
         case = cleaned.get("case") or getattr(self.instance, "case", None)
-        if authority_name and case:
+        if authority_name and case and case.pk:
             from apps.cases.models import SupervisingAuthority
 
             authority, _created = SupervisingAuthority.objects.get_or_create(

--- a/backend/apps/contacts/admin.py
+++ b/backend/apps/contacts/admin.py
@@ -12,15 +12,18 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     BaseTabularInline: TypeAlias = admin.TabularInline[Any, Any]
+    BaseStackedInline: TypeAlias = admin.StackedInline[Any, Any]
     BaseModelAdmin: TypeAlias = admin.ModelAdmin
 else:
     try:
         import nested_admin
 
         BaseTabularInline = nested_admin.NestedTabularInline
+        BaseStackedInline = nested_admin.NestedStackedInline
         BaseModelAdmin = nested_admin.NestedModelAdmin
     except ImportError:
         BaseTabularInline = admin.TabularInline
+        BaseStackedInline = admin.StackedInline
         BaseModelAdmin = admin.ModelAdmin
 
 
@@ -110,7 +113,7 @@ class CaseContactInlineForm(forms.ModelForm[CaseContact]):
         return cleaned
 
 
-class CaseContactInline(BaseTabularInline):
+class CaseContactInline(BaseStackedInline):
     model = CaseContact
     form = CaseContactInlineForm
     extra = 1

--- a/backend/apps/contracts/services/contract/contract_service_adapter.py
+++ b/backend/apps/contracts/services/contract/contract_service_adapter.py
@@ -69,7 +69,7 @@ class ContractServiceAdapter:
     def validate_contract_active(self, contract_id: int) -> bool:
         try:
             contract = self.contract_service.query_service.get_contract_internal(contract_id)
-            return bool(contract.status == "active")
+            return bool(contract.status in ("active", "unsigned"))
         except NotFoundError:
             return False
 

--- a/backend/apps/contracts/templates/admin/contracts/contract/change_form.html
+++ b/backend/apps/contracts/templates/admin/contracts/contract/change_form.html
@@ -100,27 +100,40 @@ window.CONTRACTS_I18N = Object.assign(window.CONTRACTS_I18N || {}, {
     createCaseBtn.value = (window.CONTRACTS_I18N?.createCase || '保存并创建案件');
     createCaseBtn.name = '_save_and_create_case';
 
-    // 检查当前合同类型是否允许创建案件
+    // 检查当前合同类型和状态是否允许创建案件
     function updateCreateCaseButton() {
         var caseTypeSelect = document.getElementById('id_case_type');
+        var statusSelect = document.getElementById('id_status');
+        var disabled = false;
+        var title = '';
+
         if (caseTypeSelect) {
             var currentType = caseTypeSelect.value;
-            createCaseBtn.disabled = allowedTypes.indexOf(currentType) === -1;
-            if (createCaseBtn.disabled) {
-                createCaseBtn.title = '仅民商事、刑事、行政、劳动仲裁、商事仲裁类型的合同可创建案件';
-            } else {
-                createCaseBtn.title = '';
+            if (allowedTypes.indexOf(currentType) === -1) {
+                disabled = true;
+                title = '仅民商事、刑事、行政、劳动仲裁、商事仲裁类型的合同可创建案件';
             }
         }
+        if (statusSelect && statusSelect.value !== 'active') {
+            disabled = true;
+            title = '仅在办状态的合同可创建案件';
+        }
+
+        createCaseBtn.disabled = disabled;
+        createCaseBtn.title = title;
     }
 
     // 初始化按钮状态
     updateCreateCaseButton();
 
-    // 监听合同类型变化
+    // 监听合同类型和状态变化
     var caseTypeSelect = document.getElementById('id_case_type');
     if (caseTypeSelect) {
         caseTypeSelect.addEventListener('change', updateCreateCaseButton);
+    }
+    var statusSelect = document.getElementById('id_status');
+    if (statusSelect) {
+        statusSelect.addEventListener('change', updateCreateCaseButton);
     }
 
     // 插入按钮

--- a/backend/apps/contracts/templates/admin/contracts/contract/change_form.html
+++ b/backend/apps/contracts/templates/admin/contracts/contract/change_form.html
@@ -114,9 +114,9 @@ window.CONTRACTS_I18N = Object.assign(window.CONTRACTS_I18N || {}, {
                 title = '仅民商事、刑事、行政、劳动仲裁、商事仲裁类型的合同可创建案件';
             }
         }
-        if (statusSelect && statusSelect.value !== 'active') {
+        if (statusSelect && statusSelect.value === 'archived') {
             disabled = true;
-            title = '仅在办状态的合同可创建案件';
+            title = '已归档的合同不可创建案件';
         }
 
         createCaseBtn.disabled = disabled;

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fachuan-backend"
-version = "26.48.11"
+version = "26.48.15"
 description = "法穿AI Copilot - Backend"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "26.48.14",
+  "version": "26.48.15",
   "packageManager": "pnpm@10.28.2",
   "type": "module",
   "scripts": {

--- a/frontend/src/features/clients/components/ClientForm.tsx
+++ b/frontend/src/features/clients/components/ClientForm.tsx
@@ -22,6 +22,7 @@ import {
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
 
 import { useClient } from '../hooks/use-client'
 import { useClientMutations } from '../hooks/use-client-mutations'
@@ -238,6 +239,13 @@ export function ClientForm({ clientId, mode }: ClientFormProps) {
                   <FormLabel>地址</FormLabel>
                   <FormControl><Input placeholder="请输入地址" disabled={isPending} className="h-11" {...field} /></FormControl>
                   <FormMessage />
+                </FormItem>
+              )} />
+
+              <FormField control={form.control} name="is_our_client" render={({ field }) => (
+                <FormItem className="flex flex-row items-center gap-3 lg:col-span-2">
+                  <FormControl><Switch checked={field.value} onCheckedChange={field.onChange} disabled={isPending} /></FormControl>
+                  <FormLabel className="!mt-0">我方当事人</FormLabel>
                 </FormItem>
               )} />
 


### PR DESCRIPTION
## Summary

- 当事人表单添加「我方当事人」Switch 开关，之前只有 schema 定义但无 UI 控件
- 新建案件时 CaseContactInlineForm 未保存实例守卫 + CaseAssignment 唯一约束去重
- 合同 change form 根据状态禁用/启用「保存并创建案件」按钮，允许未签约合同创建案件
- CaseAssignmentInline 隐藏冗余 case FK 并启用 lawyer autocomplete
- CasePartyInline extra=0 消除页面加载时末行重复显示当事人
- CaseContactInline 改用 StackedInline 布局

## Test plan

- [ ] 新建当事人页面可切换「我方当事人」开关
- [ ] 新建案件时 inline 填写主管机关不报 ValueError
- [ ] 新建案件时 inline 选择与合同同步相同的律师不报 IntegrityError
- [ ] 已归档合同的「保存并创建案件」按钮禁用，未签约/在办可点击
- [ ] 案件编辑页 CaseAssignmentInline 只显示 lawyer 搜索框，不溢出
- [ ] 案件编辑页 CasePartyInline 末行无重复当事人