### PR TITLE
fix: 修复 Windows 日志文件轮转错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [26.50.7] - 2026-05-30
+
+### 后端
+
+#### 修复
+
+- **Windows 日志文件轮转错误**：使用 `ConcurrentRotatingFileHandler` 替代 `RotatingFileHandler`，解决 Windows 上 `PermissionError: [WinError 32]` 文件锁定问题
+
 ## [26.50.6] - 2026-05-30
 
 ### 后端

--- a/backend/apps/core/infrastructure/logging.py
+++ b/backend/apps/core/infrastructure/logging.py
@@ -337,7 +337,7 @@ def get_logging_config(base_dir: Any, debug: bool = True) -> dict[str, Any]:
             },
             "file_api": {
                 "level": file_level,
-                "class": "logging.handlers.RotatingFileHandler",
+                "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
                 "filename": os.path.join(log_dir, "api.log"),
                 "maxBytes": file_max_size,
                 "backupCount": api_backup_count,
@@ -347,7 +347,7 @@ def get_logging_config(base_dir: Any, debug: bool = True) -> dict[str, Any]:
             },
             "file_error": {
                 "level": error_level,
-                "class": "logging.handlers.RotatingFileHandler",
+                "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
                 "filename": os.path.join(log_dir, "error.log"),
                 "maxBytes": file_max_size,
                 "backupCount": error_backup_count,
@@ -357,7 +357,7 @@ def get_logging_config(base_dir: Any, debug: bool = True) -> dict[str, Any]:
             },
             "file_sql": {
                 "level": "DEBUG",
-                "class": "logging.handlers.RotatingFileHandler",
+                "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
                 "filename": os.path.join(log_dir, "sql.log"),
                 "maxBytes": file_max_size,
                 "backupCount": sql_backup_count,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     # --- 可观测性 ---
     "psutil==7.2.2",
     "sentry-sdk>=2.59.0",
+    "concurrent-log-handler>=0.9.25",
     # --- 配置 ---
     "python-dotenv==1.2.2",
     # --- 热重载 ---


### PR DESCRIPTION
## Summary

- 添加 `concurrent-log-handler` 依赖，解决 Windows 上日志文件轮转时的 `PermissionError: [WinError 32]` 问题
- 使用 `ConcurrentRotatingFileHandler` 替代 Python 内置的 `RotatingFileHandler`，支持多进程/多线程环境下的安全日志轮转
- 影响所有日志文件：`api.log`、`error.log`、`sql.log`

## Test plan

- [ ] 在 Windows 上启动 Django 开发服务器
- [ ] 触发日志写入（访问 API 端点）
- [ ] 等待日志文件达到轮转条件（或手动触发）
- [ ] 确认日志文件正常轮转，无 `PermissionError` 错误
- [ ] 在 macOS/Linux 上验证日志功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)