### PR TITLE
Make court SMS chat notifications non-blocking

### DIFF
--- a/backend/apps/automation/services/document_delivery/_matching_mixin.py
+++ b/backend/apps/automation/services/document_delivery/_matching_mixin.py
@@ -300,9 +300,9 @@ class DocumentDeliveryMatchingMixin:
                         sms.status = CourtSMSStatus.COMPLETED
                         logger.info(f"通知发送成功: SMS ID={sms.id}")
                     else:
-                        sms.status = CourtSMSStatus.FAILED
-                        sms.error_message = "通知发送失败"
-                        logger.warning(f"通知发送失败: SMS ID={sms.id}")
+                        sms.status = CourtSMSStatus.COMPLETED
+                        sms.error_message = "通知发送失败（不影响文书归档）"
+                        logger.warning(f"通知发送失败，但文书已归档，短信标记为完成: SMS ID={sms.id}")
 
                     sms.save()
                     result["success"] = True

--- a/backend/apps/automation/services/document_delivery/api/document_delivery_api_service/_process.py
+++ b/backend/apps/automation/services/document_delivery/api/document_delivery_api_service/_process.py
@@ -216,9 +216,9 @@ class DocumentProcessMixin:
                         sms.status = CourtSMSStatus.COMPLETED
                         logger.info(f"通知发送成功: SMS ID={sms.id}")
                     else:
-                        sms.status = CourtSMSStatus.FAILED
-                        sms.error_message = "通知发送失败"
-                        logger.warning(f"通知发送失败: SMS ID={sms.id}")
+                        sms.status = CourtSMSStatus.COMPLETED
+                        sms.error_message = "通知发送失败（不影响文书归档）"
+                        logger.warning(f"通知发送失败，但文书已归档，短信标记为完成: SMS ID={sms.id}")
 
                     sms.save()
                     result["success"] = True

--- a/backend/apps/automation/services/document_delivery/delivery/document_processor.py
+++ b/backend/apps/automation/services/document_delivery/delivery/document_processor.py
@@ -298,10 +298,10 @@ class DocumentProcessor:
                         sms_id = sms.id
                         logger.info(f"通知发送成功: SMS ID={sms_id}")
                     else:
-                        sms.status = CourtSMSStatus.FAILED
-                        sms.error_message = "通知发送失败"
+                        sms.status = CourtSMSStatus.COMPLETED
+                        sms.error_message = "通知发送失败（不影响文书归档）"
                         sms_id = sms.id
-                        logger.warning(f"通知发送失败: SMS ID={sms_id}")
+                        logger.warning(f"通知发送失败，但文书已归档，短信标记为完成: SMS ID={sms_id}")
 
                     sms.save()
                     result["success"] = True

--- a/backend/apps/automation/services/document_delivery/processor/document_delivery_processor.py
+++ b/backend/apps/automation/services/document_delivery/processor/document_delivery_processor.py
@@ -207,8 +207,8 @@ class DocumentDeliveryProcessor:
                     if notification_sent:
                         sms.status = CourtSMSStatus.COMPLETED
                     else:
-                        sms.status = CourtSMSStatus.FAILED
-                        sms.error_message = "通知发送失败"
+                        sms.status = CourtSMSStatus.COMPLETED
+                        sms.error_message = "通知发送失败（不影响文书归档）"
                     sms.save()
                     result["success"] = True
                 else:

--- a/backend/apps/automation/services/sms/court_sms_service.py
+++ b/backend/apps/automation/services/sms/court_sms_service.py
@@ -553,6 +553,7 @@ class CourtSMSService(SMSCaseBindingMixin, SMSDocumentMixin, SMSDownloadMixin):
             document_paths = self.document_attachment.get_paths_for_notification(sms)
             logger.info(f"准备发送 {len(document_paths)} 个文件到群聊: SMS ID={sms.id}")
 
+            notification_is_optional = bool(sms.case)
             if sms.case:
                 result = self.notification.send_case_chat_notification(sms, document_paths)
 
@@ -578,6 +579,10 @@ class CourtSMSService(SMSCaseBindingMixin, SMSDocumentMixin, SMSDownloadMixin):
             if any_platform_success:
                 sms.status = CourtSMSStatus.COMPLETED
                 logger.info(f"案件群聊通知发送成功，短信处理完成: SMS ID={sms.id}")
+            elif notification_is_optional:
+                sms.status = CourtSMSStatus.COMPLETED
+                sms.error_message = "案件群聊通知发送失败（不影响文书归档）"
+                logger.warning(f"案件群聊通知发送失败，但文书已归档，短信标记为完成: SMS ID={sms.id}")
             else:
                 sms.status = CourtSMSStatus.FAILED
                 sms.error_message = "案件群聊通知发送失败"
@@ -590,8 +595,12 @@ class CourtSMSService(SMSCaseBindingMixin, SMSDocumentMixin, SMSDownloadMixin):
             logger.error(f"案件群聊通知发送失败: SMS ID={sms.id}, 错误: {e!s}")
             sms.notification_results = sms.notification_results or {}
             sms.notification_results["_exception"] = {"success": False, "error": str(e)}
