### PR TITLE
fix: 修复Windows下扫描子文件夹全部被 _is_within_root 过滤的问题

### DIFF
--- a/backend/apps/cases/services/material/folder_scan_service.py
+++ b/backend/apps/cases/services/material/folder_scan_service.py
@@ -520,7 +520,7 @@ class CaseFolderScanService:
 
     def _is_within_root(self, root: Path, target: Path) -> bool:
         try:
-            return os.path.commonpath([root.as_posix(), target.as_posix()]) == root.as_posix()
+            return os.path.commonpath([root.as_posix(), target.as_posix()]).replace("\\", "/") == root.as_posix()
         except ValueError:
             return False
 


### PR DESCRIPTION
## 问题
`os.path.commonpath()` 在 Windows 上返回反斜杠路径（`\`），与 `root.as_posix()` 的正斜杠路径（`/`）比较永远不相等，导致 `list_scan_subfolders()` 中 `_is_within_root` 过滤掉全部子文件夹，返回空列表，"指定子文件夹"扫描功能在 Windows 上完全不可用。

## 复现
绑定的案件文件夹下有多个子文件夹（如 `1-立案材料`、`2-庭审准备` 等），但页面加载后"指定子文件夹" radio 始终 disabled，`GET /folder-scan/subfolders` 返回 `subfolders: []`。

## 修复
对 `os.path.commonpath()` 结果统一做 `.replace("\\", "/")` 转换后再比较，兼容 Windows 和 Linux/macOS。

## 改动
- `backend/apps/cases/services/material/folder_scan_service.py`：1 行修复
