### PR TITLE
docs: 更新 CHANGELOG，版本号 26.50.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,77 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [26.50.9] - 2026-05-31
+
+### 后端
+
+#### 新功能
+
+- **智能模板填充（SmartFill）**：新增基于 LLM 的自然语言占位符填充功能，支持在 DocumentTemplate changeform 中直接使用，可切换 LLM 模型
+- **内容运营系统**：完整实现 content_ops 模块，包括数据模型、核心服务、API、Admin、执行器、RSS 采集、TTS 服务、选题灵感（热搜源 + LLM 筛选）、多人播客讨论稿（VoiceDesign 模式）
+- **案件日志批量添加**：按合同选择案件，一键写入相同日志内容
+- **法律检索自动补全**：任务页法院/案由字段支持 autocomplete，新增法院层级、地域、案由等字段级精确筛选
+- **模型连通性按需测试**：admin 页面模型列表不再加载时检查连通性，改为「测试连通性」按钮按需测试，页面加载从 ~5s 降至 ~0.05s
+- **LLM 自动重试**：临时性错误自动重试（最多3次，指数退避）
+- **东莞第三法院模板**：新增 docx 模板文件
+- **仪表盘日历增强**：事件类型颜色、议程视图、溢出 Popover
+
+#### 优化
+
+- **模型列表服务并发查询**：使用 ThreadPoolExecutor 并发查询所有后端，HTTP 超时从 15s 降至 5s，跳过未配凭证的后端
+- **Admin Top10 慢页面**：消除 N+1 查询，优化 causeofaction 和 court 编辑页面性能
+- **批量分析实时注入**：结果完成后实时注入消息列表，不再等任务结束
+
+#### 修复
+
+- **法律检索 WK API 500 错误**：修复 `filterQueries` 格式错误（Solr 字符串 vs 对象）
+- **WK DOM 检索参数错误**：URL 参数 `keyword` 改为 `simple`，修正 WK 网站实际使用的参数名
+- **推理模型 token 不足**：`SCORE_MAX_TOKENS` 从 260 提升至 65536，`ELEMENT_EXTRACTION_MAX_TOKENS` 从 300 提升至 16384，适配 mimo-v2.5-pro 等大输出模型
+- **LLM 占位符文本污染**：`_sanitize_elements()` 过滤 LLM 输出中的 "以下是提取结果" 等前缀文本，避免污染搜索关键词
+- **PostgreSQL 连接泄露**：Q cluster 从 ORM broker 切换到 Redis broker（配置 `REDIS_URL`），消除数据库轮询导致的连接累积
+- **LLM preflight SSL 握手失败**：使用 `ssl.CERT_NONE` 彻底禁用 SSL 验证，与后端保持一致
+- **模型列表支持 OpenAI-compatible 后端**：新增 `_fetch_openai_compatible_models()` 方法，mimo-v2.5-pro 等模型正确显示在下拉列表中
+- **i18n 清理后遗症**：批量恢复 91+ 个被破坏的 admin 模板文件，恢复 `{% trans %}` 标签和 i18n URL 路由
+- **OpenAI 兼容后端模型列表 URL 拼接重复**：修复 `/v1/v1` 路径问题
+- **新用户登录侧边栏为空**：修复「其他工具」菜单初始化问题
+- **DocumentTemplate add 页面隐藏状态字段**
+- **SmartFill 模型选择器默认值**：使用系统默认模型而非硬编码
+- **Windows 日志轮转**：使用 `ConcurrentRotatingFileHandler` 替代 `RotatingFileHandler`
+- **FolderTemplate NameError**：修复未导入导致的运行时错误
+- **一张网立案文件名**：上传材料保留原始中文文件名
+- **testcourt 500 错误 + MCP workbench 加载优化**
+
+#### 依赖变更
+
+- `.env` 新增 `REDIS_URL=redis://127.0.0.1:6379/0`（Q cluster 使用 Redis broker）
+
+### 前端
+
+#### 新功能
+
+- **内容运营创作工作台**：完整的前端页面，支持选题灵感、创作、发布流程
+- **VoiceDesign 模式**：自然语言描述音色风格
+
+#### 优化
+
+- **SmartFill 区域样式**：改用 Django `.module` class 统一风格
+
+#### 修复
+
+- **InspirationPage 导航简化**：去掉与面包屑重复的顶部标题栏
+- **AdminLayout 路由标签**：添加「选题灵感」路由标签
+- **批量添加日志 UI**：去重标题、美化 UI、案件名称可点击跳转，修复下拉菜单高度被 admin base.css 覆盖
+- **合同审查多项体验修复**：当事人识别、手动输入、并行化审查流程
+- **选题建议 LLM 返回中文 key 匹配问题**
+- **content_ops 前端 UX 修复**
+
+#### 杂项
+
+- plugins 独立为 git submodule（FachuanPlugins），更新子模块引用
+- 删除 UPDATE.md 中无效的环境变量同步步骤
+- 拆分 INSTALL.md 平台章节，新增 UPDATE.md 更新指南
+- `.gitignore` 添加 `.handbook/`
+
 ## [26.50.8] - 2026-05-30
 
 ### 后端


### PR DESCRIPTION
## Summary
- 恢复 PR #252 中被合并冲突覆盖的 CHANGELOG 26.50.9 版本记录
- 包含：智能模板填充、内容运营系统、法律检索优化、模型连通性按需测试等新功能

## Test plan
- [x] CHANGELOG 格式与原有风格一致