-            sms.status = CourtSMSStatus.FAILED
-            sms.error_message = f"案件群聊通知发送失败: {e!s}"
+            if sms.case:
+                sms.status = CourtSMSStatus.COMPLETED
+                sms.error_message = f"案件群聊通知发送失败（不影响文书归档）: {e!s}"
+            else:
+                sms.status = CourtSMSStatus.FAILED
+                sms.error_message = f"案件群聊通知发送失败: {e!s}"
             sms.save()
             return sms
 

--- a/backend/apps/automation/services/sms/stages/sms_notifying_stage.py
+++ b/backend/apps/automation/services/sms/stages/sms_notifying_stage.py
@@ -121,19 +121,21 @@ class SMSNotifyingStage(BaseSMSStage):
             sms.status = CourtSMSStatus.COMPLETED
             logger.info(f"案件群聊通知发送成功，短信处理完成: SMS ID={sms.id}")
         else:
-            sms.status = CourtSMSStatus.FAILED
+            sms.status = CourtSMSStatus.COMPLETED
             error_detail = "; ".join(f"{r.platform}: {r.error}" for r in result.attempts if not r.success)
-            sms.error_message = f"案件群聊通知发送失败: {error_detail}" if error_detail else "案件群聊通知发送失败"
-            logger.error(f"案件群聊通知发送失败，短信标记为失败: SMS ID={sms.id}")
+            sms.error_message = (
+                f"案件群聊通知发送失败（不影响文书归档）: {error_detail}" if error_detail else "案件群聊通知发送失败（不影响文书归档）"
+            )
+            logger.warning(f"案件群聊通知发送失败，但文书已归档，短信标记为完成: SMS ID={sms.id}")
 
     def _handle_notification_error(self, sms: CourtSMS, error: Exception) -> None:
         error_msg = str(error)
         sms.notification_results = sms.notification_results or {}
         sms.notification_results["_exception"] = {"success": False, "error": error_msg}
-        sms.status = CourtSMSStatus.FAILED
-        sms.error_message = f"案件群聊通知发送失败: {error_msg}"
+        sms.status = CourtSMSStatus.COMPLETED
+        sms.error_message = f"案件群聊通知发送失败（不影响文书归档）: {error_msg}"
         sms.save()
