### PR TITLE
fix: 修复 Windows 路径分隔符问题（12处）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 本项目的所有重要更改都将记录在此文件中。
 
+## [26.50.12] - 2026-06-01
+
+### 后端
+
+#### 修复
+
+- **Windows 路径分隔符问题**：修复 12 处 Windows 下路径比较和存储失效的问题
+  - `os.path.commonpath()` 返回反斜杠导致 `_is_within_root()` 过滤所有子文件夹（contracts、cases 模块）
+  - `str(relative_to())` 存储反斜杠路径到数据库，导致后续比较失败（output_storage、court_document_admin）
+  - `startswith(str(path) + "/")` 安全检查在 Windows 上失效，改用 `is_relative_to()`（cases admin views）
+  - `str(path.resolve())` 存储反斜杠路径，改用 `.as_posix()`（client_identity_doc、property_clue、court_sms 相关服务）
+  - ZIP 路径遍历检查改用 `is_relative_to()` 提升安全性和跨平台兼容（4 处 document_delivery 相关）
+
 ## [26.50.11] - 2026-06-01
 
 ### 前端

--- a/backend/apps/automation/admin/sms/court_sms_admin.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin.py
@@ -199,7 +199,7 @@ class CourtSMSAdmin(CourtSMSAdminActions, CourtSMSAdminBase):
         path = Path(str(raw_path or ""))
         if not path.is_absolute():
             path = Path(settings.MEDIA_ROOT) / path
