### PR TITLE
chore: 统一许可证为 Elastic License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,40 +1,93 @@
-PolyForm Noncommercial License 1.0.0 (附特别许可)
+Elastic License 2.0
 
-版权所有 (C) 2025-2099 法穿
+URL: https://www.elastic.co/licensing/elastic-license
 
-本软件遵循 PolyForm Noncommercial License 1.0.0 许可证，并附加以下特别许可条款。
+## Acceptance
 
-## 基础许可条款
+By using the software, you agree to all of the terms and conditions below.
 
-1. **禁止商业使用**：除特别许可外，不得将本软件用于任何商业目的
+## Copyright License
 
-2. **允许的使用**：
-   - 个人学习和研究
-   - 学术研究和教育
-   - 非营利组织内部使用
-   - 评估软件是否适合购买商业许可
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-3. **源代码可见**：你可以查看、复制和修改源代码，但仅限于非商业用途
+## Limitations
 
-4. **无担保**：本软件按"原样"提供，不提供任何明示或暗示的担保
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-## 特别许可条款
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-以下情形可**免费**商业使用本软件：
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
 
-- **个人使用**：单人使用（含个人律师、独立执业者）
-- **小型团队**：实际使用人数不超过 10 人（含 10 人）的团队或机构
+## Patents
 
-以下情形需**付费授权**：
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-- **大型团队**：实际使用人数超过 10 人
+## Notices
 
-**付费标准**：按实际使用人数，每人捐赠 **200 元人民币**。
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
 
-**授权方式**：通过项目主页的微信赞赏码按人数捐赠，备注"商业授权+人数"，捐赠即视为取得对应规模的商业使用授权，无需另行确认。
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
 
-**使用条件**（免费及付费授权均适用）：
-- 不得将本软件转售或分发给第三方商业使用
-- 必须保留原始版权声明
+## No Other Rights
 
-完整许可证文本：https://polyformproject.org/licenses/noncommercial/1.0.0
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.


### PR DESCRIPTION
## Summary

- main 分支许可证从 PolyForm Noncommercial 1.0.0 切换为 Elastic License 2.0，与 community 分支保持一致

## Test plan

- [ ] 确认 LICENSE 文件内容与 community 分支一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)