### PR TITLE
fix: Playwright 浏览器缺失时自动安装

### DIFF
--- a/backend/apps/core/services/browser/launcher.py
+++ b/backend/apps/core/services/browser/launcher.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,6 +21,51 @@ if TYPE_CHECKING:
     from playwright.sync_api import Browser, BrowserContext, Page, Playwright
 
 logger = logging.getLogger("apps.core")
+
+
+def _ensure_browsers_installed() -> None:
+    """检测 Playwright 浏览器是否已安装，缺失时自动下载。
+
+    通过检查 Playwright 浏览器缓存目录判断是否已安装，
+    避免每次都执行 install 命令带来的启动延迟。
+    """
+    cache_dir = Path.home() / ".cache" / "ms-playwright"
+    if not cache_dir.exists():
+        # macOS 上 Playwright 也用 ~/Library/Caches/ms-playwright/
+        cache_dir = Path.home() / "Library" / "Caches" / "ms-playwright"
+    if not cache_dir.exists():
+        cache_dir = Path.home() / ".local" / "share" / "ms-playwright"
+
+    if not cache_dir.exists():
+        _run_playwright_install()
+        return
+
+    # 检查是否有 chromium 目录（版本号随 Playwright 版本变化）
+    if not any(d.name.startswith("chromium") for d in cache_dir.iterdir() if d.is_dir()):
+        _run_playwright_install()
+
+
+def _run_playwright_install() -> None:
+    """执行 playwright install chromium。"""
+    logger.info("Playwright 浏览器缺失，自动安装中...")
+    subprocess.check_call(
+        [sys.executable, "-m", "playwright", "install", "chromium"],
+        stdout=subprocess.DEVNULL,
+    )
+    logger.info("Playwright 浏览器安装完成")
+
+
+def _launch_with_retry[T](factory: Callable[[], T], *, max_attempts: int = 2) -> T:
+    """尝试启动浏览器，遇到 Executable 不存在时自动安装后重试。"""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return factory()
+        except Exception as exc:
+            if "Executable doesn't exist" not in str(exc) or attempt >= max_attempts:
+                raise
+            logger.warning("浏览器可执行文件缺失，自动安装后重试 (attempt %d/%d)", attempt, max_attempts)
+            _run_playwright_install()
+    raise RuntimeError("unreachable")
 
 
 @contextmanager
@@ -46,6 +93,8 @@ def launch_browser(
     try:
         from playwright.sync_api import sync_playwright
 
+        _ensure_browsers_installed()
+
         logger.info("启动 Playwright 浏览器 (profile=%s, headless=%s)", profile.name, profile.headless)
         playwright = sync_playwright().start()
 
@@ -59,14 +108,18 @@ def launch_browser(
 
         if effective_user_data_dir:
             Path(effective_user_data_dir).mkdir(parents=True, exist_ok=True)
-            context = playwright.chromium.launch_persistent_context(
-                user_data_dir=effective_user_data_dir,
-                **launch_args,
+            context = _launch_with_retry(
+                lambda: playwright.chromium.launch_persistent_context(
+                    user_data_dir=effective_user_data_dir,
+                    **launch_args,
+                ),
             )
             # persistent context 本身就是 context，不需要单独的 browser
             browser = None
         else:
-            browser = playwright.chromium.launch(**launch_args)
+            browser = _launch_with_retry(
+                lambda: playwright.chromium.launch(**launch_args),
+            )
 
             # 创建 context
             context_args = profile.to_context_args()


### PR DESCRIPTION
## Summary

- 清理电脑缓存后 `~/Library/Caches/ms-playwright/` 被删除，Playwright 启动报 `Executable doesn't exist`
- 启动浏览器前检测缓存目录是否有 chromium 子目录，缺失则自动执行 `playwright install chromium`
- launch 时兜底：捕获可执行文件不存在的错误后自动安装并重试一次

## Test plan

- [ ] 删除 `~/Library/Caches/ms-playwright/` 后启动后端，确认自动安装浏览器并正常启动
- [ ] 浏览器已存在时启动无额外延迟（仅检查目录，不执行 install）

🤖 Generated with [Claude Code](https://claude.com/claude-code)