-        logger.error(f"案件群聊通知发送失败: SMS ID={sms.id}, 错误: {error_msg}")
+        logger.warning(f"案件群聊通知发送失败，但文书已归档，短信标记为完成: SMS ID={sms.id}, 错误: {error_msg}")
 
 
 def create_sms_notifying_stage(

--- a/backend/tests/ci/unit/automation/test_court_sms_notification_stage.py
+++ b/backend/tests/ci/unit/automation/test_court_sms_notification_stage.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from apps.automation.models import CourtSMSStatus
+from apps.automation.services.sms.stages.sms_notifying_stage import SMSNotifyingStage
+from apps.core.dto.chat import MultiPlatformNotificationResult, PlatformNotificationResult
+
+
+@dataclass
+class FakeSMS:
+    id: int = 1
+    status: str = CourtSMSStatus.NOTIFYING
+    error_message: str | None = None
+    notification_results: dict[str, Any] = field(default_factory=dict)
+    save_count: int = 0
+
+    def save(self) -> None:
+        self.save_count += 1
+
+
+def test_notification_failure_keeps_archived_sms_completed() -> None:
+    sms = FakeSMS()
+    result = MultiPlatformNotificationResult(
+        attempts=[
+            PlatformNotificationResult(
+                platform="feishu",
+                success=False,
+                error="not configured",
+            )
+        ]
+    )
+
+    SMSNotifyingStage()._update_notification_status(sms, result)
+
+    assert sms.status == CourtSMSStatus.COMPLETED
+    assert sms.notification_results["feishu"]["success"] is False
+    assert sms.error_message is not None
+    assert "不影响文书归档" in sms.error_message
+
+
+def test_notification_exception_keeps_archived_sms_completed() -> None:
+    sms = FakeSMS()
+
+    SMSNotifyingStage()._handle_notification_error(sms, RuntimeError("boom"))
+
+    assert sms.status == CourtSMSStatus.COMPLETED
+    assert sms.notification_results["_exception"] == {"success": False, "error": "boom"}
+    assert sms.error_message is not None
+    assert "不影响文书归档" in sms.error_message
+    assert sms.save_count == 1

--- a/backend/tests/ci/unit/automation/test_court_sms_notification_stage.py
+++ b/backend/tests/ci/unit/automation/test_court_sms_notification_stage.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from apps.automation.models import CourtSMSStatus
+from apps.automation.services.sms.court_sms_service import CourtSMSService
 from apps.automation.services.sms.stages.sms_notifying_stage import SMSNotifyingStage
 from apps.core.dto.chat import MultiPlatformNotificationResult, PlatformNotificationResult
 
@@ -12,6 +13,7 @@ from apps.core.dto.chat import MultiPlatformNotificationResult, PlatformNotifica
 class FakeSMS:
     id: int = 1
     status: str = CourtSMSStatus.NOTIFYING
+    case: object | None = object()
     error_message: str | None = None
     notification_results: dict[str, Any] = field(default_factory=dict)
     save_count: int = 0
@@ -20,9 +22,28 @@ class FakeSMS:
         self.save_count += 1
 
 
-def test_notification_failure_keeps_archived_sms_completed() -> None:
-    sms = FakeSMS()
-    result = MultiPlatformNotificationResult(
+class FakeDocumentAttachment:
+    def get_paths_for_notification(self, sms: FakeSMS) -> list[str]:
+        return ["/tmp/court-document.pdf"]
+
+
+@dataclass
+class FakeNotification:
+    result: MultiPlatformNotificationResult | None = None
+    error: Exception | None = None
+
+    def send_case_chat_notification(
+        self, sms: FakeSMS, document_paths: list[str]
+    ) -> MultiPlatformNotificationResult:
+        if self.error is not None:
+            raise self.error
+        if self.result is None:
+            raise AssertionError("FakeNotification.result is required")
+        return self.result
+
+
+def failed_notification_result() -> MultiPlatformNotificationResult:
+    return MultiPlatformNotificationResult(
         attempts=[
             PlatformNotificationResult(
                 platform="feishu",
@@ -31,6 +52,11 @@ def test_notification_failure_keeps_archived_sms_completed() -> None:
             )
         ]
     )
+
+
+def test_notification_failure_keeps_archived_sms_completed() -> None:
+    sms = FakeSMS()
+    result = failed_notification_result()
 
     SMSNotifyingStage()._update_notification_status(sms, result)
 
@@ -50,3 +76,70 @@ def test_notification_exception_keeps_archived_sms_completed() -> None:
     assert sms.error_message is not None
     assert "不影响文书归档" in sms.error_message
     assert sms.save_count == 1
+
+
+def test_process_notifying_with_case_and_failed_notification_completes() -> None:
+    sms = FakeSMS(case=object())
+    service = CourtSMSService(
+        document_attachment=FakeDocumentAttachment(),
+        notification=FakeNotification(result=failed_notification_result()),
+    )
+
+    result = service._process_notifying(sms)
+
+    assert result is sms
+    assert sms.status == CourtSMSStatus.COMPLETED
+    assert sms.notification_results["feishu"]["success"] is False
+    assert sms.error_message is not None
+    assert "不影响文书归档" in sms.error_message
+
+
+def test_process_notifying_without_case_and_failed_notification_fails() -> None:
+    sms = FakeSMS(case=None)
+    service = CourtSMSService(
+        document_attachment=FakeDocumentAttachment(),
+        notification=FakeNotification(result=failed_notification_result()),
+    )
+
+    result = service._process_notifying(sms)
+
+    assert result is sms
+    assert sms.status == CourtSMSStatus.FAILED
+    assert sms.notification_results["none"]["success"] is False
+    assert sms.error_message == "案件群聊通知发送失败"
+
+
+def test_process_notifying_with_case_and_notification_exception_completes() -> None:
+    sms = FakeSMS(case=object())
+    service = CourtSMSService(
+        document_attachment=FakeDocumentAttachment(),
+        notification=FakeNotification(error=RuntimeError("boom")),
+    )
+
+    result = service._process_notifying(sms)
+
+    assert result is sms
+    assert sms.status == CourtSMSStatus.COMPLETED
+    assert sms.notification_results["_exception"] == {"success": False, "error": "boom"}
+    assert sms.error_message is not None
+    assert "不影响文书归档" in sms.error_message
+
+
+def test_process_notifying_without_case_and_notification_exception_fails() -> None:
+    sms = FakeSMS(case=None)
+
+    class RaisingDocumentAttachment:
+        def get_paths_for_notification(self, sms: FakeSMS) -> list[str]:
+            raise RuntimeError("boom")
+
+    service = CourtSMSService(
+        document_attachment=RaisingDocumentAttachment(),
+        notification=FakeNotification(result=failed_notification_result()),
+    )
+
+    result = service._process_notifying(sms)
+
+    assert result is sms
+    assert sms.status == CourtSMSStatus.FAILED
+    assert sms.notification_results["_exception"] == {"success": False, "error": "boom"}
+    assert sms.error_message == "案件群聊通知发送失败: boom"


### PR DESCRIPTION
## Summary
- mark court SMS/document delivery workflows completed after documents are archived even when chat notification fails
- preserve notification failure details in notification_results/error_message for follow-up
- add unit coverage for the notification stage failure and exception paths

## Verification
- python -m compileall backend/apps/automation/services/sms/court_sms_service.py backend/apps/automation/services/sms/stages/sms_notifying_stage.py backend/apps/automation/services/document_delivery/_matching_mixin.py backend/apps/automation/services/document_delivery/processor/document_delivery_processor.py backend/apps/automation/services/document_delivery/api/document_delivery_api_service/_process.py backend/apps/automation/services/document_delivery/delivery/document_processor.py backend/tests/ci/unit/automation/test_court_sms_notification_stage.py

Note: local pytest could not run because the local Python environment is missing project dependencies such as psutil.