### PR TITLE
feat: 云存储抽象层全链路改造 + 依赖漏洞修复

### DIFF
--- a/backend/apps/cases/admin/mixins/views.py
+++ b/backend/apps/cases/admin/mixins/views.py
@@ -784,10 +784,12 @@ class CaseAdminViewsMixin:
                     for child in children:
                         if not child.is_dir or child.name.startswith("."):
                             continue
-                        subfolders.append({
-                            "relative_path": child.name,
-                            "display_name": child.name,
-                        })
+                        subfolders.append(
+                            {
+                                "relative_path": child.name,
+                                "display_name": child.name,
+                            }
+                        )
                     subfolders.sort(key=lambda x: x["display_name"].lower())
                     return JsonResponse({"success": True, "subfolders": subfolders})
 
@@ -798,13 +800,13 @@ class CaseAdminViewsMixin:
                     return JsonResponse({"success": False, "error": "文件夹不存在"}, status=404)
 
                 subfolders = []
-                for child in sorted(root.iterdir(), key=lambda item: item.name.lower()):
-                    if not child.is_dir() or child.name.startswith("."):
+                for local_child in sorted(root.iterdir(), key=lambda item: item.name.lower()):
+                    if not local_child.is_dir() or local_child.name.startswith("."):
                         continue
                     subfolders.append(
                         {
-                            "relative_path": child.name,
-                            "display_name": child.name,
+                            "relative_path": local_child.name,
+                            "display_name": local_child.name,
                         }
                     )
 

--- a/backend/apps/cases/admin/mixins/views.py
+++ b/backend/apps/cases/admin/mixins/views.py
@@ -769,6 +769,28 @@ class CaseAdminViewsMixin:
 
             if request.method == "GET":
                 # 列出第一层级所有子文件夹，让用户自己选
+                storage_type = getattr(binding, "storage_type", "local")
+
+                if storage_type != "local" and getattr(binding, "storage_account", None) is not None:
+                    from apps.core.cloud_storage.factory import create_provider_for_binding
+
+                    provider = create_provider_for_binding(binding)
+                    try:
+                        children = provider.list_directory(binding.resolved_folder_path)
+                    except Exception:
+                        return JsonResponse({"success": False, "error": "云存储访问失败"}, status=500)
+
+                    subfolders = []
+                    for child in children:
+                        if not child.is_dir or child.name.startswith("."):
+                            continue
+                        subfolders.append({
+                            "relative_path": child.name,
+                            "display_name": child.name,
+                        })
+                    subfolders.sort(key=lambda x: x["display_name"].lower())
+                    return JsonResponse({"success": True, "subfolders": subfolders})
+
                 from pathlib import Path
 
                 root = Path(binding.resolved_folder_path).expanduser().resolve()

--- a/backend/apps/cases/api/folder_binding_api.py
+++ b/backend/apps/cases/api/folder_binding_api.py
@@ -258,4 +258,4 @@ def list_cloud_storage_accounts(request: HttpRequest) -> list[dict[str, Any]]:
     service = _get_folder_binding_service()
     ctx = get_request_access_context(request)
     service.require_admin(ctx)
-    return list_active_cloud_accounts()  # type: ignore[return-value]
+    return list_active_cloud_accounts()

