### PR TITLE
fix: court_sms admin format_html() 无参调用导致 Django 6.0 TypeError

### DIFF
--- a/backend/apps/automation/admin/sms/court_sms_admin_base.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_base.py
@@ -478,10 +478,10 @@ class CourtSMSAdminBase(admin.ModelAdmin):
     def recommended_cases_display(self, obj: CourtSMS) -> SafeString:
         """推荐关联案件卡片（AJAX 加载 + Select2 集成）"""
         if not obj.id:
-            return format_html('<span style="color:#999;">保存后可查看推荐案件</span>')
+            return mark_safe('<span style="color:#999;">保存后可查看推荐案件</span>')
 
         if not (obj.case_numbers or obj.party_names):
-            return format_html(
+            return mark_safe(
                 '<p style="color:#999;margin:8px 0;">短信中未提取到案号或当事人信息，无法推荐关联案件。'
                 "请使用上方的搜索框手动查找。</p>"
             )


### PR DESCRIPTION
## 问题

访问 `/admin/automation/courtsms/<id>/change/` 时报错：

```
TypeError: args or kwargs must be provided
  django/utils/html.py, line 137, in format_html
```

## 根因

Django 6.0 对 `format_html()` 增加了安全校验：**必须传 `*args` 或 `**kwargs`**，纯静态字符串不再允许（防止开发者误把 `format_html(user_input)` 当 `mark_safe()` 用导致 XSS）。

`recommended_cases_display` 方法中有两处调用了 `format_html("静态HTML")` 但没有传任何格式化参数，导致触发该异常。

## 修复

将两处纯静态 HTML 的 `format_html()` 替换为 `mark_safe()`：

- `apps/automation/admin/sms/court_sms_admin_base.py` 第 481 行
- `apps/automation/admin/sms/court_sms_admin_base.py` 第 484 行

这两处均不包含用户数据插值，使用 `mark_safe()` 是安全且正确的做法。