### PR TITLE
fix: 修复 CI 错误 - 移除重复 FormatMethod 类

### DIFF
--- a/backend/apps/wechat_mp/models.py
+++ b/backend/apps/wechat_mp/models.py
@@ -50,11 +50,6 @@ class FormatMethod(models.TextChoices):
     LLM = "llm", "AI 排版"
 
 
-class FormatMethod(models.TextChoices):
-    RULE = "rule", _("规则排版")
-    LLM = "llm", _("AI 排版")
-
-
 class PublishTask(models.Model):
     """公众号文章发布任务"""
 


### PR DESCRIPTION
## Summary
- 修复 `apps/wechat_mp/models.py` 中因合并冲突产生的重复 `FormatMethod` 类
- 移除使用 `_()` 但缺少 import 的重复定义，解决 `NameError: name '_' is not defined`

## Test plan
- [x] 本地 mypy 检查通过
- [ ] CI 集成测试通过