--- a/backend/apps/cases/api/folder_binding_api.py
+++ b/backend/apps/cases/api/folder_binding_api.py
@@ -178,61 +178,21 @@ def browse_folders(
 
     # ── Cloud storage browse ──
     if storage_type and storage_type != "local" and storage_account_id:
-        from apps.core.cloud_storage.factory import create_provider_from_account
-        from apps.core.cloud_storage.models import CloudStorageAccount as CSA
+        from apps.core.cloud_storage.browse_helper import browse_cloud_folder
 
-        account = CSA.objects.filter(id=storage_account_id, storage_type=storage_type, is_active=True).first()
-        if not account:
-            return FolderBrowseResponseSchema(
-                browsable=False,
-                message="云存储账号不存在",
-                path=path,
-                parent_path=None,
-                entries=[],
-                storage_type=storage_type,
-            )
-
-        provider = create_provider_from_account(account)
-        browse_path = (path or "").strip().rstrip("/") or "/"
-
-        try:
-            children = provider.list_directory(browse_path)
-        except Exception:
-            logger.exception("cloud_browse_failed", extra={"path": browse_path, "account_id": storage_account_id})
-            return FolderBrowseResponseSchema(
-                browsable=False,
-                message="云存储目录访问失败",
-                path=browse_path,
-                parent_path=None,
-                entries=[],
-                storage_type=storage_type,
-            )
-
-        entries = []
-        for child in children:
-            if not child.is_dir:
-                continue
-            if not include_hidden and child.name.startswith("."):
-                continue
-            child_path = browse_path.rstrip("/") + "/" + child.name
-            entries.append(FolderBrowseEntrySchema(name=child.name, path=child_path))
-        entries.sort(key=lambda e: e.name.lower())
-
-        parent_path: str | None = None
-        if browse_path != "/":
-            from pathlib import PurePosixPath
-
-            parent_path = str(PurePosixPath(browse_path).parent)
-            if parent_path == ".":
-                parent_path = "/"
-
-        return FolderBrowseResponseSchema(
-            browsable=True,
-            message=None,
-            path=browse_path,
-            parent_path=parent_path,
-            entries=entries,
+        result = browse_cloud_folder(
             storage_type=storage_type,
+            storage_account_id=storage_account_id,
+            path=path,
+            include_hidden=include_hidden,
+        )
+        return FolderBrowseResponseSchema(
+            browsable=result["browsable"],
+            message=result["message"],
+            path=result["path"],
+            parent_path=result["parent_path"],
+            entries=[FolderBrowseEntrySchema(**e) for e in result["entries"]],
+            storage_type=result["storage_type"],
         )
 
     # ── Local filesystem browse (existing logic) ──
@@ -293,12 +253,9 @@ def browse_folders(
 @router.get("/cloud-storage-accounts")
 def list_cloud_storage_accounts(request: HttpRequest) -> list[dict[str, Any]]:
     """List available cloud storage accounts for folder binding."""
-    from apps.core.cloud_storage.models import CloudStorageAccount as CSA
+    from apps.core.cloud_storage.browse_helper import list_active_cloud_accounts
 
     service = _get_folder_binding_service()
     ctx = get_request_access_context(request)
     service.require_admin(ctx)
-    accounts = CSA.objects.filter(is_active=True).values(
-        "id", "name", "storage_type", "local_root_path", "webdav_root_path", "onedrive_root_path"
-    )
-    return list(accounts)  # type: ignore[arg-type]
+    return list_active_cloud_accounts()  # type: ignore[return-value]

--- a/backend/apps/cases/services/log/email_folder_scan_service.py
+++ b/backend/apps/cases/services/log/email_folder_scan_service.py
@@ -216,9 +216,13 @@ class EmailFolderScanService:
 
     def _collect_subdirs_cloud(self, folder_path: str, provider: Any) -> list[tuple[str, list[str]]]:
         """云存储版本：收集子目录."""
+        from apps.core.cloud_storage.exceptions import CloudStorageError
+
         result: list[tuple[str, list[str]]] = []
         try:
             children = provider.list_directory(folder_path)
+        except CloudStorageError:
+            raise
         except Exception:
             return []
 
@@ -263,6 +267,8 @@ class EmailFolderScanService:
 
     def _collect_allowed_files_cloud(self, folder_path: str, provider: Any) -> list[str]:
         """云存储版本：递归收集合规文件."""
+        from apps.core.cloud_storage.exceptions import CloudStorageError
+
         result: list[str] = []
         try:
             for _dirpath, _subdirs, files in provider.walk(folder_path):
@@ -280,6 +286,8 @@ class EmailFolderScanService:
                         logger.warning("文件超过大小限制，跳过: %s", f.name)
                         continue
                     result.append(file_path)
+        except CloudStorageError:
+            raise
         except Exception:
             logger.exception("云存储文件收集失败: %s", folder_path)
         return sorted(result)

--- a/backend/apps/cases/services/log/email_folder_scan_service.py
+++ b/backend/apps/cases/services/log/email_folder_scan_service.py
@@ -74,7 +74,8 @@ class EmailFolderScanService:
 
         # 检查目标是否存在
         if is_cloud:
-            if not provider.exists(target):  # type: ignore[union-attr]
+            assert provider is not None
+            if not provider.exists(str(target)):
                 raise ValidationException("指定文件夹不存在", errors={"subfolder": "文件夹路径无效"})
         else:
             if not target.exists() or not target.is_dir():  # type: ignore[union-attr]
@@ -197,7 +198,7 @@ class EmailFolderScanService:
             )
         return target
 
-    def _collect_subdirs(self, folder_path: Path | str, provider: Any = None) -> list[tuple[Path | str, list[Path | str]]]:
+    def _collect_subdirs(self, folder_path: Path | str, provider: Any = None) -> list[tuple[Any, list[Any]]]:
         """收集文件夹下所有含合规文件的子目录."""
         if provider is not None:
             return self._collect_subdirs_cloud(str(folder_path), provider)
@@ -237,7 +238,7 @@ class EmailFolderScanService:
                 result.append((child_path, files))
         return result
 
-    def _collect_allowed_files(self, folder_path: Path | str, provider: Any = None) -> list[Path | str]:
+    def _collect_allowed_files(self, folder_path: Path | str, provider: Any = None) -> list[Any]:
         """递归收集文件夹内所有合规文件."""
         if provider is not None:
             return self._collect_allowed_files_cloud(str(folder_path), provider)
@@ -297,7 +298,9 @@ class EmailFolderScanService:
         content = re.sub(r"^\d{4}[.\-]\d{1,2}[.\-]\d{1,2}[\-\s]*", "", subdir_name)
         return content if content else subdir_name
 
-    def _upload_file_as_attachment(self, log: CaseLog, file_path: Path | str, provider: Any = None) -> CaseLogAttachment | None:
+    def _upload_file_as_attachment(
+        self, log: CaseLog, file_path: Path | str, provider: Any = None
+    ) -> CaseLogAttachment | None:
         """上传文件为日志附件（本地或云存储）."""
         try:
             if provider is not None:

--- a/backend/apps/cases/services/log/email_folder_scan_service.py
+++ b/backend/apps/cases/services/log/email_folder_scan_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -21,9 +21,10 @@ from .case_log_query_service import CaseLogQueryService
 if TYPE_CHECKING:
     from django.contrib.auth.models import AbstractBaseUser
 
+    from apps.core.cloud_storage.protocols import CloudStorageProvider
+
 logger = logging.getLogger("apps.cases")
 
-# 子文件夹名中的日期提取模式，如 "2026.04.16-收到判决书" → (2026, 4, 16)
 _DATE_PATTERN = re.compile(r"^(\d{4})[.\-](\d{1,2})[.\-](\d{1,2})")
 
 
@@ -63,49 +64,30 @@ class EmailFolderScanService:
         org_access: dict[str, Any] | None = None,
         perm_open_access: bool = False,
     ) -> dict[str, Any]:
-        """将指定子文件夹下每个子目录分别导入为独立案件日志 + 附件.
-
-        目录结构示例:
-          4-邮件往来/
-            2026.04.16-收到判决书/
-              判决书.pdf
-            2026.03.12-收到移送检察院通知/
-              通知.jpg
-
-        每个 "2026.04.16-收到判决书" 子目录生成一条日志，日志内容包含目录标题和文件清单，
-        附件为该子目录下的合规文件。如果子目录名以日期开头，日志的 created_at 会被设为该日期。
-
-        去重逻辑：通过 source_subfolder 字段记录来源，重复导入时跳过已存在的子目录。
-
-        Args:
-            case_id: 案件 ID
-            subfolder: 子文件夹相对路径（与 folder-scan/subfolders 返回的 relative_path 一致）
-            user: 当前用户
-            org_access: 组织访问策略
-            perm_open_access: 是否有开放访问权限
-
-        Returns:
-            {"logs": 创建的 CaseLog 列表, "skipped_count": 跳过的子目录数量}
-        """
-        case_root = self._get_bound_case_root(case_id)
+        """将指定子文件夹下每个子目录分别导入为独立案件日志 + 附件."""
+        case_root, provider = self._get_bound_case_root(case_id)
         if case_root is None:
             raise NotFoundError("案件未绑定可用文件夹")
 
-        target = self._resolve_subfolder(case_root, subfolder)
+        is_cloud = provider is not None
+        target = self._resolve_subfolder(case_root, subfolder, provider=provider)
 
-        if not target.exists() or not target.is_dir():
-            raise ValidationException("指定文件夹不存在", errors={"subfolder": "文件夹路径无效"})
+        # 检查目标是否存在
+        if is_cloud:
+            if not provider.exists(target):  # type: ignore[union-attr]
+                raise ValidationException("指定文件夹不存在", errors={"subfolder": "文件夹路径无效"})
+        else:
+            if not target.exists() or not target.is_dir():  # type: ignore[union-attr]
+                raise ValidationException("指定文件夹不存在", errors={"subfolder": "文件夹路径无效"})
 
-        # 收集子目录（每个子目录 = 一条日志）
-        subdirs = self._collect_subdirs(target)
+        # 收集子目录
+        subdirs = self._collect_subdirs(target, provider=provider)
         if not subdirs:
-            # 如果没有子目录，将整个文件夹作为一条日志
-            files = self._collect_allowed_files(target)
+            files = self._collect_allowed_files(target, provider=provider)
             if not files:
                 raise ValidationException("文件夹内没有可导入的文件", errors={"subfolder": "无合规文件"})
             subdirs = [(target, files)]
 
-        # 查询该案件已有的来源子文件夹，用于去重
         existing_sources: set[str] = set(
             CaseLog.objects.filter(case_id=case_id)
             .exclude(source_subfolder="")
@@ -117,14 +99,14 @@ class EmailFolderScanService:
 
         with transaction.atomic():
             for subdir, files in subdirs:
-                # 去重：来源标识 = "子文件夹路径/子目录名"
-                source_key = f"{subfolder}/{subdir.name}"
+                subdir_name = subdir.name if isinstance(subdir, Path) else PurePosixPath(subdir).name
+                source_key = f"{subfolder}/{subdir_name}"
                 if source_key in existing_sources:
                     skipped_count += 1
-                    logger.info(f"案件 {case_id} 跳过已导入子目录: {source_key}")
+                    logger.info("案件 %d 跳过已导入子目录: %s", case_id, source_key)
                     continue
 
-                content = self._build_log_content(subdir, files, target)
+                content = self._build_log_content(subdir_name)
 
                 log = self.mutation_service.create_log(
                     case_id=case_id,
@@ -134,29 +116,29 @@ class EmailFolderScanService:
                     perm_open_access=perm_open_access,
                 )
 
-                # 回写 source_subfolder 用于后续去重
                 log.source_subfolder = source_key
                 log.save(update_fields=["source_subfolder"])
 
-                # 如果子目录名以日期开头，回写 created_at
-                date_match = _DATE_PATTERN.match(subdir.name)
+                date_match = _DATE_PATTERN.match(subdir_name)
                 if date_match:
                     try:
                         year, month, day = int(date_match.group(1)), int(date_match.group(2)), int(date_match.group(3))
                         log.created_at = datetime(year, month, day, 12, 0, 0)
                         log.save(update_fields=["created_at"])
                     except ValueError:
-                        pass  # 日期无效则跳过，使用默认时间
+                        pass
 
-                # 逐个上传附件
                 for file_path in files:
-                    self._upload_file_as_attachment(log, file_path)
+                    self._upload_file_as_attachment(log, file_path, provider=provider)
 
                 created_logs.append(log)
                 existing_sources.add(source_key)
 
         logger.info(
-            f"案件 {case_id} 子文件夹导入完成: 目录={target.name}, 新增={len(created_logs)}, 跳过={skipped_count}"
+            "案件 %d 子文件夹导入完成: 新增=%d, 跳过=%d",
+            case_id,
+            len(created_logs),
+            skipped_count,
         )
         return {"logs": created_logs, "skipped_count": skipped_count}
 
@@ -164,20 +146,27 @@ class EmailFolderScanService:
     # 内部方法
     # ------------------------------------------------------------------
 
-    def _get_bound_case_root(self, case_id: int) -> Path | None:
-        """获取案件绑定的文件夹根路径."""
+    def _get_bound_case_root(self, case_id: int) -> tuple[Path | str | None, CloudStorageProvider | None]:
+        """获取案件绑定的文件夹根路径和可选的云存储 provider."""
         binding = CaseFolderBinding.objects.filter(case_id=case_id).first()
         if not binding or not binding.resolved_folder_path:
-            return None
+            return None, None
+
+        storage_type = getattr(binding, "storage_type", "local")
+        if storage_type != "local" and getattr(binding, "storage_account", None) is not None:
+            from apps.core.cloud_storage.factory import create_provider_for_binding
+
+            provider = create_provider_for_binding(binding)
+            return binding.resolved_folder_path, provider
 
         root = Path(binding.resolved_folder_path).expanduser().resolve()
         if not root.exists() or not root.is_dir():
-            logger.warning(f"案件 {case_id} 绑定目录不可访问: {root}")
-            return None
-        return root
+            logger.warning("案件 %d 绑定目录不可访问: %s", case_id, root)
+            return None, None
+        return root, None
 
-    def _resolve_subfolder(self, case_root: Path, subfolder: str) -> Path:
-        """将相对子文件夹路径解析为绝对路径，并校验安全性."""
+    def _resolve_subfolder(self, case_root: Path | str, subfolder: str, provider: Any = None) -> Path | str:
+        """将相对子文件夹路径解析为完整路径，并校验安全性."""
         raw = str(subfolder or "").strip().replace("\\", "/")
         if not raw:
             raise ValidationException("子文件夹路径不能为空", errors={"subfolder": raw})
@@ -193,7 +182,14 @@ class EmailFolderScanService:
         if any(p.startswith(".") for p in parts):
             raise ValidationException("子文件夹路径非法", errors={"subfolder": raw})
 
-        target = (case_root / "/".join(parts)).resolve()
+        joined = "/".join(parts)
+
+        if provider is not None:
+            root_str = str(case_root).rstrip("/")
+            return f"{root_str}/{joined}"
+
+        assert isinstance(case_root, Path)
+        target = (case_root / joined).resolve()
         if not target.is_relative_to(case_root):
             raise ValidationException(
                 "文件夹路径不在案件绑定目录内",
@@ -201,12 +197,12 @@ class EmailFolderScanService:
             )
         return target
 
-    def _collect_subdirs(self, folder_path: Path) -> list[tuple[Path, list[Path]]]:
-        """收集文件夹下所有含合规文件的子目录.
+    def _collect_subdirs(self, folder_path: Path | str, provider: Any = None) -> list[tuple[Path | str, list[Path | str]]]:
+        """收集文件夹下所有含合规文件的子目录."""
+        if provider is not None:
+            return self._collect_subdirs_cloud(str(folder_path), provider)
 
-        Returns:
-            [(子目录路径, [合规文件列表]), ...] 按目录名排序
-        """
+        assert isinstance(folder_path, Path)
         result: list[tuple[Path, list[Path]]] = []
         for child in sorted(folder_path.iterdir()):
             if not child.is_dir():
@@ -218,13 +214,35 @@ class EmailFolderScanService:
                 result.append((child, files))
         return result
 
-    def _collect_allowed_files(self, folder_path: Path) -> list[Path]:
-        """递归收集文件夹内所有合规文件（扩展名 + 大小校验），跳过隐藏文件/目录."""
+    def _collect_subdirs_cloud(self, folder_path: str, provider: Any) -> list[tuple[str, list[str]]]:
+        """云存储版本：收集子目录."""
+        result: list[tuple[str, list[str]]] = []
+        try:
+            children = provider.list_directory(folder_path)
+        except Exception:
+            return []
+
+        for child in sorted(children, key=lambda c: c.name.lower()):
+            if not child.is_dir:
+                continue
+            if child.name.startswith("."):
+                continue
+            child_path = f"{folder_path.rstrip('/')}/{child.name}"
+            files = self._collect_allowed_files(child_path, provider=provider)
+            if files:
+                result.append((child_path, files))
+        return result
+
+    def _collect_allowed_files(self, folder_path: Path | str, provider: Any = None) -> list[Path | str]:
+        """递归收集文件夹内所有合规文件."""
+        if provider is not None:
+            return self._collect_allowed_files_cloud(str(folder_path), provider)
+
+        assert isinstance(folder_path, Path)
         result: list[Path] = []
         for f in sorted(folder_path.rglob("*")):
             if not f.is_file():
                 continue
-            # 跳过隐藏文件和隐藏目录下的文件
             try:
                 rel_parts = f.relative_to(folder_path).parts
             except ValueError:
@@ -235,38 +253,58 @@ class EmailFolderScanService:
                 continue
             try:
                 if CASE_LOG_MAX_FILE_SIZE > 0 and f.stat().st_size > CASE_LOG_MAX_FILE_SIZE:
-                    logger.warning(f"文件超过大小限制，跳过: {f.name}")
+                    logger.warning("文件超过大小限制，跳过: %s", f.name)
                     continue
             except OSError:
-                logger.warning(f"文件无法访问，跳过: {f.name}")
+                logger.warning("文件无法访问，跳过: %s", f.name)
                 continue
             result.append(f)
         return result
 
-    def _build_log_content(self, subdir: Path, files: list[Path], root: Path) -> str:
-        """构建日志内容，只保留文件夹名中日期之后的描述部分.
-
-        例如 "2026.03.02-收到鉴定意见通知书等当事人传回材料" → "收到鉴定意见通知书等当事人传回材料"
-        如果文件夹名没有日期前缀，则直接使用文件夹名。
-        """
-        name = subdir.name
-        # 尝试去掉日期前缀，如 "2026.03.02-" 或 "2026-03-02-"
-        content = re.sub(r"^\d{4}[.\-]\d{1,2}[.\-]\d{1,2}[\-\s]*", "", name)
-        return content if content else name
-
-    def _upload_file_as_attachment(self, log: CaseLog, file_path: Path) -> CaseLogAttachment | None:
-        """将本地文件上传为日志附件."""
+    def _collect_allowed_files_cloud(self, folder_path: str, provider: Any) -> list[str]:
+        """云存储版本：递归收集合规文件."""
+        result: list[str] = []
         try:
-            with open(file_path, "rb") as f:
-                file_content = f.read()
+            for _dirpath, _subdirs, files in provider.walk(folder_path):
+                for f in files:
+                    if f.is_dir:
+                        continue
+                    # 构建完整路径（兼容 WebDAV 和 OneDrive 的不同 path 格式）
+                    file_path = f"{folder_path.rstrip('/')}/{f.name}"
+                    rel = PurePosixPath(file_path)
+                    if any(part.startswith(".") for part in rel.parts):
+                        continue
+                    if PurePosixPath(f.name).suffix.lower() not in CASE_LOG_ALLOWED_EXTENSIONS:
+                        continue
+                    if CASE_LOG_MAX_FILE_SIZE > 0 and f.size > CASE_LOG_MAX_FILE_SIZE:
+                        logger.warning("文件超过大小限制，跳过: %s", f.name)
+                        continue
+                    result.append(file_path)
+        except Exception:
+            logger.exception("云存储文件收集失败: %s", folder_path)
+        return sorted(result)
 
-            uploaded_file = SimpleUploadedFile(
-                name=file_path.name,
-                content=file_content,
-            )
+    def _build_log_content(self, subdir_name: str) -> str:
+        """构建日志内容，只保留文件夹名中日期之后的描述部分."""
+        content = re.sub(r"^\d{4}[.\-]\d{1,2}[.\-]\d{1,2}[\-\s]*", "", subdir_name)
+        return content if content else subdir_name
+
+    def _upload_file_as_attachment(self, log: CaseLog, file_path: Path | str, provider: Any = None) -> CaseLogAttachment | None:
+        """上传文件为日志附件（本地或云存储）."""
+        try:
+            if provider is not None:
+                file_content = provider.read_file(str(file_path))
+                file_name = PurePosixPath(str(file_path)).name
+            else:
+                assert isinstance(file_path, Path)
+                with open(file_path, "rb") as f:
+                    file_content = f.read()
+                file_name = file_path.name
+
+            uploaded_file = SimpleUploadedFile(name=file_name, content=file_content)
             attachment = CaseLogAttachment.objects.create(log=log, file=uploaded_file)
-            logger.info(f"附件上传成功: {file_path.name} -> 日志 {log.id}")
+            logger.info("附件上传成功: %s -> 日志 %d", file_name, log.id)
             return attachment
         except Exception:
-            logger.exception(f"附件上传失败: {file_path.name}")
+            logger.exception("附件上传失败: %s", file_path)
             return None

--- a/backend/apps/cases/services/material/folder_scan_service.py
+++ b/backend/apps/cases/services/material/folder_scan_service.py
@@ -217,6 +217,19 @@ class CaseFolderScanService:
         candidates = payload.get("candidates") or []
         candidate_map = {str(item.get("source_path") or ""): item for item in candidates}
 
+        # 解析云存储 provider
+        storage_provider = None
+        try:
+            from apps.cases.models.material import CaseFolderBinding
+
+            binding = CaseFolderBinding.objects.filter(case_id=case_id).first()
+            if binding and getattr(binding, "storage_type", "local") != "local":
+                from apps.core.cloud_storage.factory import create_provider_for_binding
+
+                storage_provider = create_provider_for_binding(binding)
+        except Exception:
+            pass
+
         selected_items = [item for item in items if bool(item.get("selected", True))]
         if not selected_items:
             raise ValidationException(message="未找到可导入的 PDF")
@@ -237,14 +250,22 @@ class CaseFolderScanService:
             if not source_path or source_path not in candidate_map:
                 raise ValidationException(message="候选文件不存在", errors={"source_path": source_path})
 
-            file_path = Path(source_path)
-            if not file_path.exists() or not file_path.is_file():
-                raise ValidationException(message="源文件不存在", errors={"source_path": source_path})
+            if storage_provider is not None:
+                from pathlib import PurePosixPath
+
+                file_bytes = storage_provider.read_file(source_path)
+                file_name = PurePosixPath(source_path).name
+            else:
+                file_path = Path(source_path)
+                if not file_path.exists() or not file_path.is_file():
+                    raise ValidationException(message="源文件不存在", errors={"source_path": source_path})
+                file_bytes = file_path.read_bytes()
+                file_name = file_path.name
 
             uploads.append(
                 SimpleUploadedFile(
-                    name=file_path.name,
-                    content=file_path.read_bytes(),
+                    name=file_name,
+                    content=file_bytes,
                     content_type="application/pdf",
                 )
             )

--- a/backend/apps/cases/services/material/folder_scan_service.py
+++ b/backend/apps/cases/services/material/folder_scan_service.py
@@ -253,7 +253,17 @@ class CaseFolderScanService:
             if storage_provider is not None:
                 from pathlib import PurePosixPath
 
-                file_bytes = storage_provider.read_file(source_path)
+                from apps.core.cloud_storage.exceptions import CloudStorageError
+
+                try:
+                    file_bytes = storage_provider.read_file(source_path)
+                except CloudStorageError:
+                    raise
+                except Exception as e:
+                    raise CloudStorageError(
+                        f"读取云存储文件失败: {source_path}",
+                        provider="云存储",
+                    ) from e
                 file_name = PurePosixPath(source_path).name
             else:
                 file_path = Path(source_path)
@@ -402,10 +412,16 @@ class CaseFolderScanService:
                 updated_at=timezone.now(),
             )
         except Exception as exc:
+            from apps.core.cloud_storage.exceptions import CloudStorageError
+
+            if isinstance(exc, CloudStorageError):
+                error_msg = str(exc)
+            else:
+                error_msg = f"扫描失败: {type(exc).__name__}"
             logger.exception("case_folder_scan_failed", extra={"session_id": session_id})
             CaseFolderScanSession.objects.filter(id=session.id).update(
                 status=CaseFolderScanStatus.FAILED,
-                error_message=str(exc),
+                error_message=error_msg,
                 updated_at=timezone.now(),
             )
 

--- a/backend/apps/contracts/api/folder_binding_api.py
+++ b/backend/apps/contracts/api/folder_binding_api.py
@@ -278,4 +278,4 @@ def list_cloud_storage_accounts(request: HttpRequest) -> list[dict[str, Any]]:
     _require_admin(request)
     from apps.core.cloud_storage.browse_helper import list_active_cloud_accounts
 
-    return list_active_cloud_accounts()  # type: ignore[return-value]
+    return list_active_cloud_accounts()

--- a/backend/apps/contracts/api/folder_binding_api.py
+++ b/backend/apps/contracts/api/folder_binding_api.py
@@ -14,7 +14,6 @@ from apps.contracts.schemas import (
     FolderBrowseEntrySchema,
     FolderBrowseResponseSchema,
 )
-from apps.core.cloud_storage.models import CloudStorageAccount
 from apps.core.exceptions import PermissionDenied
 from apps.core.security import get_request_access_context
 
@@ -197,62 +196,21 @@ def browse_folders(
 
     # ── Cloud storage browse ──
     if storage_type and storage_type != "local" and storage_account_id:
-        from apps.core.cloud_storage.factory import create_provider_from_account
+        from apps.core.cloud_storage.browse_helper import browse_cloud_folder
 
-        account = CloudStorageAccount.objects.filter(
-            id=storage_account_id, storage_type=storage_type, is_active=True
-        ).first()
-        if not account:
-            return FolderBrowseResponseSchema(
-                browsable=False,
-                message="云存储账号不存在",
-                path=path,
-                parent_path=None,
-                entries=[],
-                storage_type=storage_type,
-            )
-
-        provider = create_provider_from_account(account)
-        browse_path = (path or "").strip().rstrip("/") or "/"
-
-        try:
-            children = provider.list_directory(browse_path)
-        except Exception:
-            logger.exception("cloud_browse_failed", extra={"path": browse_path, "account_id": storage_account_id})
-            return FolderBrowseResponseSchema(
-                browsable=False,
-                message="云存储目录访问失败",
-                path=browse_path,
-                parent_path=None,
-                entries=[],
-                storage_type=storage_type,
-            )
-
-        entries = []
-        for child in children:
-            if not child.is_dir:
-                continue
-            if not include_hidden and child.name.startswith("."):
-                continue
-            child_path = browse_path.rstrip("/") + "/" + child.name
-            entries.append(FolderBrowseEntrySchema(name=child.name, path=child_path))
-        entries.sort(key=lambda e: e.name.lower())
-
-        parent_path: str | None = None
-        if browse_path != "/":
-            from pathlib import PurePosixPath
-
-            parent_path = str(PurePosixPath(browse_path).parent)
-            if parent_path == ".":
-                parent_path = "/"
-
-        return FolderBrowseResponseSchema(
-            browsable=True,
-            message=None,
-            path=browse_path,
-            parent_path=parent_path,
-            entries=entries,
+        result = browse_cloud_folder(
             storage_type=storage_type,
+            storage_account_id=storage_account_id,
+            path=path,
+            include_hidden=include_hidden,
+        )
+        return FolderBrowseResponseSchema(
+            browsable=result["browsable"],
+            message=result["message"],
+            path=result["path"],
+            parent_path=result["parent_path"],
+            entries=[FolderBrowseEntrySchema(**e) for e in result["entries"]],
+            storage_type=result["storage_type"],
         )
 
     # ── Local filesystem browse (existing logic) ──
@@ -318,7 +276,6 @@ def browse_folders(
 def list_cloud_storage_accounts(request: HttpRequest) -> list[dict[str, Any]]:
     """List available cloud storage accounts for folder binding."""
     _require_admin(request)
-    accounts = CloudStorageAccount.objects.filter(is_active=True).values(
-        "id", "name", "storage_type", "local_root_path", "webdav_root_path", "onedrive_root_path"
-    )
-    return list(accounts)  # type: ignore[arg-type]
+    from apps.core.cloud_storage.browse_helper import list_active_cloud_accounts
+
+    return list_active_cloud_accounts()  # type: ignore[return-value]

--- a/backend/apps/contracts/api/folder_scan_api.py
+++ b/backend/apps/contracts/api/folder_scan_api.py
@@ -99,9 +99,21 @@ def confirm_contract_scan(
 ) -> dict[str, object]:
     _require_contract_access(request, contract_id)
 
-    return _get_service().confirm_import(
+    service = _get_service()
+
+    # 解析云存储 provider（从 session → contract → binding 链路）
+    storage_provider = None
+    session = service.get_session(contract_id=contract_id, session_id=session_id)
+    try:
+        binding = session.contract.folder_binding
+        storage_provider = service._make_provider_for_binding(binding)
+    except Exception:
+        pass
+
+    return service.confirm_import(
         contract_id=contract_id,
         session_id=session_id,
         items=[item.model_dump() for item in payload.items],
         work_log_suggestions=[item.model_dump() for item in payload.work_log_suggestions],
+        storage_provider=storage_provider,
     )

--- a/backend/apps/contracts/services/archive/generation/folder_builder.py
+++ b/backend/apps/contracts/services/archive/generation/folder_builder.py
@@ -34,7 +34,12 @@ def generate_archive_folder(contract: Contract) -> dict[str, Any]:
     3. 将1-3号模板文书写入（仅 docx）
     4. 将剩余材料项合并为"4-案卷材料.pdf"（带页码）
     5. 将1-3号docx转PDF，与4号合并为"5-Final案卷材料.pdf"（无页码）
+
+    云存储模式：先在本地临时目录完成所有操作，最后上传到云存储。
     """
+    import shutil
+    import tempfile
+
     from apps.contracts.models.folder_binding import ContractFolderBinding
 
     try:
@@ -45,14 +50,58 @@ def generate_archive_folder(contract: Contract) -> dict[str, Any]:
     if not binding or not binding.folder_path:
         return {"success": False, "error": "合同未绑定文件夹"}
 
-    folder_path = Path(binding.folder_path)
-    if not folder_path.exists():
-        return {"success": False, "error": f"绑定文件夹不存在: {binding.folder_path}"}
+    # 判断是否为云存储
+    storage_type = getattr(binding, "storage_type", "local")
+    is_cloud = storage_type != "local"
+
+    if is_cloud:
+        from apps.core.cloud_storage.factory import create_provider_for_binding
+
+        provider = create_provider_for_binding(binding)
+        cloud_archive_path = f"{binding.folder_path.rstrip('/')}/{ARCHIVE_FOLDER_NAME}"
+        # 用临时目录代替本地路径
+        temp_dir = tempfile.mkdtemp(prefix="archive_")
+        archive_dir = Path(temp_dir) / ARCHIVE_FOLDER_NAME
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        local_work_dir = Path(temp_dir)
+    else:
+        provider = None
+        cloud_archive_path = ""
+        temp_dir = None
+        folder_path = Path(binding.folder_path)
+        if not folder_path.exists():
+            return {"success": False, "error": f"绑定文件夹不存在: {binding.folder_path}"}
+        archive_dir = folder_path / ARCHIVE_FOLDER_NAME
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        local_work_dir = folder_path
+
+    try:
+        return _generate_archive_folder_inner(
+            contract=contract,
+            archive_dir=archive_dir,
+            local_work_dir=local_work_dir,
+            provider=provider,
+            cloud_archive_path=cloud_archive_path,
+            is_cloud=is_cloud,
+        )
+    finally:
+        # 云存储模式：清理临时目录
+        if temp_dir and Path(temp_dir).exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _generate_archive_folder_inner(
+    contract: Contract,
+    archive_dir: Path,
+    local_work_dir: Path,
+    provider: Any,
+    cloud_archive_path: str,
+    is_cloud: bool,
+) -> dict[str, Any]:
+    """归档文件夹生成的核心逻辑（本地和云存储共用）。"""
 
     # 生成模板文书到 DB
     doc_results = generate_archive_documents(contract)
-
-    # 重新生成案卷目录以确保内容完整
     archive_category = get_archive_category(contract.case_type)
     catalog_code = _ARCHIVE_CATALOG_CODES.get(archive_category)
     if catalog_code:
@@ -61,10 +110,6 @@ def generate_archive_folder(contract: Contract) -> dict[str, Any]:
             if r.get("template_subtype") == "inner_catalog":
                 doc_results[i] = catalog_result
                 break
-
-    # 创建归档文件夹
-    archive_dir = folder_path / ARCHIVE_FOLDER_NAME
-    archive_dir.mkdir(parents=True, exist_ok=True)
 
     from datetime import date
 
@@ -135,12 +180,30 @@ def generate_archive_folder(contract: Contract) -> dict[str, Any]:
         extra={"contract_id": contract.id, "archive_dir": str(archive_dir)},
     )
 
+    # 云存储：将临时目录中的文件上传到云存储
+    if is_cloud and provider and generated_docs:
+        try:
+            provider.mkdir(cloud_archive_path)
+            for f in archive_dir.iterdir():
+                if f.is_file():
+                    cloud_file_path = f"{cloud_archive_path.rstrip('/')}/{f.name}"
+                    provider.write_file(cloud_file_path, f.read_bytes())
+            logger.info(
+                "归档文件夹已上传到云存储: %s, %d 个文件",
+                cloud_archive_path,
+                len(list(archive_dir.iterdir())),
+                extra={"contract_id": contract.id, "cloud_archive_path": cloud_archive_path},
+            )
+        except Exception as e:
+            errors.append(f"上传到云存储失败: {e}")
+            logger.exception("archive_cloud_upload_failed", extra={"contract_id": contract.id})
+
     return {
         "success": True,
-        "archive_dir": str(archive_dir),
+        "archive_dir": cloud_archive_path if is_cloud else str(archive_dir),
         "generated_docs": generated_docs,
         "errors": errors,
-        "folder_path": str(folder_path),
+        "folder_path": str(local_work_dir),
         "doc_results": doc_results,
     }
 

--- a/backend/apps/contracts/services/contract/integrations/archive_classifier.py
+++ b/backend/apps/contracts/services/contract/integrations/archive_classifier.py
@@ -367,16 +367,24 @@ def parse_work_log_from_folder_name(
     return {"date": date_str, "content": content}
 
 
-def collect_work_log_suggestions(scan_folder: str, archive_category: str) -> list[dict[str, str]]:
+def collect_work_log_suggestions(
+    scan_folder: str,
+    archive_category: str,
+    storage_provider: Any | None = None,
+) -> list[dict[str, str]]:
     """扫描目录下所有日期前缀子目录，返回工作日志建议列表。
 
     Args:
         scan_folder: 扫描根目录路径
         archive_category: 归档分类
+        storage_provider: 云存储 provider（可选）
 
     Returns:
         工作日志建议列表，按日期排序
     """
+    if storage_provider is not None:
+        return _collect_work_log_suggestions_cloud(scan_folder, archive_category, storage_provider)
+
     root = Path(scan_folder).expanduser().resolve()
     if not root.exists() or not root.is_dir():
         return []
@@ -390,6 +398,29 @@ def collect_work_log_suggestions(scan_folder: str, archive_category: str) -> lis
             suggestions.append(result)
 
     # 按日期排序
+    suggestions.sort(key=lambda x: x["date"])
+    return suggestions
+
+
+def _collect_work_log_suggestions_cloud(
+    scan_folder: str,
+    archive_category: str,
+    storage_provider: Any,
+) -> list[dict[str, str]]:
+    """云存储版本：遍历一层子目录收集工作日志建议。"""
+    suggestions: list[dict[str, str]] = []
+    try:
+        children = storage_provider.list_directory(scan_folder)
+    except Exception:
+        return []
+
+    for child in children:
+        if not child.is_dir:
+            continue
+        result = parse_work_log_from_folder_name(child.name, archive_category)
+        if result:
+            suggestions.append(result)
+
     suggestions.sort(key=lambda x: x["date"])
     return suggestions
 

--- a/backend/apps/contracts/services/contract/integrations/file_hash_utils.py
+++ b/backend/apps/contracts/services/contract/integrations/file_hash_utils.py
@@ -20,3 +20,12 @@ def compute_file_hash(file_path: Path) -> str:
     except (OSError, ValueError):
         logger.exception("compute_file_hash_failed", extra={"path": file_path.as_posix()})
         return ""
+
+
+def compute_file_hash_from_bytes(data: bytes) -> str:
+    """计算 bytes 内容的 SHA-256 哈希值。用于云存储场景。"""
+    try:
+        return hashlib.sha256(data).hexdigest()
+    except (ValueError, TypeError):
+        logger.exception("compute_file_hash_from_bytes_failed")
+        return ""

--- a/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
+++ b/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
@@ -256,7 +256,17 @@ class ContractFolderScanService:
             if storage_provider is not None:
                 from pathlib import PurePosixPath
 
-                file_bytes = storage_provider.read_file(source_path)
+                from apps.core.cloud_storage.exceptions import CloudStorageError
+
+                try:
+                    file_bytes = storage_provider.read_file(source_path)
+                except CloudStorageError:
+                    raise
+                except Exception as e:
+                    raise CloudStorageError(
+                        f"读取云存储文件失败: {source_path}",
+                        provider="云存储",
+                    ) from e
                 file_name = PurePosixPath(source_path).name
             else:
                 file_path = Path(source_path)
@@ -482,10 +492,16 @@ class ContractFolderScanService:
                 updated_at=timezone.now(),
             )
         except Exception as exc:
+            from apps.core.cloud_storage.exceptions import CloudStorageError
+
+            if isinstance(exc, CloudStorageError):
+                error_msg = str(exc)
+            else:
+                error_msg = f"扫描失败: {type(exc).__name__}"
             logger.exception("contract_folder_scan_failed", extra={"session_id": session_id})
             ContractFolderScanSession.objects.filter(id=session.id).update(
                 status=ContractFolderScanStatus.FAILED,
-                error_message=str(exc),
+                error_message=error_msg,
                 updated_at=timezone.now(),
             )
 

--- a/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
+++ b/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
@@ -286,7 +286,9 @@ class ContractFolderScanService:
             try:
                 if temp_pdf_path is not None:
                     upload_content = temp_pdf_path.read_bytes()
-                    upload_name = str(PurePosixPath(file_name).stem) + ".pdf" if storage_provider else temp_pdf_path.name
+                    upload_name = (
+                        str(PurePosixPath(file_name).stem) + ".pdf" if storage_provider else temp_pdf_path.name
+                    )
                 else:
                     upload_content = file_bytes
                     upload_name = file_name
@@ -705,7 +707,7 @@ class ContractFolderScanService:
         if storage_provider is not None:
             from pathlib import PurePosixPath
 
-            scan_root_posix = PurePosixPath(scan_folder)
+            scan_root_posix: PurePosixPath | None = PurePosixPath(scan_folder)
         else:
             scan_root_posix = None
             scan_root = Path(scan_folder).expanduser().resolve()
@@ -790,6 +792,7 @@ class ContractFolderScanService:
                     try:
                         from pathlib import PurePosixPath
 
+                        assert scan_root_posix is not None
                         rel_path = str(PurePosixPath(source).relative_to(scan_root_posix))
                     except ValueError:
                         rel_path = source
@@ -805,9 +808,7 @@ class ContractFolderScanService:
 
         # 仅非诉项目收集 docx 文件（修订版/批注版 → 转 PDF）
         if archive_category == "non_litigation":
-            docx_candidates = self._collect_docx_files(
-                scan_folder, archive_category, storage_provider=storage_provider
-            )
+            docx_candidates = self._collect_docx_files(scan_folder, archive_category, storage_provider=storage_provider)
             processed.extend(docx_candidates)
 
         # 标记已导入文件：计算文件哈希并比对已有材料
@@ -905,12 +906,14 @@ class ContractFolderScanService:
             for f in files:
                 if not f.is_dir and PurePosixPath(f.name).suffix.lower() in (".docx", ".doc"):
                     if any(kw in _normalize_docx_name(f.name) for kw in revision_keywords):
-                        all_files.append({
-                            "name": f.name,
-                            "path": f.path,
-                            "size": f.size,
-                            "modified_at": f.modified_at,
-                        })
+                        all_files.append(
+                            {
+                                "name": f.name,
+                                "path": f.path,
+                                "size": f.size,
+                                "modified_at": f.modified_at,
+                            }
+                        )
 
         if not all_files:
             return []
@@ -946,23 +949,25 @@ class ContractFolderScanService:
                 archive_item_name = "案件其它关联材料"
                 reason = "常法docx（修订版/批注版）→ nl_9"
 
-            candidates.append({
-                "source_path": item["path"],
-                "filename": item["name"],
-                "file_size": item["size"],
-                "modified_at": "",
-                "base_name": normalized_name,
-                "version_token": "",
-                "extract_method": "none",
-                "text_excerpt": "",
-                "suggested_category": "case_material",
-                "confidence": 0.85,
-                "reason": reason,
-                "selected": True,
-                "is_docx": True,
-                "archive_item_code": archive_item_code,
-                "archive_item_name": archive_item_name,
-            })
+            candidates.append(
+                {
+                    "source_path": item["path"],
+                    "filename": item["name"],
+                    "file_size": item["size"],
+                    "modified_at": "",
+                    "base_name": normalized_name,
+                    "version_token": "",
+                    "extract_method": "none",
+                    "text_excerpt": "",
+                    "suggested_category": "case_material",
+                    "confidence": 0.85,
+                    "reason": reason,
+                    "selected": True,
+                    "is_docx": True,
+                    "archive_item_code": archive_item_code,
+                    "archive_item_name": archive_item_name,
+                }
+            )
 
         return candidates
 

--- a/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
+++ b/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
@@ -31,7 +31,7 @@ from apps.core.dependencies.core import build_task_submission_service
 from apps.core.exceptions import NotFoundError, ValidationException
 from apps.core.services.bound_folder_scan_service import BoundFolderScanService
 
-from .file_hash_utils import compute_file_hash
+from .file_hash_utils import compute_file_hash, compute_file_hash_from_bytes
 from .material_service import MaterialService
 from .quality_card_detector import has_quality_card_on_last_page
 
@@ -216,6 +216,7 @@ class ContractFolderScanService:
         session_id: UUID,
         items: list[dict[str, Any]],
         work_log_suggestions: list[dict[str, str]] | None = None,
+        storage_provider: Any | None = None,
     ) -> dict[str, Any]:
         session = self.get_session(contract_id=contract_id, session_id=session_id)
         if session.status == ContractFolderScanStatus.IMPORTED:
@@ -251,38 +252,62 @@ class ContractFolderScanService:
             is_docx = bool(item.get("is_docx", False))
             archive_item_code = str(item.get("archive_item_code") or "").strip()
 
-            file_path = Path(source_path)
-            if not file_path.exists() or not file_path.is_file():
-                raise ValidationException(message="源文件不存在", errors={"source_path": source_path})
+            # ── 读取文件内容（云存储 vs 本地）──
+            if storage_provider is not None:
+                from pathlib import PurePosixPath
+
+                file_bytes = storage_provider.read_file(source_path)
+                file_name = PurePosixPath(source_path).name
+            else:
+                file_path = Path(source_path)
+                if not file_path.exists() or not file_path.is_file():
+                    raise ValidationException(message="源文件不存在", errors={"source_path": source_path})
+                file_bytes = file_path.read_bytes()
+                file_name = file_path.name
 
             # docx → PDF 转换
-            actual_file_path = file_path
             temp_pdf_path: Path | None = None
             if is_docx:
-                temp_pdf_path = self._convert_docx_to_temp_pdf(file_path)
+                temp_pdf_path = self._convert_docx_to_temp_pdf_from_bytes(file_bytes, file_name)
                 if temp_pdf_path is None:
                     logger.warning("docx_convert_failed_skip", extra={"source_path": source_path})
                     continue
-                actual_file_path = temp_pdf_path
 
             try:
+                if temp_pdf_path is not None:
+                    upload_content = temp_pdf_path.read_bytes()
+                    upload_name = str(PurePosixPath(file_name).stem) + ".pdf" if storage_provider else temp_pdf_path.name
+                else:
+                    upload_content = file_bytes
+                    upload_name = file_name
+
                 upload = SimpleUploadedFile(
-                    name=actual_file_path.name,
-                    content=actual_file_path.read_bytes(),
+                    name=upload_name,
+                    content=upload_content,
                     content_type="application/pdf",
                 )
                 rel_path, original_name = self._material_service.save_material_file(upload, contract_id)
                 display_name = original_name
                 # 如果原始文件是 docx，显示名保留原 docx 文件名
                 if is_docx:
-                    display_name = file_path.name
+                    display_name = file_name
 
-                if (
-                    category == MaterialCategory.CONTRACT_ORIGINAL
-                    and not is_docx
-                    and has_quality_card_on_last_page(file_path)
-                ):
-                    display_name = self._QUALITY_CARD_TITLE
+                # 质量监督卡检测（需要读取 PDF 内容）
+                if category == MaterialCategory.CONTRACT_ORIGINAL and not is_docx:
+                    if storage_provider is not None:
+                        import tempfile
+
+                        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+                            tmp.write(file_bytes)
+                            tmp_path = Path(tmp.name)
+                        try:
+                            quality_card = has_quality_card_on_last_page(tmp_path)
+                        finally:
+                            tmp_path.unlink(missing_ok=True)
+                    else:
+                        quality_card = has_quality_card_on_last_page(Path(source_path))
+                    if quality_card:
+                        display_name = self._QUALITY_CARD_TITLE
 
                 material_kwargs: dict[str, Any] = {
                     "contract_id": contract_id,
@@ -296,7 +321,10 @@ class ContractFolderScanService:
                 # 计算文件内容哈希
                 # 注意：docx 文件存入 DB 的哈希是原始 docx 的哈希（而非转换后 PDF），
                 # 这样扫描时也能用同一哈希值比对已导入状态
-                content_hash = compute_file_hash(file_path)
+                if is_docx:
+                    content_hash = compute_file_hash_from_bytes(file_bytes)
+                else:
+                    content_hash = compute_file_hash_from_bytes(file_bytes)
                 if content_hash:
                     material_kwargs["content_hash"] = content_hash
 
@@ -430,11 +458,14 @@ class ContractFolderScanService:
                 archive_category=archive_category,
                 scan_folder=scan_scope["scan_folder"],
                 contract_id=session.contract_id,
+                storage_provider=storage_provider,
             )
             result["candidates"] = candidates
 
             # 工作日志建议
-            work_log_suggestions = collect_work_log_suggestions(scan_scope["scan_folder"], archive_category)
+            work_log_suggestions = collect_work_log_suggestions(
+                scan_scope["scan_folder"], archive_category, storage_provider=storage_provider
+            )
             result["work_log_suggestions"] = work_log_suggestions
 
             # 归档清单项选项
@@ -651,10 +682,17 @@ class ContractFolderScanService:
         archive_category: str,
         scan_folder: str,
         contract_id: int = 0,
+        storage_provider: Any | None = None,
     ) -> list[dict[str, Any]]:
         """扫描后处理：归档清单项匹配 + docx 文件收集 + 跳过项过滤。"""
         processed: list[dict[str, Any]] = []
-        scan_root = Path(scan_folder).expanduser().resolve()
+        if storage_provider is not None:
+            from pathlib import PurePosixPath
+
+            scan_root_posix = PurePosixPath(scan_folder)
+        else:
+            scan_root_posix = None
+            scan_root = Path(scan_folder).expanduser().resolve()
 
         for candidate in candidates:
             suggested_category = str(candidate.get("suggested_category") or "")
@@ -730,10 +768,20 @@ class ContractFolderScanService:
 
             # 案件材料的 reason 统一替换为相对路径，方便用户定位文件
             if candidate.get("suggested_category") == "case_material":
-                rel_path = self._relative_path_str(
-                    source_path=str(candidate.get("source_path") or ""),
-                    scan_root=scan_root,
-                )
+                if storage_provider is not None:
+                    # 云存储：用 PurePosixPath 计算相对路径
+                    source = str(candidate.get("source_path") or "")
+                    try:
+                        from pathlib import PurePosixPath
+
+                        rel_path = str(PurePosixPath(source).relative_to(scan_root_posix))
+                    except ValueError:
+                        rel_path = source
+                else:
+                    rel_path = self._relative_path_str(
+                        source_path=str(candidate.get("source_path") or ""),
+                        scan_root=scan_root,
+                    )
                 if rel_path:
                     candidate["reason"] = rel_path
 
@@ -741,12 +789,14 @@ class ContractFolderScanService:
 
         # 仅非诉项目收集 docx 文件（修订版/批注版 → 转 PDF）
         if archive_category == "non_litigation":
-            docx_candidates = self._collect_docx_files(scan_folder, archive_category)
+            docx_candidates = self._collect_docx_files(
+                scan_folder, archive_category, storage_provider=storage_provider
+            )
             processed.extend(docx_candidates)
 
         # 标记已导入文件：计算文件哈希并比对已有材料
         if contract_id:
-            self._mark_already_imported(processed, contract_id=contract_id)
+            self._mark_already_imported(processed, contract_id=contract_id, storage_provider=storage_provider)
 
         return processed
 
@@ -754,6 +804,7 @@ class ContractFolderScanService:
         self,
         scan_folder: str,
         archive_category: str,
+        storage_provider: Any | None = None,
     ) -> list[dict[str, Any]]:
         """单独收集 docx/doc 文件，仅非诉项目且仅含修订版/批注版关键词。
 
@@ -762,12 +813,14 @@ class ContractFolderScanService:
         if archive_category != "non_litigation":
             return []
 
+        _DOCX_REVISION_KEYWORDS = ("修订版", "批注版", "律师修订")
+
+        if storage_provider is not None:
+            return self._collect_docx_files_cloud(scan_folder, storage_provider, _DOCX_REVISION_KEYWORDS)
+
         root = Path(scan_folder).expanduser().resolve()
         if not root.exists() or not root.is_dir():
             return []
-
-        # 仅收集文件名含"修订版"/"批注版"/"律师修订"关键词的 docx
-        _DOCX_REVISION_KEYWORDS = ("修订版", "批注版", "律师修订")
 
         docx_files = [
             p
@@ -822,8 +875,83 @@ class ContractFolderScanService:
 
         return candidates
 
+    def _collect_docx_files_cloud(
+        self,
+        scan_folder: str,
+        storage_provider: Any,
+        revision_keywords: tuple[str, ...],
+    ) -> list[dict[str, Any]]:
+        """云存储版本的 docx 文件收集。使用 provider.walk() 替代 Path.rglob()。"""
+        from pathlib import PurePosixPath
+
+        all_files: list[dict[str, Any]] = []
+        for _dirpath, _subdirs, files in storage_provider.walk(scan_folder):
+            for f in files:
+                if not f.is_dir and PurePosixPath(f.name).suffix.lower() in (".docx", ".doc"):
+                    if any(kw in _normalize_docx_name(f.name) for kw in revision_keywords):
+                        all_files.append({
+                            "name": f.name,
+                            "path": f.path,
+                            "size": f.size,
+                            "modified_at": f.modified_at,
+                        })
+
+        if not all_files:
+            return []
+
+        all_files.sort(key=lambda x: x["path"])
+
+        # 简单去重：按文件名分组，取每个组最新的一个
+        from collections import defaultdict
+
+        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for item in all_files:
+            stem = PurePosixPath(item["name"]).stem
+            grouped[stem].append(item)
+
+        deduped: list[dict[str, Any]] = []
+        for group_items in grouped.values():
+            group_items.sort(key=lambda x: (-x["modified_at"], x["path"]))
+            deduped.append(group_items[0])
+
+        candidates: list[dict[str, Any]] = []
+        for item in deduped:
+            archive_item_code = ""
+            archive_item_name = "未匹配"
+            reason = "常法docx（修订版/批注版）→ 转 PDF"
+            normalized_name = _normalize_docx_name(item["name"])
+
+            if "律师函" in normalized_name:
+                archive_item_code = "nl_8"
+                archive_item_name = "法律意见书、律师函等"
+                reason = "常法docx（律师函）→ nl_8"
+            else:
+                archive_item_code = "nl_9"
+                archive_item_name = "案件其它关联材料"
+                reason = "常法docx（修订版/批注版）→ nl_9"
+
+            candidates.append({
+                "source_path": item["path"],
+                "filename": item["name"],
+                "file_size": item["size"],
+                "modified_at": "",
+                "base_name": normalized_name,
+                "version_token": "",
+                "extract_method": "none",
+                "text_excerpt": "",
+                "suggested_category": "case_material",
+                "confidence": 0.85,
+                "reason": reason,
+                "selected": True,
+                "is_docx": True,
+                "archive_item_code": archive_item_code,
+                "archive_item_name": archive_item_name,
+            })
+
+        return candidates
+
     def _convert_docx_to_temp_pdf(self, file_path: Path) -> Path | None:
-        """将 docx 文件转换为临时 PDF 文件。返回临时 PDF 路径，失败返回 None。"""
+        """将本地 docx 文件转换为临时 PDF 文件。返回临时 PDF 路径，失败返回 None。"""
         try:
             from apps.documents.services.infrastructure.pdf_merge_utils import convert_docx_to_pdf
 
@@ -833,6 +961,27 @@ class ContractFolderScanService:
             return None
         except (OSError, RuntimeError):
             logger.exception("docx_to_pdf_conversion_failed", extra={"path": file_path.as_posix()})
+            return None
+
+    def _convert_docx_to_temp_pdf_from_bytes(self, file_bytes: bytes, filename: str) -> Path | None:
+        """将 docx bytes 转换为临时 PDF 文件（用于云存储场景）。"""
+        import tempfile
+
+        try:
+            from apps.documents.services.infrastructure.pdf_merge_utils import convert_docx_to_pdf
+
+            with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
+                tmp.write(file_bytes)
+                docx_path = tmp.name
+            try:
+                pdf_path_str = convert_docx_to_pdf(docx_path)
+                if pdf_path_str:
+                    return Path(pdf_path_str)
+                return None
+            finally:
+                Path(docx_path).unlink(missing_ok=True)
+        except (OSError, RuntimeError):
+            logger.exception("docx_to_pdf_conversion_from_bytes_failed", extra={"filename": filename})
             return None
 
     def _learn_from_import_correction(
@@ -906,6 +1055,7 @@ class ContractFolderScanService:
         candidates: list[dict[str, Any]],
         *,
         contract_id: int,
+        storage_provider: Any | None = None,
     ) -> None:
         """标记已导入文件：计算文件哈希，与已有材料比对。"""
         existing_hashes: set[str] = set(
@@ -930,11 +1080,20 @@ class ContractFolderScanService:
             source_path = str(candidate.get("source_path") or "").strip()
             if not source_path:
                 continue
-            file_path = Path(source_path)
-            if not file_path.exists() or not file_path.is_file():
+
+            try:
+                if storage_provider is not None:
+                    file_bytes = storage_provider.read_file(source_path)
+                    content_hash = compute_file_hash_from_bytes(file_bytes)
+                else:
+                    file_path = Path(source_path)
+                    if not file_path.exists() or not file_path.is_file():
+                        continue
+                    content_hash = compute_file_hash(file_path)
+            except Exception:
+                logger.warning("mark_imported_hash_failed", extra={"source_path": source_path})
                 continue
 
-            content_hash = compute_file_hash(file_path)
             if content_hash and content_hash in existing_hashes:
                 candidate["already_imported"] = True
                 candidate["selected"] = False

--- a/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
+++ b/backend/apps/contracts/services/contract/integrations/folder_scan_service.py
@@ -341,7 +341,7 @@ class ContractFolderScanService:
                         "material_hash_duplicate_skipped",
                         extra={
                             "contract_id": contract_id,
-                            "filename": display_name,
+                            "file_name": display_name,
                             "content_hash": content_hash[:16],
                         },
                     )
@@ -359,7 +359,7 @@ class ContractFolderScanService:
                     skipped_dupes += 1
                     logger.info(
                         "material_name_duplicate_skipped",
-                        extra={"contract_id": contract_id, "filename": display_name, "category": category},
+                        extra={"contract_id": contract_id, "file_name": display_name, "category": category},
                     )
                     continue
 
@@ -981,7 +981,7 @@ class ContractFolderScanService:
             finally:
                 Path(docx_path).unlink(missing_ok=True)
         except (OSError, RuntimeError):
-            logger.exception("docx_to_pdf_conversion_from_bytes_failed", extra={"filename": filename})
+            logger.exception("docx_to_pdf_conversion_from_bytes_failed", extra={"file_name": filename})
             return None
 
     def _learn_from_import_correction(

--- a/backend/apps/core/cloud_storage/__init__.py
+++ b/backend/apps/core/cloud_storage/__init__.py
@@ -3,6 +3,7 @@
 from .factory import create_provider_for_binding, create_provider_from_account
 from .local import LocalProvider
 from .models import CloudStorageAccount
+from .null_provider import NullProvider
 from .protocols import CloudFileInfo, CloudStorageProvider
 
 __all__ = [
@@ -10,6 +11,7 @@ __all__ = [
     "CloudStorageAccount",
     "CloudStorageProvider",
     "LocalProvider",
+    "NullProvider",
     "create_provider_for_binding",
     "create_provider_from_account",
 ]

--- a/backend/apps/core/cloud_storage/browse_helper.py
+++ b/backend/apps/core/cloud_storage/browse_helper.py
@@ -1,0 +1,86 @@
+"""Shared helpers for cloud storage folder browsing in API endpoints."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import PurePosixPath
+from typing import Any
+
+from .models import CloudStorageAccount
+
+logger = logging.getLogger("apps.core.cloud_storage")
+
+
+def list_active_cloud_accounts() -> list[dict[str, Any]]:
+    """Return active cloud storage accounts for folder binding UI."""
+    return list(
+        CloudStorageAccount.objects.filter(is_active=True).values(
+            "id", "name", "storage_type", "local_root_path", "webdav_root_path", "onedrive_root_path"
+        )
+    )
+
+
+def browse_cloud_folder(
+    *,
+    storage_type: str,
+    storage_account_id: int,
+    path: str | None = None,
+    include_hidden: bool = False,
+) -> dict[str, Any]:
+    """Browse a cloud storage folder, returning a standardised result dict.
+
+    Returns a dict with keys: browsable, message, path, parent_path, entries, storage_type.
+    Caller converts to its own Schema type.
+    """
+    from .factory import create_provider_from_account
+
+    account = CloudStorageAccount.objects.filter(
+        id=storage_account_id, storage_type=storage_type, is_active=True
+    ).first()
+    if not account:
+        return _error_result("云存储账号不存在", path, storage_type)
+
+    provider = create_provider_from_account(account)
+    browse_path = (path or "").strip().rstrip("/") or "/"
+
+    try:
+        children = provider.list_directory(browse_path)
+    except Exception:
+        logger.exception("cloud_browse_failed", extra={"path": browse_path, "account_id": storage_account_id})
+        return _error_result("云存储目录访问失败", browse_path, storage_type)
+
+    entries: list[dict[str, str]] = []
+    for child in children:
+        if not child.is_dir:
+            continue
+        if not include_hidden and child.name.startswith("."):
+            continue
+        child_path = browse_path.rstrip("/") + "/" + child.name
+        entries.append({"name": child.name, "path": child_path})
+    entries.sort(key=lambda e: e["name"].lower())
+
+    parent_path: str | None = None
+    if browse_path != "/":
+        parent_path = str(PurePosixPath(browse_path).parent)
+        if parent_path == ".":
+            parent_path = "/"
+
+    return {
+        "browsable": True,
+        "message": None,
+        "path": browse_path,
+        "parent_path": parent_path,
+        "entries": entries,
+        "storage_type": storage_type,
+    }
+
+
+def _error_result(message: str, path: str | None, storage_type: str) -> dict[str, Any]:
+    return {
+        "browsable": False,
+        "message": message,
+        "path": path,
+        "parent_path": None,
+        "entries": [],
+        "storage_type": storage_type,
+    }

--- a/backend/apps/core/cloud_storage/browse_helper.py
+++ b/backend/apps/core/cloud_storage/browse_helper.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import PurePosixPath
 from typing import Any
 
+from .exceptions import CloudStorageRateLimitError
 from .models import CloudStorageAccount
 
 logger = logging.getLogger("apps.core.cloud_storage")
@@ -45,9 +46,12 @@ def browse_cloud_folder(
 
     try:
         children = provider.list_directory(browse_path)
+    except CloudStorageRateLimitError as e:
+        logger.warning("cloud_browse_rate_limited", extra={"path": browse_path, "account_id": storage_account_id})
+        return _error_result(str(e), browse_path, storage_type)
     except Exception:
         logger.exception("cloud_browse_failed", extra={"path": browse_path, "account_id": storage_account_id})
-        return _error_result("云存储目录访问失败", browse_path, storage_type)
+        return _error_result("云存储目录访问失败，请稍后重试", browse_path, storage_type)
 
     entries: list[dict[str, str]] = []
     for child in children:

--- a/backend/apps/core/cloud_storage/browse_helper.py
+++ b/backend/apps/core/cloud_storage/browse_helper.py
@@ -14,11 +14,10 @@ logger = logging.getLogger("apps.core.cloud_storage")
 
 def list_active_cloud_accounts() -> list[dict[str, Any]]:
     """Return active cloud storage accounts for folder binding UI."""
-    return list(
-        CloudStorageAccount.objects.filter(is_active=True).values(
-            "id", "name", "storage_type", "local_root_path", "webdav_root_path", "onedrive_root_path"
-        )
+    qs = CloudStorageAccount.objects.filter(is_active=True).values(
+        "id", "name", "storage_type", "local_root_path", "webdav_root_path", "onedrive_root_path"
     )
+    return list(qs)  # type: ignore[arg-type]
 
 
 def browse_cloud_folder(

--- a/backend/apps/core/cloud_storage/browse_helper.py
+++ b/backend/apps/core/cloud_storage/browse_helper.py
@@ -64,6 +64,8 @@ def browse_cloud_folder(
         parent_path = str(PurePosixPath(browse_path).parent)
         if parent_path == ".":
             parent_path = "/"
+    else:
+        parent_path = "/"
 
     return {
         "browsable": True,

--- a/backend/apps/core/cloud_storage/exceptions.py
+++ b/backend/apps/core/cloud_storage/exceptions.py
@@ -1,0 +1,24 @@
+"""Cloud storage specific exceptions."""
+
+from __future__ import annotations
+
+
+class CloudStorageError(Exception):
+    """Base exception for cloud storage operations.
+
+    Attributes:
+        provider: Storage provider name (e.g. "坚果云 WebDAV", "OneDrive")
+        retry_after: Suggested seconds to wait before retrying (None if unknown)
+    """
+
+    def __init__(self, message: str, *, provider: str = "", retry_after: int | None = None) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.retry_after = retry_after
+
+
+class CloudStorageRateLimitError(CloudStorageError):
+    """Raised when the cloud storage service returns a rate limit (HTTP 503/429)."""
+
+    def __init__(self, message: str, *, provider: str = "", retry_after: int | None = None) -> None:
+        super().__init__(message, provider=provider, retry_after=retry_after)

--- a/backend/apps/core/cloud_storage/factory.py
+++ b/backend/apps/core/cloud_storage/factory.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from .local import LocalProvider
+from .null_provider import NullProvider
 
 if TYPE_CHECKING:
     from .protocols import CloudStorageProvider
@@ -25,10 +26,10 @@ def create_provider_for_binding(binding: Any) -> CloudStorageProvider:
         return LocalProvider()
 
     if storage_type == "webdav":
-        from .webdav_provider import JianguoyunProvider
+        from .webdav_provider import WebDAVProvider
 
         if storage_account is not None:
-            return JianguoyunProvider(
+            return WebDAVProvider(
                 username=storage_account.webdav_username,
                 app_password=storage_account.get_decrypted_webdav_password(),
                 root_path=getattr(storage_account, "webdav_root_path", "/"),
@@ -36,7 +37,7 @@ def create_provider_for_binding(binding: Any) -> CloudStorageProvider:
             )
 
         logger.warning("No Nutstore WebDAV account linked to binding")
-        return LocalProvider()
+        return NullProvider(reason="坚果云 WebDAV 账号未配置或已禁用，请在 Admin 后台 -> 云存储账号 中配置")
 
     if storage_type == "onedrive":
         from .onedrive_provider import OAuthTokenManager, OneDriveProvider
@@ -49,10 +50,10 @@ def create_provider_for_binding(binding: Any) -> CloudStorageProvider:
             )
 
         logger.warning("No OneDrive account linked to binding")
-        return LocalProvider()
+        return NullProvider(reason="OneDrive 账号未配置或已禁用，请在 Admin 后台 -> 云存储账号 中配置")
 
-    logger.warning("Unknown storage_type %r, falling back to local", storage_type)
-    return LocalProvider()
+    logger.warning("Unknown storage_type %r", storage_type)
+    return NullProvider(reason=f"不支持的存储类型: {storage_type}")
 
 
 def create_provider_from_account(account: Any) -> CloudStorageProvider:
@@ -63,9 +64,9 @@ def create_provider_from_account(account: Any) -> CloudStorageProvider:
         return LocalProvider(root=getattr(account, "local_root_path", "/"))
 
     if storage_type == "webdav":
-        from .webdav_provider import JianguoyunProvider
+        from .webdav_provider import WebDAVProvider
 
-        return JianguoyunProvider(
+        return WebDAVProvider(
             username=account.webdav_username,
             app_password=account.get_decrypted_webdav_password(),
             root_path=getattr(account, "webdav_root_path", "/"),
@@ -81,5 +82,5 @@ def create_provider_from_account(account: Any) -> CloudStorageProvider:
             root_path=getattr(account, "onedrive_root_path", "/"),
         )
 
-    logger.warning("Unknown storage_type %r, falling back to local", storage_type)
-    return LocalProvider()
+    logger.warning("Unknown storage_type %r", storage_type)
+    return NullProvider(reason=f"不支持的存储类型: {storage_type}")

--- a/backend/apps/core/cloud_storage/local.py
+++ b/backend/apps/core/cloud_storage/local.py
@@ -13,7 +13,7 @@ class LocalProvider:
     """Read/write files on the local filesystem via pathlib."""
 
     def __init__(self, root: str = "/") -> None:
-        self._root = Path(root)
+        self._root = Path(root).resolve()
 
     def _resolve(self, path: str) -> Path:
         resolved = (self._root / path).resolve()

--- a/backend/apps/core/cloud_storage/local.py
+++ b/backend/apps/core/cloud_storage/local.py
@@ -16,7 +16,10 @@ class LocalProvider:
         self._root = Path(root)
 
     def _resolve(self, path: str) -> Path:
-        return (self._root / path).resolve()
+        resolved = (self._root / path).resolve()
+        if not resolved.is_relative_to(self._root):
+            raise OSError(f"路径逃逸: {path} 不在根目录 {self._root} 内")
+        return resolved
 
     def list_directory(self, path: str) -> list[CloudFileInfo]:
         target = self._resolve(path)
@@ -83,12 +86,18 @@ class LocalProvider:
 
     def walk(self, path: str) -> Iterator[tuple[str, list[str], list[CloudFileInfo]]]:
         target = self._resolve(path)
-        for root, dirs, files in os.walk(target):
+        for abs_root, dirs, files in os.walk(target):
+            root_path = Path(abs_root)
+            if not root_path.is_relative_to(self._root):
+                break
+            rel_root = str(root_path.relative_to(self._root))
             file_infos = []
             for f in files:
-                fp = Path(root) / f
+                fp = root_path / f
                 try:
                     stat = fp.stat()
+                    if not fp.is_relative_to(self._root):
+                        continue
                     file_infos.append(
                         CloudFileInfo(
                             name=f,
@@ -100,4 +109,4 @@ class LocalProvider:
                     )
                 except (OSError, PermissionError):
                     continue
-            yield (root, dirs, file_infos)
+            yield (rel_root, dirs, file_infos)

--- a/backend/apps/core/cloud_storage/null_provider.py
+++ b/backend/apps/core/cloud_storage/null_provider.py
@@ -1,0 +1,50 @@
+"""Null provider — raised when storage account is missing or misconfigured."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import NoReturn
+
+from .protocols import CloudFileInfo
+
+
+class NullProvider:
+    """Placeholder provider that raises on every operation.
+
+    Returned by the factory when a binding references a missing or
+    disabled storage account, preventing silent fallback to the
+    local filesystem.
+    """
+
+    def __init__(self, reason: str = "存储账号未配置或已禁用") -> None:
+        self._reason = reason
+
+    def _fail(self) -> NoReturn:
+        raise RuntimeError(self._reason)
+
+    def list_directory(self, path: str) -> list[CloudFileInfo]:
+        self._fail()
+
+    def read_file(self, path: str) -> bytes:
+        self._fail()
+
+    def write_file(self, path: str, content: bytes) -> None:
+        self._fail()
+
+    def mkdir(self, path: str) -> None:
+        self._fail()
+
+    def exists(self, path: str) -> bool:
+        self._fail()
+
+    def is_dir(self, path: str) -> bool:
+        self._fail()
+
+    def delete_file(self, path: str) -> None:
+        self._fail()
+
+    def get_file_info(self, path: str) -> CloudFileInfo | None:
+        self._fail()
+
+    def walk(self, path: str) -> Iterator[tuple[str, list[str], list[CloudFileInfo]]]:
+        self._fail()

--- a/backend/apps/core/cloud_storage/onedrive_provider.py
+++ b/backend/apps/core/cloud_storage/onedrive_provider.py
@@ -58,9 +58,17 @@ class OAuthTokenManager:
 
         refresh_token = self._account.get_decrypted_onedrive_refresh_token()
         if refresh_token:
-            return self._refresh_token(refresh_token)
+            try:
+                return self._refresh_token(refresh_token)
+            except Exception as e:
+                raise RuntimeError(
+                    "OneDrive 授权已过期（refresh_token 无效），请在 Admin 后台 -> 云存储账号 "
+                    "中重新点击「获取授权」按钮完成授权。"
+                ) from e
 
-        raise RuntimeError("OneDrive 未授权。请在 Admin 后台 -> 云存储账号 中点击「获取授权」按钮完成授权。")
+        raise RuntimeError(
+            "OneDrive 未授权。请在 Admin 后台 -> 云存储账号 中点击「获取授权」按钮完成授权。"
+        )
 
     def _refresh_token(self, refresh_token: str) -> str:
         resp = httpx.post(

--- a/backend/apps/core/cloud_storage/onedrive_provider.py
+++ b/backend/apps/core/cloud_storage/onedrive_provider.py
@@ -192,10 +192,14 @@ class OneDriveProvider:
 
     def _item_url(self, path: str) -> str:
         item_path = urllib.parse.quote(self._item_path(path), safe="/:")
+        if not item_path:
+            return f"{GRAPH_BASE}/me/drive/root"
         return f"{GRAPH_BASE}/me/drive/root:/{item_path}"
 
     def _children_url(self, path: str) -> str:
         item_path = urllib.parse.quote(self._item_path(path), safe="/:")
+        if not item_path:
+            return f"{GRAPH_BASE}/me/drive/root/children"
         return f"{GRAPH_BASE}/me/drive/root:/{item_path}:/children"
 
     # ── Protocol implementation ────────────────────────────────

--- a/backend/apps/core/cloud_storage/webdav_provider.py
+++ b/backend/apps/core/cloud_storage/webdav_provider.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import io
 import logging
 import time
-import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 
@@ -32,8 +30,8 @@ class _RateLimiter:
         self._last_call = time.monotonic()
 
 
-class JianguoyunProvider:
-    """Read/write files on Nutstore via WebDAV.
+class WebDAVProvider:
+    """Read/write files on any WebDAV server.
 
     Uses ``requests`` + HTTPBasicAuth directly for full control over
     PROPFIND / PUT / GET / DELETE / MKCOL operations, avoiding the
@@ -214,9 +212,6 @@ class JianguoyunProvider:
         return resp.status_code in (200, 207)
 
     def is_dir(self, path: str) -> bool:
-        results = self.list_directory(path)
-        # If we can list it, it's a directory
-        # PROPFIND on directories requires trailing slash for Nutstore
         url = self._url(path).rstrip("/") + "/"
         self._limiter.wait_if_needed()
         resp = self._session.request("PROPFIND", url, headers={"Depth": "0"}, timeout=30)
@@ -264,3 +259,7 @@ class JianguoyunProvider:
         for subdir in subdirs:
             sub_path = f"{path.rstrip('/')}/{subdir}"
             yield from self.walk(sub_path)
+
+
+# Backward-compat alias
+JianguoyunProvider = WebDAVProvider

--- a/backend/apps/core/cloud_storage/webdav_provider.py
+++ b/backend/apps/core/cloud_storage/webdav_provider.py
@@ -74,6 +74,14 @@ class WebDAVProvider:
         self._limiter.wait_if_needed()
         url = self._url(path)
         resp = self._session.request(method, url, timeout=30, **kwargs)
+        if resp.status_code == 503:
+            from .exceptions import CloudStorageRateLimitError
+
+            raise CloudStorageRateLimitError(
+                "坚果云服务暂时不可用（请求过于频繁），请稍后重试",
+                provider="坚果云 WebDAV",
+                retry_after=60,
+            )
         if resp.status_code >= 400:
             logger.error("WebDAV %s %s returned %d", method, url, resp.status_code)
         return resp
@@ -91,6 +99,14 @@ class WebDAVProvider:
             headers={"Depth": "1"},
             timeout=30,
         )
+        if resp.status_code == 503:
+            from .exceptions import CloudStorageRateLimitError
+
+            raise CloudStorageRateLimitError(
+                "坚果云服务暂时不可用（请求过于频繁），请稍后重试",
+                provider="坚果云 WebDAV",
+                retry_after=60,
+            )
         if resp.status_code == 404:
             return []
         if resp.status_code >= 400:

--- a/backend/apps/documents/services/generation/contract_generation_service.py
+++ b/backend/apps/documents/services/generation/contract_generation_service.py
@@ -313,9 +313,19 @@ class ContractGenerationService:
             if not subdir_path:
                 return "V1"
 
-            folder_path = Path(binding.folder_path) / subdir_path
-            if not folder_path.exists():
-                return "V1"
+            # 获取文件名列表（云存储 vs 本地）
+            storage_type = getattr(binding, "storage_type", "local")
+            if storage_type != "local":
+                from apps.core.cloud_storage.factory import create_provider_for_binding
+
+                provider = create_provider_for_binding(binding)
+                children = provider.list_directory(subdir_path)
+                names = [c.name for c in children if not c.is_dir]
+            else:
+                folder_path = Path(binding.folder_path) / subdir_path
+                if not folder_path.exists():
+                    return "V1"
+                names = [f.name for f in folder_path.iterdir() if f.is_file()]
 
             # 构建文件名模式（不包含版本号和日期）
             template_prefix = re.sub(r"\.(docx?|doc)$", "", template_name or "合同", flags=re.IGNORECASE)
@@ -327,12 +337,11 @@ class ContractGenerationService:
 
             # 查找已存在的版本号
             max_version = 0
-            for file_path in folder_path.iterdir():
-                if file_path.is_file():
-                    match = pattern.match(file_path.name)
-                    if match:
-                        version_num = int(match.group(1))
-                        max_version = max(max_version, version_num)
+            for name in names:
+                match = pattern.match(name)
+                if match:
+                    version_num = int(match.group(1))
+                    max_version = max(max_version, version_num)
 
             return f"V{max_version + 1}"
 

--- a/backend/apps/documents/services/generation/contract_generation_service.py
+++ b/backend/apps/documents/services/generation/contract_generation_service.py
@@ -319,8 +319,9 @@ class ContractGenerationService:
                 from apps.core.cloud_storage.factory import create_provider_for_binding
 
                 provider = create_provider_for_binding(binding)
-                children = provider.list_directory(subdir_path)
-                names = [c.name for c in children if not c.is_dir]
+                names = []
+                for _d, _s, files in provider.walk(subdir_path):
+                    names.extend(c.name for c in files if not c.is_dir)
             else:
                 folder_path = Path(binding.folder_path) / subdir_path
                 if not folder_path.exists():

--- a/backend/apps/documents/services/generation/supplementary_agreement_generation_service.py
+++ b/backend/apps/documents/services/generation/supplementary_agreement_generation_service.py
@@ -239,9 +239,19 @@ class SupplementaryAgreementGenerationService:
             if not subdir_path:
                 return "V1"
 
-            folder_path = Path(binding.folder_path) / subdir_path
-            if not folder_path.exists():
-                return "V1"
+            # 获取文件名列表（云存储 vs 本地）
+            storage_type = getattr(binding, "storage_type", "local")
+            if storage_type != "local":
+                from apps.core.cloud_storage.factory import create_provider_for_binding
+
+                provider = create_provider_for_binding(binding)
+                children = provider.list_directory(subdir_path)
+                names = [c.name for c in children if not c.is_dir]
+            else:
+                folder_path = Path(binding.folder_path) / subdir_path
+                if not folder_path.exists():
+                    return "V1"
+                names = [f.name for f in folder_path.iterdir() if f.is_file()]
 
             # 构建文件名模式（不包含版本号和日期）
             today_str = date.today().strftime("%Y%m%d")
@@ -252,12 +262,11 @@ class SupplementaryAgreementGenerationService:
 
             # 查找已存在的版本号
             max_version = 0
-            for file_path in folder_path.iterdir():
-                if file_path.is_file():
-                    match = pattern.match(file_path.name)
-                    if match:
-                        version_num = int(match.group(1))
-                        max_version = max(max_version, version_num)
+            for name in names:
+                match = pattern.match(name)
+                if match:
+                    version_num = int(match.group(1))
+                    max_version = max(max_version, version_num)
 
             return f"V{max_version + 1}"
 

--- a/backend/apps/documents/services/generation/supplementary_agreement_generation_service.py
+++ b/backend/apps/documents/services/generation/supplementary_agreement_generation_service.py
@@ -245,8 +245,9 @@ class SupplementaryAgreementGenerationService:
                 from apps.core.cloud_storage.factory import create_provider_for_binding
 
                 provider = create_provider_for_binding(binding)
-                children = provider.list_directory(subdir_path)
-                names = [c.name for c in children if not c.is_dir]
+                names = []
+                for _d, _s, files in provider.walk(subdir_path):
+                    names.extend(c.name for c in files if not c.is_dir)
             else:
                 folder_path = Path(binding.folder_path) / subdir_path
                 if not folder_path.exists():

--- a/backend/apps/documents/services/generation/supplementary_agreement_generation_service.py
+++ b/backend/apps/documents/services/generation/supplementary_agreement_generation_service.py
@@ -245,7 +245,7 @@ class SupplementaryAgreementGenerationService:
                 from apps.core.cloud_storage.factory import create_provider_for_binding
 
                 provider = create_provider_for_binding(binding)
-                names = []
+                names: list[str] = []
                 for _d, _s, files in provider.walk(subdir_path):
                     names.extend(c.name for c in files if not c.is_dir)
             else:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # --- 数据处理 ---
     "pandas==3.0.2",
     "pydantic==2.13.3",
-    "pydantic-ai[mcp]==1.90.0",
+    "pydantic-ai[mcp]==1.105.0",
     "python-dateutil==2.9.0.post0",
     "pyyaml==6.0.3",
     # --- 安全 / 加密 ---

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -299,7 +299,7 @@ pyee==13.0.1
     # via playwright
 pygments==2.20.0
     # via rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   django-ninja-jwt
     #   mcp
@@ -384,7 +384,7 @@ sqlparse==0.5.5
     # via django
 sse-starlette==3.4.1
     # via mcp
-starlette==1.0.0
+starlette==1.2.1
     # via
     #   mcp
     #   sse-starlette

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,8 @@ annotated-doc==0.0.4
     # via typer
 annotated-types==0.7.0
     # via pydantic
+aiohttp==3.14.0
+    # via xai-sdk
 antlr4-python3-runtime==4.13.2
     # via omegaconf
 anyio==4.13.0

--- a/backend/tests/ci/unit/test_cloud_storage_browse_helper.py
+++ b/backend/tests/ci/unit/test_cloud_storage_browse_helper.py
@@ -1,0 +1,164 @@
+"""browse_helper 单元测试."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.core.cloud_storage.browse_helper import browse_cloud_folder, list_active_cloud_accounts
+
+
+class TestListActiveCloudAccounts:
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_returns_active_accounts(self, mock_csa):
+        mock_qs = MagicMock()
+        mock_csa.objects.filter.return_value = mock_qs
+        mock_qs.values.return_value = mock_qs
+        mock_qs.__iter__ = MagicMock(return_value=iter([
+            {"id": 1, "name": "坚果云", "storage_type": "webdav"},
+        ]))
+        mock_qs.__bool__ = MagicMock(return_value=True)
+
+        result = list_active_cloud_accounts()
+        mock_csa.objects.filter.assert_called_once_with(is_active=True)
+
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_empty_when_no_accounts(self, mock_csa):
+        mock_qs = MagicMock()
+        mock_csa.objects.filter.return_value = mock_qs
+        mock_qs.values.return_value = []
+        mock_qs.__iter__ = MagicMock(return_value=iter([]))
+        mock_qs.__bool__ = MagicMock(return_value=True)
+
+        result = list_active_cloud_accounts()
+        assert result == []
+
+
+class TestBrowseCloudFolder:
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_account_not_found(self, mock_csa):
+        mock_csa.objects.filter.return_value.first.return_value = None
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=999,
+            path="/",
+        )
+        assert result["browsable"] is False
+        assert "不存在" in result["message"]
+
+    @patch("apps.core.cloud_storage.factory.create_provider_from_account")
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_successful_browse(self, mock_csa, mock_create_provider):
+        mock_account = MagicMock()
+        mock_csa.objects.filter.return_value.first.return_value = mock_account
+
+        mock_provider = MagicMock()
+        mock_provider.list_directory.return_value = [
+            MagicMock(name="folder1", is_dir=True),
+            MagicMock(name="file1.pdf", is_dir=False),
+            MagicMock(name="folder2", is_dir=True),
+        ]
+        # Set name attribute on mocks
+        mock_provider.list_directory.return_value[0].name = "folder1"
+        mock_provider.list_directory.return_value[1].name = "file1.pdf"
+        mock_provider.list_directory.return_value[2].name = "folder2"
+        mock_create_provider.return_value = mock_provider
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=1,
+            path="/docs",
+        )
+        assert result["browsable"] is True
+        assert len(result["entries"]) == 2  # only dirs
+        assert result["entries"][0]["name"] == "folder1"
+        assert result["entries"][1]["name"] == "folder2"
+        assert result["path"] == "/docs"
+
+    @patch("apps.core.cloud_storage.factory.create_provider_from_account")
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_provider_exception_returns_error(self, mock_csa, mock_create_provider):
+        mock_account = MagicMock()
+        mock_csa.objects.filter.return_value.first.return_value = mock_account
+
+        mock_provider = MagicMock()
+        mock_provider.list_directory.side_effect = ConnectionError("timeout")
+        mock_create_provider.return_value = mock_provider
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=1,
+            path="/",
+        )
+        assert result["browsable"] is False
+        assert "访问失败" in result["message"]
+
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_root_path_default(self, mock_csa):
+        mock_csa.objects.filter.return_value.first.return_value = None
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=1,
+            path=None,
+        )
+        assert result["browsable"] is False  # account not found
+
+    @patch("apps.core.cloud_storage.factory.create_provider_from_account")
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_hidden_files_filtered(self, mock_csa, mock_create_provider):
+        mock_account = MagicMock()
+        mock_csa.objects.filter.return_value.first.return_value = mock_account
+
+        mock_provider = MagicMock()
+        item1 = MagicMock(name="visible", is_dir=True)
+        item1.name = "visible"
+        item2 = MagicMock(name=".hidden", is_dir=True)
+        item2.name = ".hidden"
+        mock_provider.list_directory.return_value = [item1, item2]
+        mock_create_provider.return_value = mock_provider
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=1,
+            path="/",
+            include_hidden=False,
+        )
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["name"] == "visible"
+
+    @patch("apps.core.cloud_storage.factory.create_provider_from_account")
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_parent_path_computed(self, mock_csa, mock_create_provider):
+        mock_account = MagicMock()
+        mock_csa.objects.filter.return_value.first.return_value = mock_account
+
+        mock_provider = MagicMock()
+        mock_provider.list_directory.return_value = []
+        mock_create_provider.return_value = mock_provider
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=1,
+            path="/docs/2024",
+        )
+        assert result["parent_path"] == "/docs"
+
+    @patch("apps.core.cloud_storage.factory.create_provider_from_account")
+    @patch("apps.core.cloud_storage.browse_helper.CloudStorageAccount")
+    def test_root_parent_is_slash(self, mock_csa, mock_create_provider):
+        mock_account = MagicMock()
+        mock_csa.objects.filter.return_value.first.return_value = mock_account
+
+        mock_provider = MagicMock()
+        mock_provider.list_directory.return_value = []
+        mock_create_provider.return_value = mock_provider
+
+        result = browse_cloud_folder(
+            storage_type="webdav",
+            storage_account_id=1,
+            path="/",
+        )
+        assert result["parent_path"] == "/"

--- a/backend/tests/ci/unit/test_cloud_storage_factory.py
+++ b/backend/tests/ci/unit/test_cloud_storage_factory.py
@@ -1,0 +1,54 @@
+"""Cloud storage factory 单元测试."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from apps.core.cloud_storage.factory import create_provider_for_binding
+from apps.core.cloud_storage.local import LocalProvider
+from apps.core.cloud_storage.null_provider import NullProvider
+
+
+class TestFactoryNullProviderFallback:
+    """Verify factory returns NullProvider when storage account is missing."""
+
+    def test_webdav_without_account_returns_null(self):
+        binding = SimpleNamespace(storage_type="webdav", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        assert isinstance(provider, NullProvider)
+
+    def test_onedrive_without_account_returns_null(self):
+        binding = SimpleNamespace(storage_type="onedrive", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        assert isinstance(provider, NullProvider)
+
+    def test_unknown_type_returns_null(self):
+        binding = SimpleNamespace(storage_type="s3", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        assert isinstance(provider, NullProvider)
+
+    def test_local_type_returns_local_provider(self):
+        binding = SimpleNamespace(storage_type="local", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        assert isinstance(provider, LocalProvider)
+
+    def test_webdav_null_provider_raises_on_use(self):
+        binding = SimpleNamespace(storage_type="webdav", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        with pytest.raises(RuntimeError, match="坚果云 WebDAV 账号未配置"):
+            provider.list_directory("/")
+
+    def test_onedrive_null_provider_raises_on_use(self):
+        binding = SimpleNamespace(storage_type="onedrive", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        with pytest.raises(RuntimeError, match="OneDrive 账号未配置"):
+            provider.list_directory("/")
+
+    def test_unknown_type_null_provider_raises_on_use(self):
+        binding = SimpleNamespace(storage_type="ftp", storage_account=None)
+        provider = create_provider_for_binding(binding)
+        with pytest.raises(RuntimeError, match="不支持的存储类型: ftp"):
+            provider.list_directory("/")

--- a/backend/tests/ci/unit/test_cloud_storage_local.py
+++ b/backend/tests/ci/unit/test_cloud_storage_local.py
@@ -127,7 +127,7 @@ class TestWalk:
     def test_walks_tree(self, provider: LocalProvider, sample_tree: Path):
         collected = []
         for dirpath, dirs, files in provider.walk("testroot"):
-            collected.append((dirpath, [d for d in dirs], [f.name for f in files]))
+            collected.append((dirpath, list(dirs), [f.name for f in files]))
 
         all_names = [f for _, _, files in collected for f in files]
         assert "top.txt" in all_names
@@ -154,3 +154,47 @@ class TestCloudFileInfoContract:
             assert isinstance(info.is_dir, bool)
             assert isinstance(info.size, int)
             assert isinstance(info.modified_at, float)
+
+
+class TestPathTraversal:
+    """Verify path traversal attacks are blocked."""
+
+    def test_dotdot_read_blocked(self, provider: LocalProvider, tmp_path: Path):
+        """Reading outside root via .. should raise OSError."""
+        (tmp_path / "secret.txt").write_text("secret")
+        with pytest.raises(OSError, match="路径逃逸"):
+            provider.read_file("../../../secret.txt")
+
+    def test_dotdot_write_blocked(self, provider: LocalProvider, tmp_path: Path):
+        """Writing outside root via .. should raise OSError."""
+        with pytest.raises(OSError, match="路径逃逸"):
+            provider.write_file("../../../evil.txt", b"bad")
+
+    def test_dotdot_mkdir_blocked(self, provider: LocalProvider, tmp_path: Path):
+        """Creating dir outside root via .. should raise OSError."""
+        with pytest.raises(OSError, match="路径逃逸"):
+            provider.mkdir("../../../evil_dir")
+
+    def test_dotdot_exists_blocked(self, provider: LocalProvider, tmp_path: Path):
+        """Checking existence outside root via .. should raise OSError."""
+        with pytest.raises(OSError, match="路径逃逸"):
+            provider.exists("../../../etc/passwd")
+
+    def test_dotdot_delete_blocked(self, provider: LocalProvider, tmp_path: Path):
+        """Deleting outside root via .. should raise OSError."""
+        (tmp_path / "important.txt").write_text("keep")
+        with pytest.raises(OSError, match="路径逃逸"):
+            provider.delete_file("../../important.txt")
+
+    def test_walk_stays_within_root(self, provider: LocalProvider, sample_tree: Path):
+        """walk() should yield paths relative to root, not absolute."""
+        for dirpath, _dirs, files in provider.walk("testroot"):
+            assert not Path(dirpath).is_absolute(), f"dirpath should be relative: {dirpath}"
+            for f in files:
+                assert not Path(f.path).is_absolute(), f"file path should be relative: {f.path}"
+
+    def test_normal_relative_path_works(self, provider: LocalProvider, sample_tree: Path):
+        """Normal relative paths should work fine."""
+        info = provider.get_file_info("testroot/top.txt")
+        assert info is not None
+        assert info.name == "top.txt"

--- a/backend/tests/ci/unit/test_cloud_storage_null.py
+++ b/backend/tests/ci/unit/test_cloud_storage_null.py
@@ -1,0 +1,61 @@
+"""NullProvider 单元测试."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.cloud_storage.null_provider import NullProvider
+
+
+class TestNullProvider:
+    """Verify NullProvider raises RuntimeError on every operation."""
+
+    @pytest.fixture
+    def provider(self) -> NullProvider:
+        return NullProvider(reason="测试：存储账号未配置")
+
+    def test_list_directory_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.list_directory("/")
+
+    def test_read_file_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.read_file("test.txt")
+
+    def test_write_file_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.write_file("test.txt", b"data")
+
+    def test_mkdir_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.mkdir("dir")
+
+    def test_exists_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.exists("test.txt")
+
+    def test_is_dir_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.is_dir("dir")
+
+    def test_delete_file_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.delete_file("test.txt")
+
+    def test_get_file_info_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            provider.get_file_info("test.txt")
+
+    def test_walk_raises(self, provider: NullProvider):
+        with pytest.raises(RuntimeError, match="存储账号未配置"):
+            list(provider.walk("/"))
+
+    def test_custom_reason(self):
+        provider = NullProvider(reason="OneDrive 授权已过期")
+        with pytest.raises(RuntimeError, match="OneDrive 授权已过期"):
+            provider.list_directory("/")
+
+    def test_default_reason(self):
+        provider = NullProvider()
+        with pytest.raises(RuntimeError, match="存储账号未配置或已禁用"):
+            provider.list_directory("/")

--- a/backend/tests/ci/unit/test_cloud_storage_phase1.py
+++ b/backend/tests/ci/unit/test_cloud_storage_phase1.py
@@ -1,0 +1,182 @@
+"""Phase 1 cloud storage import pipeline unit tests."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.contracts.services.contract.integrations.file_hash_utils import (
+    compute_file_hash,
+    compute_file_hash_from_bytes,
+)
+
+
+class TestComputeFileHashFromBytes:
+    def test_empty_bytes(self):
+        result = compute_file_hash_from_bytes(b"")
+        assert result == hashlib_sha256(b"")
+
+    def test_normal_bytes(self):
+        data = b"hello world"
+        result = compute_file_hash_from_bytes(data)
+        assert result == hashlib_sha256(data)
+        assert len(result) == 64  # SHA-256 hex digest
+
+    def test_large_bytes(self):
+        data = b"x" * 1_000_000
+        result = compute_file_hash_from_bytes(data)
+        assert len(result) == 64
+
+    def test_matches_file_hash(self, tmp_path):
+        """Verify bytes hash matches file hash for same content."""
+        data = b"test content for hash comparison"
+        f = tmp_path / "test.bin"
+        f.write_bytes(data)
+        assert compute_file_hash_from_bytes(data) == compute_file_hash(f)
+
+    def test_none_returns_empty(self):
+        result = compute_file_hash_from_bytes(None)  # type: ignore[arg-type]
+        assert result == ""
+
+
+def hashlib_sha256(data: bytes) -> str:
+    import hashlib
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_cloud_file(name: str, path: str, size: int = 100, is_dir: bool = False, modified_at: float = 1000.0):
+    """Helper to create mock CloudFileInfo-like objects."""
+    return SimpleNamespace(name=name, path=path, is_dir=is_dir, size=size, modified_at=modified_at)
+
+
+def _make_mock_provider(files: list | None = None, dirs: list | None = None):
+    """Create a mock CloudStorageProvider."""
+    provider = MagicMock()
+    all_items = []
+    if dirs:
+        all_items.extend(dirs)
+    if files:
+        all_items.extend(files)
+    provider.list_directory.return_value = all_items
+    provider.walk.return_value = [("/", [d.name for d in (dirs or [])], files or [])]
+    provider.read_file.return_value = b"mock file content"
+    provider.exists.return_value = True
+    provider.is_dir.return_value = True
+    return provider
+
+
+class TestCollectDocxFilesCloud:
+    """Test the cloud variant of _collect_docx_files."""
+
+    def _get_service(self):
+        from apps.contracts.services.contract.integrations.folder_scan_service import ContractFolderScanService
+        return ContractFolderScanService()
+
+    def test_returns_empty_for_litigation(self):
+        service = self._get_service()
+        result = service._collect_docx_files("/", "litigation", storage_provider=_make_mock_provider())
+        assert result == []
+
+    def test_collects_revision_docx(self):
+        service = self._get_service()
+        provider = _make_mock_provider(
+            files=[
+                _make_cloud_file("合同修订版V2.docx", "/docs/合同修订版V2.docx"),
+                _make_cloud_file("普通文件.pdf", "/docs/普通文件.pdf"),
+                _make_cloud_file("批注版-修改稿.docx", "/docs/批注版-修改稿.docx"),
+            ]
+        )
+        result = service._collect_docx_files_cloud("/docs", provider, ("修订版", "批注版", "律师修订"))
+        assert len(result) == 2
+        names = {r["filename"] for r in result}
+        assert "合同修订版V2.docx" in names
+        assert "批注版-修改稿.docx" in names
+        assert "普通文件.pdf" not in names
+
+    def test_deduplicates_by_name(self):
+        service = self._get_service()
+        provider = _make_mock_provider(
+            files=[
+                _make_cloud_file("合同修订版.docx", "/docs/合同修订版.docx", size=100, modified_at=2000.0),
+                _make_cloud_file("合同修订版.docx", "/docs/sub/合同修订版.docx", size=200, modified_at=3000.0),
+            ]
+        )
+        result = service._collect_docx_files_cloud("/docs", provider, ("修订版",))
+        assert len(result) == 1  # deduplicated
+
+    def test_empty_folder(self):
+        service = self._get_service()
+        provider = _make_mock_provider(files=[])
+        result = service._collect_docx_files_cloud("/docs", provider, ("修订版",))
+        assert result == []
+
+
+class TestConvertDocxToTempPdfFromBytes:
+    """Test the bytes-based docx→PDF conversion."""
+
+    def _get_service(self):
+        from apps.contracts.services.contract.integrations.folder_scan_service import ContractFolderScanService
+        return ContractFolderScanService()
+
+    @patch("apps.contracts.services.contract.integrations.folder_scan_service.ContractFolderScanService._convert_docx_to_temp_pdf_from_bytes")
+    def test_returns_none_on_conversion_failure(self, mock_convert):
+        mock_convert.return_value = None
+        service = self._get_service()
+        result = service._convert_docx_to_temp_pdf_from_bytes(b"fake docx", "test.docx")
+        assert result is None
+
+
+class TestConfirmImportProviderThreading:
+    """Test that confirm_import properly threads storage_provider."""
+
+    def test_signature_accepts_storage_provider(self):
+        from apps.contracts.services.contract.integrations.folder_scan_service import ContractFolderScanService
+        import inspect
+        sig = inspect.signature(ContractFolderScanService.confirm_import)
+        assert "storage_provider" in sig.parameters
+
+    def test_mark_already_imported_accepts_storage_provider(self):
+        from apps.contracts.services.contract.integrations.folder_scan_service import ContractFolderScanService
+        import inspect
+        sig = inspect.signature(ContractFolderScanService._mark_already_imported)
+        assert "storage_provider" in sig.parameters
+
+    def test_collect_docx_files_accepts_storage_provider(self):
+        from apps.contracts.services.contract.integrations.folder_scan_service import ContractFolderScanService
+        import inspect
+        sig = inspect.signature(ContractFolderScanService._collect_docx_files)
+        assert "storage_provider" in sig.parameters
+
+
+class TestCollectWorkLogSuggestionsCloud:
+    """Test the cloud variant of collect_work_log_suggestions."""
+
+    def test_returns_empty_on_provider_error(self):
+        from apps.contracts.services.contract.integrations.archive_classifier import (
+            _collect_work_log_suggestions_cloud,
+        )
+        provider = MagicMock()
+        provider.list_directory.side_effect = ConnectionError("timeout")
+        result = _collect_work_log_suggestions_cloud("/", "litigation", provider)
+        assert result == []
+
+    def test_collects_date_prefixed_dirs(self):
+        from apps.contracts.services.contract.integrations.archive_classifier import (
+            _collect_work_log_suggestions_cloud,
+        )
+        provider = _make_mock_provider(
+            dirs=[
+                _make_cloud_file("2026.01.15-立案", "/2026.01.15-立案", is_dir=True),
+                _make_cloud_file("2026.03.20-开庭", "/2026.03.20-开庭", is_dir=True),
+                _make_cloud_file("其他文件夹", "/其他文件夹", is_dir=True),
+            ]
+        )
+        result = _collect_work_log_suggestions_cloud("/", "litigation", provider)
+        assert len(result) == 2
+        dates = {r["date"] for r in result}
+        assert "2026-01-15" in dates
+        assert "2026-03-20" in dates

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -60,78 +60,93 @@ dependencies = [
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/ab/93ce242f899b68c51b0578c027aafa791ab3614cb9345fa5d37b5f5c8e3e/aiohttp-3.14.0.tar.gz", hash = "sha256:2882de819734c715fd1b9c11c97e09fa020d14438203d1d354d8ed1702791c9b", size = 7940674, upload-time = "2026-06-01T19:41:02.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
-    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
-    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
-    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
-    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
-    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
-    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
-    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
-    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
-    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
-    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
-    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
-    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
-    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/89/97/2b6889bfb6b6847520d50d95eb8c4307a45e28aaca39faf4a9454b3d1b2f/aiohttp-3.14.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b29518c9c2ec7e373e68259206a137c7f4f5439c58baaec4b5ab3ab799850a4e", size = 750194, upload-time = "2026-06-01T19:37:48.164Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e2/62634b7fff918ed98c3c6b2f0e70d520f7f28846cb412d451b04354c6459/aiohttp-3.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dbec68ce61b64cb73cab4d33df9433427b1713c8bcccb181dce695c1b6f8e87c", size = 506966, upload-time = "2026-06-01T19:37:50.014Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/fb/5ce075150828c797a5106f1c2fb26034e709d4289b9d2bf8b07f1e59fac6/aiohttp-3.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3cdf534aa455593e589302990c5097aa5c92c06c4262a20da22934f9186a5fff", size = 507527, upload-time = "2026-06-01T19:37:51.96Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d5/405a0ae4e6b081754a3609c1c97c63a950e000a2def16046f1e736933a0e/aiohttp-3.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb6c657104393b5fbff01a5f59b2023db74058a8077d94475d6c25d03882a108", size = 1762420, upload-time = "2026-06-01T19:37:53.839Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1d/e05a7c896b15a6bc6fb8fc5319eb437861c2c49c34559ef928add6590315/aiohttp-3.14.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:46fbbec4e4fab7428d4396a3823f9320e4560aa3113b89eeebce712c27c9ed5a", size = 1733672, upload-time = "2026-06-01T19:37:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/22/a72f7c459e195fa41bf4f7abd1f925b91fe91f8097e51c654229ba144a33/aiohttp-3.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c2c7e05dd5335b298085abf45ddf98673934c3ee1c083d0b9ea13d4186ad500", size = 1805064, upload-time = "2026-06-01T19:37:57.931Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/e85bdaba0be59ca4838005ebfef4048fcdd5f35a02b07057a9a123394440/aiohttp-3.14.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c7139100fbaae76515b73051d8f0aa3a3ff02e415eec8a8eee8e2223d9ba955", size = 1902125, upload-time = "2026-06-01T19:38:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/51de5c6b971c27bb1ef620293b8d1ca611ec78736b34b3f6ccf68e4c8785/aiohttp-3.14.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d6f9286a629ce52728430afe18f8ed2b6c39a1fddb3802d7244b9983910ad2", size = 1783112, upload-time = "2026-06-01T19:38:02.641Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ae/b4402bfde77e43dfb1b6ccff83c7b7ab63ed06b50c4754f0c5423fb374fe/aiohttp-3.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3c3e12cdaeb92d7dcf13db00e9f6b1956b910e47256e696df1cfa946d02159", size = 1586356, upload-time = "2026-06-01T19:38:04.637Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/05/750a3265ca4dc54a460bd0cb1121a8f2ce9171fce4a135fb47ea7fd594d2/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4d6a998191f5ebe3b8c28463ff72bc030250008b3193c402464efadd08b5ca02", size = 1723119, upload-time = "2026-06-01T19:38:06.713Z" },
+    { url = "https://files.pythonhosted.org/packages/37/01/8c0812c50b3b1b1c37b323bf170d6be8847a8f234060485b7d1e71953f60/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0fc2b75ae8d169d853be2862d960be8550da6c5c65711d5476407eb3fdb006bd", size = 1757216, upload-time = "2026-06-01T19:38:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2a/50fb98028a26887cbe48dcc1df92a90825615bc73b5584301304090cded8/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:16eee56bcc72d04600bc56c1759982c2385ec0b41d3fd3521f836bf64a0957ef", size = 1770500, upload-time = "2026-06-01T19:38:11.111Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/32/0ffd598a2fa2b9a423daf242e700cfdabda35d6e602394ad9ae58972c1c7/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5a2e7ca615c3ddc15b82687e05a624e5f5cba3f1d6c20cb81172d70ea498451e", size = 1576224, upload-time = "2026-06-01T19:38:13.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f9/b9fc381dd9b66afb33f2634c40e229d106467be0afcabe79648631ab6712/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f0b7b8bbbec3ce9467ee0ebe334622fd90624f593edd3136c567811453fc4fae", size = 1794252, upload-time = "2026-06-01T19:38:15.498Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/fb/05d9214c975f23225a8cd5c439325e338c7c377b315480ef3871db51f54e/aiohttp-3.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ba10966d4f03dd96a14365be4b8e37c327c76f11c3ca867116966cdd9f98066", size = 1760193, upload-time = "2026-06-01T19:38:17.624Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4b/02992fc4fb9e1b6673ee3f888a8e587a6447afda1f6f4aca776c148c2876/aiohttp-3.14.0-cp312-cp312-win32.whl", hash = "sha256:101df7779c80c0636014a6b2c6642acd3efb5b355d48347c9d7dfb720aee9430", size = 448650, upload-time = "2026-06-01T19:38:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e9/246532214c3abda518477cbaaf16d420295ad8effa5233844cbb38f299ab/aiohttp-3.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:b0a5747586d4467efd1f932710b269131c9717a872dce082cd92a00c1c13123a", size = 476145, upload-time = "2026-06-01T19:38:21.505Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c3/63f8c20090048915711598b0adf475b149216d736157961de06480a45b15/aiohttp-3.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:5f1c5be60add78fabb4aacd13c5a348ae79d2fcbfc7fa78da8f1eb192273b370", size = 444250, upload-time = "2026-06-01T19:38:24.027Z" },
+    { url = "https://files.pythonhosted.org/packages/21/61/d11f7d9a3144bffe825247d6367cd93053666da50b94707c9129c78868d5/aiohttp-3.14.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:25400d710641a8040bf022a8a99f579e581ffa1c5bd42c33255d7d6f3957c127", size = 502399, upload-time = "2026-06-01T19:38:25.955Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9b/a7e317625d36356844f8bb022cabd305b541f968856cc3c2e0b58e53ee6e/aiohttp-3.14.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:c5492b9929826e07cc3fcb9739ae87aab05dff6b5e67a9b73fd1700c6d008981", size = 510068, upload-time = "2026-06-01T19:38:27.828Z" },
+    { url = "https://files.pythonhosted.org/packages/11/41/cc2d2cfbfbdc3126ba258f3cd27d1ac8a33492ae3c35a4583ee21f0ba7f1/aiohttp-3.14.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3366751d68d237c621264233a32f3078bbc21b7904ab90a77e03d21390c742c6", size = 481670, upload-time = "2026-06-01T19:38:29.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/381f4023c3b08cb616e520f566d8c58957abad54e56441d41fe67cfb0195/aiohttp-3.14.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:57ea07d28695a7a40304d42251892a8df765e5588c10ee32afeddcd5df33c0a2", size = 487591, upload-time = "2026-06-01T19:38:31.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/4d/4506fdb7a022bdf70011a3bbb4ca00c5c570026ef6a3c5bd7bc70c39089c/aiohttp-3.14.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:076cb014191ae2e65d949e1ad01f1dcfe33e32789b5172510f3e79c79fc04d50", size = 496503, upload-time = "2026-06-01T19:38:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7d/c814111e04894a45d9e2defc94443879a6f118d9633d5fedfe6e2e8af5f0/aiohttp-3.14.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f3fc37054564dee64a855b5b092d87ec35dcddfaabf7dacb1c8a2b1f83dc0a9", size = 745870, upload-time = "2026-06-01T19:38:36.013Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/80eee0efddfe187e7cd05027086b7ce1c0e492e82a4eda58f5c5543a44a0/aiohttp-3.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8fcaef74d2ab0f607d7ff85a0d15e21bb5a258c4a58df1908396eb50d7f4ed3c", size = 505588, upload-time = "2026-06-01T19:38:38.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f8/0f28f04eef75d52fc9c715dde7ce9c0abb810fd20cfeb0fea7afd2ab1e98/aiohttp-3.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e4c01b0bfc6209590960e68eac083cd22d5d87c21f974dd6208cafa5d3542bc8", size = 504492, upload-time = "2026-06-01T19:38:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/db/44c755232085545065c94378dfce38641b1aee647f4939fcd32f5b32e719/aiohttp-3.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f12eb7896e81caf403a2b18c9406426f1207361e7239c057ab29c076d4257e83", size = 1752111, upload-time = "2026-06-01T19:38:42.682Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6a/42e030a46743841414402a3b00cd3d78419055e86c66fb5822c14b5abfc6/aiohttp-3.14.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6c79a044cacf360ec46738d863d2f41c9300d2a06ef4a7402ea0df306a350e61", size = 1729674, upload-time = "2026-06-01T19:38:44.79Z" },
+    { url = "https://files.pythonhosted.org/packages/34/26/3199beb415202e3108e7b83ecebe10914d806d33fb9860c3e4aa60a19be3/aiohttp-3.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85e0675f47be4eff0636bf88c02140ea89168ae0df3ff1f3f464e9de9610d277", size = 1798808, upload-time = "2026-06-01T19:38:47.01Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/94/b9b6fcf0ee17c21d0d19fb8c22bf83ad18f82e702a9c3bd901a868f5e446/aiohttp-3.14.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b33e751cab03fdc960095b1e326cb5a03f5ee577d6ded59f3d1c100f8668882", size = 1891921, upload-time = "2026-06-01T19:38:49.233Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a3/3800dbd095cb2bb165a7ea5d94d790914677e27f45638c7d80e3f34c8945/aiohttp-3.14.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26d9224c6dd7f5c749aba4f61315a894601448b28d94d12f4dea0903e26d2096", size = 1777241, upload-time = "2026-06-01T19:38:52.04Z" },
+    { url = "https://files.pythonhosted.org/packages/21/2a/45be91ad1b860508557448d4cc2e165a2ee68dd865657b73bf66cc5a00fb/aiohttp-3.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6281aecdf2732940f4fe06bd6adec5ae4d59b78b080b8e3a6b81467301010988", size = 1579554, upload-time = "2026-06-01T19:38:54.508Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/dc94df99ed1511fdf28314f722643ed334112643cab00223577085e788c4/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:23e8314e7aed8576fbe33314d218bd81447a3adbc91dc36f1163bf583cd3084c", size = 1714864, upload-time = "2026-06-01T19:38:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e4/1f1c8acbb3acd5c8f795473b92c9c3d44eb60a5692c6104256c8a1c83a0c/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3b54fbff46127aeafdd764cecd0d99fa2f24a0e37ea5c18a7c3a4ac450df1db3", size = 1749803, upload-time = "2026-06-01T19:38:59.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c8/c45ea6e7ed84cebba939b9c334498a045ba19d79c61b0110df5f21580de3/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b27d89af91a555f58e08e4902dbcbc48862fd40095720ca705990476bd93b7ac", size = 1765023, upload-time = "2026-06-01T19:39:01.651Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a1/a932941784432962fe390e1066823aaef64b4e5ac9fa595df57b5fe472a9/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:25d2326a4967bf705a9f9913a13005e93b6020ad8a9f6bd6bd78850d5171332e", size = 1571671, upload-time = "2026-06-01T19:39:04.044Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/01/e1280feac522597a4d46eb67a0cdfa053cfae263033030b761ab146f29fb/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a1d209375c503472b3c0a340cdf3c55fcd82e84b46dda7caeaced59faba373ec", size = 1789904, upload-time = "2026-06-01T19:39:06.294Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/10/ab28818262f4d26bdb47ed5f1fc7999b69e2fc6e0370b02d0f49011f45ea/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:666c7c5036df57b693026398b69b41874a1931ac5b3485fd910e57bfac253869", size = 1754516, upload-time = "2026-06-01T19:39:08.788Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cc/c122eabd7a1b7e0c9bbdd6be60e4715905b858399145d9df872bb94f1427/aiohttp-3.14.0-cp313-cp313-win32.whl", hash = "sha256:23f094a1ef64823fd35854ddf5c7a80a078162f37f9d2f7c6142b51a6affa456", size = 448656, upload-time = "2026-06-01T19:39:11.171Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a5/bab07d79848a00eedd8ed979ccb302aaea3ac6eb9fa16bd0ed87135869b4/aiohttp-3.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:e03abdaa17d553f17e1d1d06bb266b3970106c78051d06795723e748d8e49d11", size = 475803, upload-time = "2026-06-01T19:39:13.439Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/f03ade8566c153666a3871afccbedf6d99911da006325e1fc6cf72a2de99/aiohttp-3.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:acdb400538cf4769543548bb5d1eb23d39bed4f96554a6078cb728c7cb2c268b", size = 443889, upload-time = "2026-06-01T19:39:15.945Z" },
+    { url = "https://files.pythonhosted.org/packages/28/03/5f36ab196a88ba5e9648ae5643e6531e67a3a8c0e96f9c6510ff41540fec/aiohttp-3.14.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:363ef9e91014e7891679bfb2ac0a7c6ea93435dbbfd10ecf41b9f06fcf506c5f", size = 503330, upload-time = "2026-06-01T19:39:18.195Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ce/8b49ec2f30f68e02f314f4832186cd45e583360a5a386058be36855d23b6/aiohttp-3.14.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:884a4edbdad77be9d0ef36142c8b504351b170df0bf62b51e784fadabf311c42", size = 509822, upload-time = "2026-06-01T19:39:20.396Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/fe/6edbf5d39bf29322b6816365b17ed8ede4dace164a3aea1abcd30110eb78/aiohttp-3.14.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:70ea956f6cc4a37620966b56c2e205d88ca3e6d85ec063277e414b1035cddad3", size = 483329, upload-time = "2026-06-01T19:39:22.607Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/5a/fae531bdbc6456fb6241f46b7b81e4d8a0dd3fc09118a0055dc7141ac1ec/aiohttp-3.14.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:ea3b9806c89f61da22fddf1f12dd524fb368e5e28f1261fbdafe5c3cd8ce893b", size = 489502, upload-time = "2026-06-01T19:39:24.881Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f4/48a7b0414db7fed77a03d5dde34508c026afd83510ab6bca08c313855776/aiohttp-3.14.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a071be341c2bd9b0188e62d173509f024e0a35b1c342c53c50f8daaeda8c3bd8", size = 497357, upload-time = "2026-06-01T19:39:27.197Z" },
+    { url = "https://files.pythonhosted.org/packages/75/75/e85a13a370acc007fca5feb1fd1b88ac2d8426e6dadd625479b7cadd55a3/aiohttp-3.14.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:198cfe61bf253b19da1fb3e0fa122249dc4f14c12709493fed8054aa0411cc76", size = 750898, upload-time = "2026-06-01T19:39:29.563Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/3d637f800c724eff0e2bed64df72557444482366fd0a35b0cec0e6968f6c/aiohttp-3.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9dc203d6ce6b9106d54e2a93f41dfdfebfbca2d99962ba503bfd3e5921a6549e", size = 506986, upload-time = "2026-06-01T19:39:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/df/35161f3598bf7501d2b2a805b41ab4f45a2e34150c421bcb4ef8c0d281a7/aiohttp-3.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9e19d17ab02bf16832a2c8c0d55a486792c5b1645665652ee9531aebcc30cb72", size = 508033, upload-time = "2026-06-01T19:39:34.137Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/39/b36e5d3d31e850fb4691dd3e941684ac490a2559249f6fa634b6b0fdf020/aiohttp-3.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d925fba0c14d5b498a8028b0107beebdfd16c5d48d702ff54f879cb017aaaca3", size = 1746213, upload-time = "2026-06-01T19:39:36.654Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/28/24e1409e605a9aa5d84abe0e2acb365354b70ae56d40948101cabe3341ab/aiohttp-3.14.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d33e61021222ce7f9792bcac870d6f58d8adfceda33ab857b01264f4560f2c5f", size = 1705862, upload-time = "2026-06-01T19:39:38.968Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d0/e5eb3ff1daeaf644c7e36a957517672494122628e067c38b263fa04eda77/aiohttp-3.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:44eca38755d0105bb32f47d085f5dd449846a449e1245fc105889e3279dcf8e3", size = 1798909, upload-time = "2026-06-01T19:39:41.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ba/8943f906f0570342886ababb9a722a44e360f786a028c5e0b0e29e3f735b/aiohttp-3.14.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f13087e06f68fea4941c21a0c541c00553aa16e4f8fd7bbe2b198df761e964d6", size = 1868892, upload-time = "2026-06-01T19:39:43.807Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/05/27df32c844b2156e1675a8d8ec22d963e3c8ba469ed7ceb1863320c7b521/aiohttp-3.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ff82be7f1ef73634cb77890a770743239bc3d487b848669be1c599889336dc0a", size = 1751659, upload-time = "2026-06-01T19:39:46.398Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/62/da182e5910ab912b2e88aa919b61a16046a37a95714a5795b02eb57b2d18/aiohttp-3.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a150c0875ac8fd87f1c398650841308a30d65facf7416b12dbdb9cfdcbe5a48c", size = 1578775, upload-time = "2026-06-01T19:39:48.902Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e3/53c67097e8a5ce98625e91e3fa7f43c9c6940de680345d03b3509a72a078/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:edc01ea4e1ec5a1649a28866262bf24195889ff7b27bdd947029a6086741de9b", size = 1710090, upload-time = "2026-06-01T19:39:51.392Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/55/0e2732ca598c7a4dfe8a775662376d0ca2977cb1030e48386d4da5d9a456/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:540632bf882ff8fc88f2e1697be0761578e89e0d79fb4a8a6d65dc5da7e729d4", size = 1715016, upload-time = "2026-06-01T19:39:53.807Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/f0b73730798c9ca525afc30b39f1f81bbe24e245d9654c54d3b39d63212d/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:860a86bc2c80237f5dff52edcf427e10a8d8352271fd84845429a3e60199e02c", size = 1763810, upload-time = "2026-06-01T19:39:56.31Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cc/11acb6c4518f448323405a7312b6f255d0f974a34373ad1db7633c4aadc8/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cbd50e6a50d6b99283a826b18cbdebf65b0797689a7535cb0e9dd37be0f63c3", size = 1573064, upload-time = "2026-06-01T19:39:58.718Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/28c31dde0a7dc98c0ee7d0da2ddcec3f7688c4fc131e5989e278d0c03c0a/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:20144819e99db593e22bbd2f3f2691a5e149f879142d6b8670254708853ff4fb", size = 1775765, upload-time = "2026-06-01T19:40:01.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/155c4ef3aec96417d47024800472b33b16c5d8a665371dcd044c2afdf25d/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:26b6d79aa54cb4ed50cc7d41ed14e99e0f1fc8e7c2d42f2e05b37aea897b2b52", size = 1733716, upload-time = "2026-06-01T19:40:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/44/6126116fd8a316b712bb615660b855c78466bb67ba1bb1742427eafcf7ac/aiohttp-3.14.0-cp314-cp314-win32.whl", hash = "sha256:106ed074a856f3e21d186b8579e2c8afb6da598e267cdaab01059e13db2fc44d", size = 453684, upload-time = "2026-06-01T19:40:06.277Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d7/eff4c58a88c5cac5e38b55f44fb8a6d3929c3cbd77356e383e094d3220bd/aiohttp-3.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f770846edae8f00ecc57af825bce811f787f87a7dcf0e90d191790efe5b31f7", size = 481758, upload-time = "2026-06-01T19:40:08.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ed/17b5bd9fbcb46e688f02e572f517754a9a75831e7b54702f027761dc4fa5/aiohttp-3.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:acf1581c4f21ed4b80a2dded504d87b055a071a84d5737ea966435f768275ac6", size = 450557, upload-time = "2026-06-01T19:40:11.03Z" },
+    { url = "https://files.pythonhosted.org/packages/12/34/6180103ce9aabc8ebff3f7bb55a1228ffe60f61042823031d9692cb7b101/aiohttp-3.14.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6aa1a40f9cbb3da9f80714c5966b8946c21e6a2530d809b9498b33161e3c8733", size = 787878, upload-time = "2026-06-01T19:40:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e9/08954a40e8b7baa3d8beadd2b074b186e9b1e9c8ddabc288678a6265de50/aiohttp-3.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b62af5a8cc96a194eaa01a9ed7b34a3ffa58d3d8daaa1a0d7a749353ad12d228", size = 524400, upload-time = "2026-06-01T19:40:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6a/b5965a634ac4d5ba99a463314cf4ab214ca073fcdc38a15e0294273701fc/aiohttp-3.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6eb63b1417efaf7d1002a6ad034a40d44376afcc16508a57f8e74b49ad26a095", size = 527904, upload-time = "2026-06-01T19:40:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b4/932bcdd850c354d9bcca30f360e475d7852e30413fbbd44b182782ed5432/aiohttp-3.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c20b9ad156a79eb97be5cf9e069eec01d2f0dc8472ffbd75299a8b2d4c2cbbde", size = 1912162, upload-time = "2026-06-01T19:40:20.825Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/85/ce79bab0310d2e3fd2d7bc7e44412abeff7c8338f8a21dd0f2f1714989e5/aiohttp-3.14.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:40ae7b0642c25632c7eabc4a04754012691864d2a1b93becf7cddb76027b838a", size = 1778813, upload-time = "2026-06-01T19:40:23.726Z" },
+    { url = "https://files.pythonhosted.org/packages/05/54/ba62ac2d1bc87e010aad23751e383b8794e45d931df67677313a2da78823/aiohttp-3.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95f5217e76a046b9f228a101717ef8d42b1eb3d9d196d15202db5bf41df88936", size = 1899969, upload-time = "2026-06-01T19:40:26.406Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/7cc7907725d83a19f31551334061e1ab8e108b1d7ac52632a2a844a4acb5/aiohttp-3.14.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1a4a9f17e85b80878c176695c1998c790e83731d8271881e5d356488652a1f9e", size = 1991771, upload-time = "2026-06-01T19:40:29.061Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1c/a57de71a4508c93a830b77c28af3d08cd97f606dedfc6b94275347744508/aiohttp-3.14.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:145262119b07d7f95abc1839add35ba2bfc84551d4b4660ca11542c0b215455b", size = 1868606, upload-time = "2026-06-01T19:40:31.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ae/3839726cd49150a53ed340cc24ce5ba09d4c2117020ef9d45542bec5eb2f/aiohttp-3.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:49a33ded29b0b2fa7a367a02cf0fb89af602bb87542a16177ec8ce1c9c51d12a", size = 1665437, upload-time = "2026-06-01T19:40:35.01Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1e/c237923232c7da7f0392ea25d89fc5e60c0e93f685f4ebca8e7bcdd5271c/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cc736a9c9fc2bc4dd71fd404815741b6573df27c3f985948ec4076989ac57de", size = 1834090, upload-time = "2026-06-01T19:40:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/98/02/a5a7a2524f92d3911761b405a7c067c751891942144adc13e2ad79611e39/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b4141a3e5342ee3053a9cab54d25b64ed28289c1041e4c54b3d99839314d90ce", size = 1816907, upload-time = "2026-06-01T19:40:40.46Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/76/a8b9f0d09234d516af9f2d7dd715557f33b5da3b0b56ead41d1170e86e3c/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:e30871b2d58996cb81aac52d2b1d15ac05257131ef0f90f18c2115a380fbfe7c", size = 1840382, upload-time = "2026-06-01T19:40:43.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8e/140e715a0a4bbc211979ea30ec8396ad2ed5bf90ab87d8058fc4668b1923/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:667b881d083ccae3900ea5a241e17e5007ca78844c53ed389bb63d48f729d9c7", size = 1659497, upload-time = "2026-06-01T19:40:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c7/7ba5de8af9650b9767b063c675427b8685f43fa7ce563673a7bc3af60f08/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:b584dfe615d151e9b8f0a8ecb3aee6147f2927ec5b95ba25fe621f5377510928", size = 1870829, upload-time = "2026-06-01T19:40:49.583Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/2aaab2f85cadb26ea59c091fa2b8e370d625154b5c14b478f1b489d07551/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6199707cc40e0e9cd39c36fbc97bec416c704e1d0ddce03412bb3b3e6a90ccd0", size = 1832281, upload-time = "2026-06-01T19:40:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/39/98/31b9ad9fbc01f0075ee7221002df5fd2d10b647f451ca5f30edc802d9dd6/aiohttp-3.14.0-cp314-cp314t-win32.whl", hash = "sha256:a8d93334d4961c9d566b1f046c81dee475b7c21eb730728d38237bfa70d1c8e6", size = 490597, upload-time = "2026-06-01T19:40:54.937Z" },
+    { url = "https://files.pythonhosted.org/packages/59/1f/299b21441c8de42ff70fddc7cfe65e92f810abcf740739a09b56f7835364/aiohttp-3.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d2ffe9b614f50f069068b3b52e73414e4107fc10b7efc939a76acff9251fdd2", size = 525789, upload-time = "2026-06-01T19:40:57.306Z" },
+    { url = "https://files.pythonhosted.org/packages/70/11/7f83fcba9ee05d4c54d61b3f8104da0d43a59adac44dd28effc0c9a10422/aiohttp-3.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7a3fc4358e65826c515350f199c210de747cf669998211b1ee6c2e46de364b24", size = 467399, upload-time = "2026-06-01T19:40:59.993Z" },
 ]
 
 [[package]]
@@ -167,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.100.0"
+version = "0.105.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -179,9 +194,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
+    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
 ]
 
 [[package]]
@@ -1298,7 +1313,7 @@ wheels = [
 
 [[package]]
 name = "fachuan-backend"
-version = "26.50.4"
+version = "26.51.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1354,6 +1369,7 @@ dependencies = [
     { name = "watchdog" },
     { name = "watchfiles" },
     { name = "weasyprint" },
+    { name = "webdavclient3" },
     { name = "xlrd" },
 ]
 
@@ -1420,7 +1436,7 @@ requires-dist = [
     { name = "psutil", specifier = "==7.2.2" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pydantic", specifier = "==2.13.3" },
-    { name = "pydantic-ai", extras = ["mcp"], specifier = "==1.90.0" },
+    { name = "pydantic-ai", extras = ["mcp"], specifier = "==1.105.0" },
     { name = "pymupdf", specifier = "==1.27.2.3" },
     { name = "pyobjc-framework-eventkit", marker = "sys_platform == 'darwin'", specifier = ">=12.0" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
@@ -1436,6 +1452,7 @@ requires-dist = [
     { name = "watchdog", specifier = "==6.0.0" },
     { name = "watchfiles", specifier = "==1.1.1" },
     { name = "weasyprint", specifier = ">=68.1" },
+    { name = "webdavclient3", specifier = ">=3.14.7" },
     { name = "xlrd", specifier = ">=2.0.1" },
 ]
 
@@ -1528,35 +1545,63 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/519739e98daf92ebc64580e9d3320649bf9a1612c029a913dd88c3474d73/fastmcp-3.4.0.tar.gz", hash = "sha256:29055fb6816f4862c615aabaf0112ae8feb8b469740db13403a0ce5b799ec1dc", size = 28754939, upload-time = "2026-06-03T02:32:40.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/72/9f9bbfc3a8d26870dbdbbd633cd1c6f42b8d3bec379426c760676d936e86/fastmcp-3.4.0-py3-none-any.whl", hash = "sha256:34523083d6149400a0655a8aa769eb34f85b1ce6dac6d66efb07503ebbe5f44b", size = 8017, upload-time = "2026-06-03T02:32:38.05Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/4da6078c2d6aa0a38a8b1ae0271e1ed400f9e2cd1b3b46e6453fb1fe2b75/fastmcp_slim-3.4.0.tar.gz", hash = "sha256:faa0ccf16e85ec4b9f79c006fed3546b866d7e6dba3f60cd32cd98e84753a496", size = 575895, upload-time = "2026-06-03T02:32:18.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/66/cc283d4efd3faf325c26f51cfb43a118270ea732e70dda509f49d80ea625/fastmcp_slim-3.4.0-py3-none-any.whl", hash = "sha256:17cd0a1535972d3748d8c2416f0826dfc86c18df7a6cbc38602373277d44baa6", size = 748849, upload-time = "2026-06-03T02:32:17.435Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -1947,34 +1992,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.5.0"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
-    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
-    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
-    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
-    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
-    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
-    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
-    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
 ]
 
 [[package]]
@@ -3996,19 +4041,19 @@ email = [
 
 [[package]]
 name = "pydantic-ai"
-version = "1.90.0"
+version = "1.105.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "spec", "temporal", "ui", "vertexai", "xai"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/21/aa63a8b137a3400970ec12f5f040303321e532d859723d5fffd5b5ce6460/pydantic_ai-1.90.0.tar.gz", hash = "sha256:9c00884d5fc46df4ec8a7f393c9aae4936948ca0ea72e7f8fbc5c704b8af5516", size = 13063, upload-time = "2026-05-05T00:51:02.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/b5/f9d3333b994a626e8dc2db49eacd24f7f16bf1810664f5ffd5918f57781a/pydantic_ai-1.105.0.tar.gz", hash = "sha256:f4f4ecd357c0f13f97ce5976e0bd29c98cc1d08b68c1477cf9711c96853c8120", size = 18368, upload-time = "2026-06-02T06:19:59.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/a5/d6f4ae7f15b13dc6ffccd9aa5e0c093da355267ef354755fb206d64e3f8e/pydantic_ai-1.90.0-py3-none-any.whl", hash = "sha256:530985297ef5aada9c4480fd416f457a21cc19d6caed88c7652c85da620b6952", size = 7577, upload-time = "2026-05-05T00:50:52.634Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5e/19cd865dd7e356ca6f43ae761421f27dbcfb658bf0ccc294eeeb35563819/pydantic_ai-1.105.0-py3-none-any.whl", hash = "sha256:186d2735a7c424e2cf9bb8f1c74684e08d07f5e06adae4cf43c6e24ab619a5e6", size = 7587, upload-time = "2026-06-02T06:19:49.795Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.90.0"
+version = "1.105.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -4019,9 +4064,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/1a/8d27dd7f4b34a1ed78900943a0933c4c7e290cfe238f80d9e8fc8fe4c1b1/pydantic_ai_slim-1.90.0.tar.gz", hash = "sha256:39e6c8eca29436a6aa9a7440852cb80081ebd54d49b91a1dfbc18dd4a6da77a0", size = 616448, upload-time = "2026-05-05T00:51:04.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/ae/1b0370f9b9f1ca7ccf2e6b51ec5a8d11da11d9dd621e5eb015c6420c5e9b/pydantic_ai_slim-1.105.0.tar.gz", hash = "sha256:8b4ad8034b40ab3bde8e0c6285082a204ecd203007150a47943f192b474e06e9", size = 772048, upload-time = "2026-06-02T06:20:01.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/3d/39ddaaee36de205969b3a09a73ee1dde9c9f4c106a711a2c18fcd3009a6a/pydantic_ai_slim-1.90.0-py3-none-any.whl", hash = "sha256:4916258f5a422e5aace4cc5285fa55e7cc332939109594f2c1ff9a5f59be4104", size = 782077, upload-time = "2026-05-05T00:50:55.905Z" },
+    { url = "https://files.pythonhosted.org/packages/12/6e/8afdff693d21c0743ee71d792ce90afc27d4ddbaf7270d969a84452cfd0d/pydantic_ai_slim-1.105.0-py3-none-any.whl", hash = "sha256:1e65561ba9a58a9d8fc3a63b550c3c2b2c4017da275dea78291e526aa06298d8", size = 956108, upload-time = "2026-06-02T06:19:52.821Z" },
 ]
 
 [package.optional-dependencies]
@@ -4058,13 +4103,14 @@ groq = [
     { name = "groq" },
 ]
 huggingface = [
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "huggingface-hub" },
 ]
 logfire = [
     { name = "logfire", extra = ["httpx"] },
 ]
 mcp = [
-    { name = "mcp" },
+    { name = "fastmcp-slim", extra = ["client"] },
 ]
 mistral = [
     { name = "mistralai" },
@@ -4171,7 +4217,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-evals"
-version = "1.90.0"
+version = "1.105.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4181,14 +4227,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/95/cae334e7d6a8b5723a6d449c24b83a47d94d941da90304b4b0fa0812a7d2/pydantic_evals-1.90.0.tar.gz", hash = "sha256:0bc676554b9f2c4e487f5e2bacb2d22ddb96390ebe0d85f62855cd1678491ed7", size = 76570, upload-time = "2026-05-05T00:51:05.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/9a/aa1b99d2600aa61365f792bd093ca9eb39d75a2223bcb699d64e6cc1c3bf/pydantic_evals-1.105.0.tar.gz", hash = "sha256:9a12b1062329fbc26ca2b75e30c79bf0938146ed3e080a082d36442428bf4926", size = 78534, upload-time = "2026-06-02T06:20:04.047Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/86/fa7b0a13f3e132198571f46702ff8fed31872e416f23619857b2aba4349d/pydantic_evals-1.90.0-py3-none-any.whl", hash = "sha256:d3b78775b90ad4c8e68c3cfaa7fe643492a2908bbb092333fadfbb50bc63bada", size = 91528, upload-time = "2026-05-05T00:50:58.16Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ea/7e3da28a264e9d63628f419fcc15d81777e1261c61f85176f9210b196838/pydantic_evals-1.105.0-py3-none-any.whl", hash = "sha256:990a5d46255c43dbf2e04c3143f4c25212f492357259f7b358ffc5ef3d2625ff", size = 93531, upload-time = "2026-06-02T06:19:55.586Z" },
 ]
 
 [[package]]
 name = "pydantic-graph"
-version = "1.90.0"
+version = "1.105.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -4196,9 +4242,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/19/2cb30b5dd3ad367b838dbc858d63b428a36fd371ef1e19c831d04e0b23ee/pydantic_graph-1.90.0.tar.gz", hash = "sha256:30d69bb491599612ad88a5122ebf4a10a000eae8f89abb8910f1532bead23cc5", size = 59253, upload-time = "2026-05-05T00:51:07.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/98/0361e1eb28f8d107e4e12dcd2d14eabef55f4a8ca18b1a6f185df74934c0/pydantic_graph-1.105.0.tar.gz", hash = "sha256:3f5cf97d544b900098d3cc2dbd6a8cdd79ea59dac610d7651f86c9228d33c0b9", size = 62570, upload-time = "2026-06-02T06:20:05.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/09/7f86467a2a113b7dbaa415bb068972401a8c66db310de38dd8ef755e573a/pydantic_graph-1.90.0-py3-none-any.whl", hash = "sha256:0845d5726f95a63e89342bcf8236c8a660d616b7e5a30d8aa2c9a731f96018ed", size = 73066, upload-time = "2026-05-05T00:50:59.911Z" },
+    { url = "https://files.pythonhosted.org/packages/be/1b/13882fd4d70299dc2995bee20f21599cb8d453b27f44e239f82384d4ea3f/pydantic_graph-1.105.0-py3-none-any.whl", hash = "sha256:ba76d77ad21a13f2961fbda9d988f3d5a3d9ffc1817ee912e0ea59b0b5a9e825", size = 80099, upload-time = "2026-06-02T06:19:57.098Z" },
 ]
 
 [[package]]
@@ -5672,6 +5718,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/3e/65c0f176e6fb5c2b0a1ac13185b366f727d9723541babfa7fa4309998169/weasyprint-68.1.tar.gz", hash = "sha256:d3b752049b453a5c95edb27ce78d69e9319af5a34f257fa0f4c738c701b4184e", size = 1542379, upload-time = "2026-02-06T15:04:11.203Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/dd/14eb73cea481ad8162d3b18a4850d4a84d6e804a22840cca207648532265/weasyprint-68.1-py3-none-any.whl", hash = "sha256:4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be", size = 319789, upload-time = "2026-02-06T15:04:09.189Z" },
+]
+
+[[package]]
+name = "webdavclient3"
+version = "3.14.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/d8/ca3981053ed553363322f71745f543186b93439b6417f5d6ca91d4b4fec7/webdavclient3-3.14.7.tar.gz", hash = "sha256:6c04252b579bc015cec78081480c63eadf1030f382768248777c6203f059b3f5", size = 30836, upload-time = "2026-02-06T17:54:15.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/5e/0b1c2f494d03c4acbc44567fa68b954cd0fa3f21eb3f9528011da371f9b1/webdavclient3-3.14.7-py3-none-any.whl", hash = "sha256:a904381da8e3ae77b4ca9e11e05058d91a07704254d71c193c797f7c2fb15025", size = 22887, upload-time = "2026-02-06T17:54:14.068Z" },
 ]
 
 [[package]]

--- a/frontend/src/features/cases/components/CaseFolderSection.tsx
+++ b/frontend/src/features/cases/components/CaseFolderSection.tsx
@@ -127,9 +127,14 @@ export function CaseFolderSection({ binding, caseId }: CaseFolderSectionProps) {
     try {
       const session = await mutations.startFolderScan.mutateAsync({})
       setScanSession(session)
-      toast.success('扫描完成')
-    } catch {
-      toast.error('扫描失败')
+      if (session.status === 'failed' && session.error_message) {
+        toast.error(`扫描失败: ${session.error_message}`)
+      } else {
+        toast.success('扫描完成')
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '扫描失败'
+      toast.error(msg)
     } finally {
       setScanning(false)
     }
@@ -146,7 +151,10 @@ export function CaseFolderSection({ binding, caseId }: CaseFolderSectionProps) {
           setScanSession(null)
           setSelectedCandidates(new Set())
         },
-        onError: () => toast.error('导入失败'),
+        onError: (e: unknown) => {
+          const msg = e instanceof Error ? e.message : '导入失败'
+          toast.error(msg)
+        },
       },
     )
   }
@@ -251,6 +259,13 @@ export function CaseFolderSection({ binding, caseId }: CaseFolderSectionProps) {
         <div className="space-y-1.5">
           <Progress value={undefined} className="h-1.5" />
           <p className="text-[11px] text-muted-foreground text-center">正在扫描文件夹...</p>
+        </div>
+      )}
+
+      {/* Scan error message */}
+      {scanSession && scanSession.error_message && (
+        <div className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">
+          {scanSession.error_message}
         </div>
       )}
 

--- a/frontend/src/features/cases/types.ts
+++ b/frontend/src/features/cases/types.ts
@@ -469,6 +469,7 @@ export interface FolderScanSession {
   status: string
   progress: number
   current_file: string
+  error_message: string
   summary: Record<string, unknown>
   candidates: FolderScanCandidate[]
 }

--- a/frontend/src/features/contracts/components/FolderScanPanel.tsx
+++ b/frontend/src/features/contracts/components/FolderScanPanel.tsx
@@ -21,7 +21,10 @@ export function FolderScanPanel({ contractId }: { contractId: number }) {
       const res = await startScan.mutateAsync({ rescan, subfolder: subfolder === '__root__' ? '' : subfolder })
       setSessionId(res.session_id)
       toast.success('扫描已启动')
-    } catch { toast.error('启动失败') }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '启动失败'
+      toast.error(msg)
+    }
   }, [startScan, subfolder])
 
   const handleConfirm = useCallback(async () => {
@@ -33,7 +36,10 @@ export function FolderScanPanel({ contractId }: { contractId: number }) {
       const res = await confirmScan.mutateAsync({ sessionId, items })
       toast.success(`已导入 ${res.imported_count} 个文件`)
       setSessionId(null)
-    } catch { toast.error('确认失败') }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '确认失败'
+      toast.error(msg)
+    }
   }, [sessionId, status, candidates, confirmScan])
 
   const toggleCandidate = (idx: number) => {


### PR DESCRIPTION
## Summary

完成云存储抽象层的全链路改造，使坚果云 WebDAV、OneDrive 和本地文件系统三种存储后端在扫描→导入→版本号→案卷生成→邮件导入的完整业务流程中均可正常使用。同时修复抽象层安全漏洞和依赖 CVE。

### 核心改动

**抽象层加固（P0 安全）**
- LocalProvider 路径逃逸防护（`_resolve()` + `walk()` 均限制在 root 内）
- NullProvider 替代静默降级（缺失账号时抛明确错误而非 fallback 到本地文件系统）
- OneDrive 根目录 URL 修复（`_item_url`/`_children_url` 空路径处理）

**Phase 1：扫描→导入管道**
- `confirm_import` 支持 `storage_provider` 参数，云文件通过 `provider.read_file()` 读取
- 新增 `compute_file_hash_from_bytes()` 支持云存储哈希计算
- `_collect_docx_files` 新增云存储变体（`provider.walk()` + 名称去重）
- `_mark_already_imported` 支持云存储哈希比对
- 案件 `stage_to_attachments` 支持云存储文件读取

**Phase 2：版本号 + 案卷生成**
- `_get_next_version` 使用 `provider.walk()` 递归搜索版本文件（兼容日期子目录结构）
- `generate_archive_folder` 云存储模式：临时目录操作 → 最后上传到云存储

**Phase 3：邮件附件导入**
- `email_folder_scan_service` 全部 5 个方法支持云存储
- Admin mixin GET 分支支持云存储目录列表

**限流错误提示**
- 新增 `CloudStorageError`/`CloudStorageRateLimitError` 异常类
- WebDAV 503 时抛出明确的中文提示（而非静默返回空或通用"系统错误"）
- 前端扫描面板显示 `error_message`，toast 显示服务端错误详情

**依赖漏洞修复**
- pyjwt 2.12.1→2.13.0, starlette 1.0.0→1.2.1, aiohttp 3.13.5→3.14.0, pydantic-ai 1.90.0→1.105.0

## Test plan

### 单元测试
- 481 个单元测试全部通过
- 新增 49 个测试覆盖：路径逃逸、NullProvider、bytes 哈希、云存储 docx 收集、browse_helper、版本号、OneDrive root

### E2E 业务场景测试（85 项）

| 场景 | 坚果云 | OneDrive | 本地 |
|:---|:---:|:---:|:---:|
| 扫描→导入→哈希去重 | ✅ | ✅ | ✅ |
| 案卷生成（5文件上传） | ✅ | ✅ | - |
| 版本号 V1→V2 | ✅ | ✅ | - |
| 邮件导入+去重 | ✅ | - | - |
| 503限流错误提示 | ✅ | - | - |
| 路径逃逸防护 | - | - | ✅ |
| folder-browse API | ✅ | - | ✅ |

### CI
- 13/13 全部通过（ruff, mypy, tsc, eslint, vite-build, pytest, bandit, pip-audit）

### 13 个 Commit
```
6cbc66cb fix: upgrade vulnerable dependencies (pip-audit clean)
ec1ea7d0 fix: resolve mypy type errors in cloud storage modules
fbf3fb10 feat: improve cloud storage error messages for rate limiting
fdb07ece fix: LocalProvider._resolve() path comparison on macOS
c7630dc9 feat: cloud storage support for email folder import (Phase 3)
472949fe fix: OneDrive _item_url/_children_url broken for root path
7d4cebf9 fix: use provider.walk() instead of list_directory() for version numbering
9a108585 feat: cloud storage support for version numbering and archive generation (Phase 2)
117685dd fix: rename 'filename' to 'file_name' in logger extra dicts
73627f5d test: add Phase 1 cloud storage import pipeline unit tests
9dc433a7 feat: cloud storage support for scan-to-import pipeline (Phase 1)
1e17413c test: add comprehensive unit tests for cloud storage hardening
583ac093 fix: cloud storage abstraction layer hardening