### PR TITLE
Fix contract review numbering for DOCX files without numbering part

### DIFF
--- a/backend/apps/contract_review/services/extraction/heading_numbering.py
+++ b/backend/apps/contract_review/services/extraction/heading_numbering.py
@@ -6,8 +6,12 @@ import re
 
 from docx import Document
 from docx.document import Document as DocumentType
-from docx.oxml import OxmlElement
+from docx.opc.constants import CONTENT_TYPE as CT
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.opc.packuri import PackURI
+from docx.oxml import OxmlElement, parse_xml
 from docx.oxml.ns import qn
+from docx.parts.numbering import NumberingPart
 
 from apps.core.llm.service import LLMService
 
@@ -52,7 +56,7 @@ class HeadingNumbering:
                 num_pr.getparent().remove(num_pr)
 
         # 拆分区域并分配 numId
-        numbering_elem = doc.part.numbering_part.element
+        numbering_elem = self._get_or_add_numbering_part(doc).element
         sections: list[list[tuple[int, int]]] = [[]]
         for idx, lvl in headings:
             if lvl == -1:
@@ -229,7 +233,7 @@ class HeadingNumbering:
 
     def _create_abstract_num(self, doc: DocumentType) -> int:
         """创建 abstractNum 定义，返回 abstractNumId"""
-        numbering_part = doc.part.numbering_part
+        numbering_part = self._get_or_add_numbering_part(doc)
         numbering_elem = numbering_part.element
 
         existing_ids = {int(a.get(qn("w:abstractNumId"), 0)) for a in numbering_elem.findall(qn("w:abstractNum"))}
@@ -277,6 +281,32 @@ class HeadingNumbering:
             numbering_elem.append(abstract_num)
 
         return abstract_id
+
+    @staticmethod
+    def _get_or_add_numbering_part(doc: DocumentType) -> NumberingPart:
+        """Return the numbering part, creating it for DOCX files that omit it.
+
+        python-docx 1.2.0 tries to create this part through NumberingPart.new(),
+        but that method raises NotImplementedError. Uploaded contracts can omit
+        word/numbering.xml entirely, so create the minimal OOXML part directly.
+        """
+        try:
+            return doc.part.numbering_part
+        except NotImplementedError:
+            logger.info("DOCX has no numbering part; creating a minimal numbering.xml part")
+
+        package = doc.part.package
+        partnames = {part.partname for part in package.iter_parts()}
+        partname = PackURI("/word/numbering.xml")
+        if partname in partnames:
+            partname = package.next_partname("/word/numbering%d.xml")
+
+        numbering_xml = (
+            '<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>'
+        )
+        numbering_part = NumberingPart(partname, CT.WML_NUMBERING, parse_xml(numbering_xml), package)
+        doc.part.relate_to(numbering_part, RT.NUMBERING)
+        return numbering_part
 
     @staticmethod
     def _create_num_ref(numbering_elem: object, abstract_id: int) -> int:

--- a/backend/tests/ci/unit/test_contract_review_heading_numbering.py
+++ b/backend/tests/ci/unit/test_contract_review_heading_numbering.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree
+
+import pytest
+from docx import Document
+
+
+def _remove_numbering_part(source: str, target: str) -> None:
+    """Write a copy of `source` without the optional Word numbering part."""
+    with zipfile.ZipFile(source, "r") as zin, zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            data = zin.read(item.filename)
+            if item.filename == "word/numbering.xml":
+                continue
+
+            if item.filename == "word/_rels/document.xml.rels":
+                root = ElementTree.fromstring(data)
+                for rel in list(root):
+                    if rel.attrib.get("Type", "").endswith("/numbering"):
+                        root.remove(rel)
+                data = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+
+            if item.filename == "[Content_Types].xml":
+                root = ElementTree.fromstring(data)
+                for override in list(root):
+                    if override.attrib.get("PartName") == "/word/numbering.xml":
+                        root.remove(override)
+                data = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+
+            zout.writestr(item, data)
+
+
+def _load_heading_numbering_class():
+    """Load the module without importing the Django-heavy services package."""
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "apps"
+        / "contract_review"
+        / "services"
+        / "extraction"
+        / "heading_numbering.py"
+    )
+
+    module_names = ["apps", "apps.core", "apps.core.llm", "apps.core.llm.service"]
+    original_modules = {name: sys.modules.get(name) for name in module_names}
+
+    apps_module = types.ModuleType("apps")
+    core_module = types.ModuleType("apps.core")
+    llm_module = types.ModuleType("apps.core.llm")
+    service_module = types.ModuleType("apps.core.llm.service")
+    service_module.LLMService = type("LLMService", (), {})
+
+    sys.modules.update(
+        {
+            "apps": apps_module,
+            "apps.core": core_module,
+            "apps.core.llm": llm_module,
+            "apps.core.llm.service": service_module,
+        }
+    )
+    try:
+        spec = importlib.util.spec_from_file_location("heading_numbering_under_test", module_path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.HeadingNumbering
+    finally:
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+@pytest.mark.unit
+def test_get_or_add_numbering_part_creates_missing_part(tmp_path) -> None:
+    original_path = tmp_path / "original.docx"
+    missing_numbering_path = tmp_path / "missing-numbering.docx"
+    output_path = tmp_path / "output.docx"
+
+    doc = Document()
+    doc.add_paragraph("Section heading")
+    doc.add_paragraph("Subsection heading")
+    doc.save(original_path)
+    _remove_numbering_part(str(original_path), str(missing_numbering_path))
+
+    broken_doc = Document(missing_numbering_path)
+    with pytest.raises(NotImplementedError):
+        _ = broken_doc.part.numbering_part
+
+    service = _load_heading_numbering_class()()
+    numbering_part = service._get_or_add_numbering_part(broken_doc)
+    abstract_id = service._create_abstract_num(broken_doc)
+    num_id = service._create_num_ref(numbering_part.element, abstract_id)
+    service._apply_num_to_paragraphs(broken_doc, [(0, 0), (1, 1)], num_id)
+    broken_doc.save(output_path)
+
+    with zipfile.ZipFile(output_path, "r") as zf:
+        assert any(name.startswith("word/numbering") for name in zf.namelist())
+        assert "relationships/numbering" in zf.read("word/_rels/document.xml.rels").decode("utf-8")


### PR DESCRIPTION
## Summary
- Fix contract review heading numbering for uploaded DOCX files that do not contain `word/numbering.xml`.
- Create a minimal numbering part and relationship directly when `python-docx` raises `NotImplementedError` from `NumberingPart.new()`.
- Add a unit test that reproduces the missing-numbering-part document shape and verifies the repaired document can be saved with numbering relationships.

## Why
Some valid DOCX files omit the optional numbering part. During contract review output formatting, `HeadingNumbering.apply_numbering()` accesses `doc.part.numbering_part`; in python-docx 1.2.0 this attempts to call the unimplemented `NumberingPart.new()`, causing the whole review task to fail after LLM processing succeeds.

## Verification
- `python -m pytest -p no:django -o addopts='' tests/ci/unit/test_contract_review_heading_numbering.py -q`
- `python -m compileall apps\\contract_review\\services\\extraction\\heading_numbering.py tests\\ci\\unit\\test_contract_review_heading_numbering.py`

Note: The local Windows environment did not have the project's full `uv` environment available, so I ran this focused pure-DOCX unit test with Django plugin disabled.