-        return str(path.resolve(strict=False))
+        return path.resolve(strict=False).as_posix()
 
     def _sync_document_references(
         self,

--- a/backend/apps/automation/services/admin/court_document_admin_service.py
+++ b/backend/apps/automation/services/admin/court_document_admin_service.py
@@ -357,7 +357,7 @@ class CourtDocumentAdminService:
             for root, _dirs, files in documents_dir.walk():
                 for file in files:
                     file_path = root / file
-                    relative_path = str(file_path.relative_to(media_root))
+                    relative_path = file_path.relative_to(media_root).as_posix()
 
                     if relative_path not in downloaded_files:
                         orphaned_files.append(str(file_path))

--- a/backend/apps/automation/services/document_delivery/_downloading_mixin.py
+++ b/backend/apps/automation/services/document_delivery/_downloading_mixin.py
@@ -111,7 +111,7 @@ class DocumentDeliveryDownloadingMixin:
             with zipfile.ZipFile(file_path, "r") as zip_ref:
                 for member in zip_ref.infolist():
                     target = (extract_path / member.filename).resolve()
-                    if not str(target).startswith(str(extract_path.resolve())):
+                    if not target.is_relative_to(extract_path.resolve()):
                         logger.warning(f"跳过不安全的 ZIP 条目: {member.filename}")
                         continue
                     zip_ref.extract(member, extract_path)

--- a/backend/apps/automation/services/document_delivery/delivery/document_processor.py
+++ b/backend/apps/automation/services/document_delivery/delivery/document_processor.py
@@ -95,7 +95,7 @@ class DocumentProcessor:
             with zipfile.ZipFile(file_path, "r") as zip_ref:
                 for member in zip_ref.infolist():
                     target = (extract_path / member.filename).resolve()
-                    if not str(target).startswith(str(extract_path.resolve())):
+                    if not target.is_relative_to(extract_path.resolve()):
                         logger.warning(f"跳过不安全的 ZIP 条目: {member.filename}")
                         continue
                     zip_ref.extract(member, extract_path)

--- a/backend/apps/automation/services/document_delivery/processor/document_delivery_processor.py
+++ b/backend/apps/automation/services/document_delivery/processor/document_delivery_processor.py
@@ -398,7 +398,7 @@ class DocumentDeliveryProcessor:
             with zipfile.ZipFile(file_path, "r") as zip_ref:
                 for member in zip_ref.infolist():
                     target = (extract_path / member.filename).resolve()
-                    if not str(target).startswith(str(extract_path.resolve())):
+                    if not target.is_relative_to(extract_path.resolve()):
                         logger.warning(f"跳过不安全的 ZIP 条目: {member.filename}")
                         continue
                     zip_ref.extract(member, extract_path)

--- a/backend/apps/automation/services/scraper/scrapers/court_document/gdems_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/gdems_scraper.py
@@ -309,7 +309,7 @@ class GdemsCourtScraper(BaseCourtDocumentScraper):
             with zipfile.ZipFile(zip_filepath, "r") as zip_ref:
                 for member in zip_ref.infolist():
                     target = (extract_dir / member.filename).resolve()
-                    if not str(target).startswith(str(extract_dir.resolve())):
+                    if not target.is_relative_to(extract_dir.resolve()):
                         logger.warning(f"跳过不安全的 ZIP 条目: {member.filename}")
                         continue
                     zip_ref.extract(member, extract_dir)

--- a/backend/apps/automation/services/sms/court_sms_document_reference_service.py
+++ b/backend/apps/automation/services/sms/court_sms_document_reference_service.py
@@ -183,7 +183,7 @@ class CourtSMSDocumentReferenceService:
             path = Path(settings.MEDIA_ROOT) / path
 
         if path.exists():
-            return str(path.resolve())
+            return path.resolve().as_posix()
 
         # 文件被重命名时，尝试在同目录下匹配
         parent = path.parent
@@ -199,7 +199,7 @@ class CourtSMSDocumentReferenceService:
         stem = path.stem
         prefix_matches = [f for f in same_suffix if f.stem.startswith(stem)]
         if prefix_matches:
-            return str(max(prefix_matches, key=lambda f: f.stat().st_mtime).resolve())
+            return max(prefix_matches, key=lambda f: f.stat().st_mtime).resolve().as_posix()
 
         # 2) 兜底：取同后缀最新的文件（适用于完全重命名的情况）
-        return str(max(same_suffix, key=lambda f: f.stat().st_mtime).resolve())
+        return max(same_suffix, key=lambda f: f.stat().st_mtime).resolve().as_posix()

--- a/backend/apps/cases/admin/mixins/views.py
+++ b/backend/apps/cases/admin/mixins/views.py
@@ -619,7 +619,7 @@ class CaseAdminViewsMixin:
             media_root = Path(settings.MEDIA_ROOT).resolve()
             allowed_dir = media_root / "case_documents" / "temp"
             file_path = Path(temp_file_path).resolve()
-            if not str(file_path).startswith(str(allowed_dir) + "/") and file_path != allowed_dir:
+            if not file_path.is_relative_to(allowed_dir):
                 return JsonResponse({"success": False, "error": "非法文件路径"}, status=400)
 
             if not file_path.exists():
@@ -733,8 +733,8 @@ class CaseAdminViewsMixin:
 
             # 安全检查：只允许打开用户主目录或 /Volumes 下的目录（防止打开系统敏感目录）
             home = Path.home().resolve()
-            folder_str = str(folder)
-            if not (folder_str.startswith(str(home) + "/") or folder_str.startswith("/Volumes/")):
+            volumes = Path("/Volumes").resolve()
+            if not (folder.is_relative_to(home) or folder.is_relative_to(volumes)):
                 return JsonResponse({"success": False, "error": "不允许打开该目录"}, status=403)
 
             system = platform.system()

--- a/backend/apps/client/services/client_identity_doc_service.py
+++ b/backend/apps/client/services/client_identity_doc_service.py
@@ -110,9 +110,9 @@ class ClientIdentityDocService:
                 media_root = Path(media_root_str) if media_root_str else None
                 try:
                     relative_path = new_abs_path.relative_to(media_root) if media_root else None
-                    doc_instance.file_path = str(relative_path) if relative_path else str(new_abs_path)
+                    doc_instance.file_path = relative_path.as_posix() if relative_path else new_abs_path.as_posix()
                 except ValueError:
-                    doc_instance.file_path = str(new_abs_path)
+                    doc_instance.file_path = new_abs_path.as_posix()
                 doc_instance.save(update_fields=["file_path"])
                 logger.info("文件重命名成功: %s -> %s", raw_path, doc_instance.file_path)
             except Exception:
@@ -189,6 +189,6 @@ class ClientIdentityDocService:
         return self.add_identity_doc(
             client_id=client_id,
             doc_type=doc_type,
-            file_path=str(saved_path),
+            file_path=saved_path.as_posix(),
             user=user,
         )

--- a/backend/apps/client/services/property_clue_service.py
+++ b/backend/apps/client/services/property_clue_service.py
@@ -271,7 +271,7 @@ class PropertyClueService:
         file_name: str = uploaded_file.name or saved_path.name
         return self.add_attachment(
             clue_id=clue_id,
-            file_path=str(saved_path),
+            file_path=saved_path.as_posix(),
             file_name=file_name,
             user=user,
         )

--- a/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
+++ b/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
@@ -548,7 +548,7 @@ class ContractFolderScanService:
 
     def _is_within_root(self, root: Path, target: Path) -> bool:
         try:
-            return os.path.commonpath([root.as_posix(), target.as_posix()]) == root.as_posix()
+            return os.path.commonpath([root.as_posix(), target.as_posix()]).replace("\\", "/") == root.as_posix()
         except ValueError:
             return False
 

--- a/backend/apps/documents/services/generation/output_storage.py
+++ b/backend/apps/documents/services/generation/output_storage.py
@@ -29,7 +29,8 @@ class GeneratedDocumentStorage:
         with file_path.open("wb") as f:
             f.write(content)
 
-        return file_path.relative_to(media_root).as_posix()
+        relative = file_path.relative_to(media_root)
+        return relative.as_posix() if relative else ""
 
     def save_for_case(self, *, case_id: int, filename: str, content: bytes) -> str:
         return self.save_bytes(relative_dir=f"generated_documents/case_{case_id}", filename=filename, content=content)

--- a/backend/apps/documents/services/generation/output_storage.py
+++ b/backend/apps/documents/services/generation/output_storage.py
@@ -29,7 +29,7 @@ class GeneratedDocumentStorage:
         with file_path.open("wb") as f:
             f.write(content)
 
-        return str(file_path.relative_to(media_root))
+        return file_path.relative_to(media_root).as_posix()
 
     def save_for_case(self, *, case_id: int, filename: str, content: bytes) -> str:
         return self.save_bytes(relative_dir=f"generated_documents/case_{case_id}", filename=filename, content=content)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "26.50.11",
+  "version": "26.50.12",
   "packageManager": "pnpm@10.28.2",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

修复 Windows 下路径比较和存储失效的问题，涉及 12 处代码。

### 问题根源
Python 的 `pathlib.Path` 在 Windows 上 `str()` 返回反斜杠路径（如 `C:\Users\foo`），而项目中多处使用正斜杠进行路径比较和存储，导致功能静默失效。

### 修复内容

**P0 - 安全检查修复（2处）**
- `cases/admin/mixins/views.py`: `startswith(str(path) + "/")` 改用 `is_relative_to()`

**P0 - 数据库存储修复（5处）**
- `client_identity_doc_service.py`: `str(relative_path)` → `.as_posix()`
- `property_clue_service.py`: `str(saved_path)` → `.as_posix()`
- `court_sms_admin.py`: `_normalize_path_like` 返回 `.as_posix()`
- `court_sms_document_reference_service.py`: `_normalize_existing_path` 返回 `.as_posix()`
- `output_storage.py`: `str(relative_to())` → `.as_posix()`

**P1 - 路径比较修复（5处）**
- `contracts/folder_scan_service.py`: `os.path.commonpath` 添加 `.replace("\\", "/")`
- `court_document_admin_service.py`: `str(relative_to())` → `.as_posix()`
- 4处 ZIP 路径遍历检查改用 `is_relative_to()`

## Test plan

- [x] 本地 mypy 通过
- [x] 本地 ruff 通过
- [ ] 在 Windows 环境测试案件文件夹生成功能
- [ ] 在 Windows 环境测试证件文档上传和读取
