### PR TITLE
feat: 江西电子送达平台 + 道律平台架构重构 (v26.52.10)

### DIFF
--- a/backend/apps/automation/admin/sms/court_sms_admin_base.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_base.py
@@ -618,6 +618,7 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
                             "<span title='sd.gdems.com'>睿法智达</span>"
                             "<span title='jysd.10102368.com'>集约送达</span>"
                             "<span title='dzsd.hbfy.gov.cn'>湖北电子送达</span>"
+                            "<span title='sfsd.jxfy.gov.cn'>江西电子送达</span>"
                             "<span title='sfpt.cdfy12368.gov.cn'>司法送达网</span>"
                             "<span title='171.106.48.55:28083'>广西法院短信平台</span>"
                             "</div>"

--- a/backend/apps/automation/api/court_sms_api.py
+++ b/backend/apps/automation/api/court_sms_api.py
@@ -150,7 +150,8 @@ def retry_processing(request: Any, sms_id: int) -> CourtSMSSubmitOut:  # pragma:
     """
     重新处理短信
 
-    重置状态并重新执行完整处理流程
+    如果短信已手动绑定案件，保留关联，仅重新执行下载/重命名/通知流程。
+    否则重置全部状态，重新执行完整处理流程（含匹配）。
     """
     service = _get_court_sms_service()
 

--- a/backend/apps/automation/services/scraper/scrapers/court_document/daolv_sifa_songda_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/daolv_sifa_songda_scraper.py
@@ -1,0 +1,356 @@
+"""
+道律「司法送达网」平台共享基类
+
+上海道律信息技术有限公司的电子送达系统，湖北、江西等省份共用同一套接口，
+仅域名不同。本基类提取账号密码登录模式的全部共享逻辑，子类只需声明域名
+常量和少量差异（如密码正则）。
+
+子类:
+  - HbfyCourtScraper（湖北电子送达 dzsd.hbfy.gov.cn）
+  - JxfyCourtScraper（江西电子送达 sfsd.jxfy.gov.cn）
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urljoin, urlparse
+
+import requests
+
+from apps.automation.services.scraper.core.captcha_recognizer import CaptchaRecognizer
+
+from .base_court_scraper import BaseCourtDocumentScraper
+
+logger = logging.getLogger("apps.automation")
+
+
+class DaolvSifaSongdaScraper(BaseCourtDocumentScraper):  # pragma: no cover
+    """道律司法送达网平台共享基类
+
+    子类必须覆写的类属性:
+      - _DOMAIN:           平台域名（如 "dzsd.hbfy.gov.cn"）
+      - _LOGIN_PAGE_URL:   登录页完整 URL
+      - _CAPTCHA_IMAGE_URL ~ _LIST_URLS: 接口地址
+      - _PASSWORD_PATTERN: 密码正则（各省短信格式不同）
+
+    可选覆写:
+      - _ACCOUNT_PATTERN:  账号正则（默认匹配 15-20 位数字）
+      - _PLATFORM_LABEL:   平台中文名（用于日志和错误信息，默认 "道律"）
+    """
+
+    # ── 子类必须覆写 ────────────────────────────────────────────
+    _DOMAIN: str = ""
+    _LOGIN_PAGE_URL: str = ""
+    _CAPTCHA_IMAGE_URL: str = ""
+    _CAPTCHA_CHECK_URL: str = ""
+    _LOGIN_URL: str = ""
+    _MAIN_URL: str = ""
+    _LIST_URLS: tuple[str, ...] = ()
+    _PASSWORD_PATTERN: re.Pattern[str] = re.compile(r"")
+
+    # ── 子类可选覆写 ────────────────────────────────────────────
+    _ACCOUNT_PATTERN: re.Pattern[str] = re.compile(r"账号\s*([0-9]{15,20})")
+    _PLATFORM_LABEL: str = "道律"
+
+    def __init__(
+        self,
+        task: Any,
+        captcha_recognizer: CaptchaRecognizer | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(task, **kwargs)
+        if captcha_recognizer is None:
+            from apps.automation.services.scraper.core.captcha_recognizer import get_captcha_recognizer
+
+            self.captcha_recognizer: CaptchaRecognizer = get_captcha_recognizer(task=self.task)
+        else:
+            self.captcha_recognizer = captcha_recognizer
+
+    # ── 账号密码模式 ──────────────────────────────────────────────
+
+    def _run_account_mode(self, *, source_domain: str) -> dict[str, Any]:  # pragma: no cover
+        label = self._PLATFORM_LABEL
+        logger.info("开始处理%s账号密码链接: %s", label, self.task.url)
+        download_dir = self._prepare_download_dir()
+
+        task_config = self.task.config if isinstance(self.task.config, dict) else {}
+        account, login_secret = self._resolve_account_credentials(task_config)
+
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                ),
+                "Referer": self._LOGIN_PAGE_URL,
+            }
+        )
+
+        self._login_account_session(session, account, login_secret)
+
+        all_entries: list[dict[str, str]] = []
+        for list_url in self._LIST_URLS:
+            all_entries.extend(self._fetch_record_entries(session, list_url))
+
+        dedup_entries: list[dict[str, str]] = []
+        seen_ids: set[str] = set()
+        for item in all_entries:
+            doc_id = item.get("id", "")
+            if not doc_id or doc_id in seen_ids:
+                continue
+            seen_ids.add(doc_id)
+            dedup_entries.append(item)
+
+        if not dedup_entries:
+            raise ValueError(f"{label}账号模式登录成功，但未发现可查阅文书")
+
+        files: list[str] = []
+        errors: list[str] = []
+        for item in dedup_entries:
+            doc_id = item.get("id", "")
+            title = item.get("title", "未命名文书")
+            try:
+                filepath = self._download_record_document(session, doc_id, title, download_dir)
+                if filepath:
+                    files.append(filepath)
+            except Exception as exc:
+                errors.append(f"{doc_id}:{exc}")
+                logger.warning("下载%s文书失败 id=%s, error=%s", label, doc_id, exc)
+
+        if not files:
+            raise ValueError(f"{label}账号模式未下载成功，失败原因: {'; '.join(errors[:3])}")
+
+        return {
+            "source": source_domain,
+            "mode": "account_http",
+            "files": files,
+            "document_count": len(dedup_entries),
+            "downloaded_count": len(files),
+            "failed_count": max(0, len(dedup_entries) - len(files)),
+            "errors": errors,
+            "message": f"{label}账号模式下载成功: {len(files)}/{len(dedup_entries)} 份",
+        }
+
+    # ── 凭证解析 ─────────────────────────────────────────────────
+
+    def _extract_account_credentials_from_content(self, content: str) -> tuple[str, str]:  # pragma: no cover
+        account_match = self._ACCOUNT_PATTERN.search(content)
+        password_match = self._PASSWORD_PATTERN.search(content)
+        account = account_match.group(1).strip() if account_match else ""
+        login_secret = password_match.group(1).strip() if password_match else ""
+        return account, login_secret
+
+    def _resolve_account_credentials(self, task_config: dict[str, Any]) -> tuple[str, str]:  # pragma: no cover
+        """解析账号模式凭证。
+
+        优先从 task_config 读取平台专属 key，其次尝试通用 hbfy_* key
+        （兼容历史配置），最后从 CourtSMS 短信内容中正则提取。
+        """
+        label = self._PLATFORM_LABEL
+        # 子类可通过覆写 _CREDENTIAL_CONFIG_KEYS 自定义配置 key
+        config_keys = getattr(self, "_CREDENTIAL_CONFIG_KEYS", ("hbfy_account", "hbfy_password"))
+        account_key, password_key = config_keys[0], config_keys[1]
+
+        account = str(task_config.get(account_key) or "").strip()
+        login_secret = str(task_config.get(password_key) or "").strip()
+        if account and login_secret:
+            return account, login_secret
+
+        # 兼容通用 hbfy_* key
+        if account_key != "hbfy_account":
+            account = account or str(task_config.get("hbfy_account") or "").strip()
+            login_secret = login_secret or str(task_config.get("hbfy_password") or "").strip()
+            if account and login_secret:
+                return account, login_secret
+
+        sms_id_raw = task_config.get("court_sms_id")
+        sms_id_text = str(sms_id_raw).strip() if sms_id_raw is not None else ""
+        try:
+            sms_id = int(sms_id_text) if sms_id_text else 0
+        except ValueError:
+            sms_id = 0
+
+        if sms_id > 0:
+            try:
+                from apps.automation.models import CourtSMS
+
+                sms = CourtSMS.objects.only("content").get(id=sms_id)
+                account, login_secret = self._extract_account_credentials_from_content(sms.content)
+            except Exception as exc:
+                logger.warning("%s账号模式读取短信凭证失败: sms_id=%s, error=%s", label, sms_id, exc)
+
+        if not account or not login_secret:
+            raise ValueError(f"{label}账号模式缺少账号或密码，请在短信中提供账号和密码")
+
+        return account, login_secret
+
+    # ── 登录 ─────────────────────────────────────────────────────
+
+    def _login_account_session(self, session: requests.Session, account: str, login_secret: str) -> None:  # pragma: no cover
+        label = self._PLATFORM_LABEL
+        landing = session.get(self._LOGIN_PAGE_URL, timeout=20)
+        if landing.status_code >= 500:
+            raise ValueError(f"打开{label}登录页失败: {landing.status_code}")
+
+        for _ in range(12):
+            timestamp = str(int(time.time() * 1000))
+            image_resp = session.get(f"{self._CAPTCHA_IMAGE_URL}?t={timestamp}", timeout=20)
+            if image_resp.status_code != 200:
+                continue
+
+            recognized = self.captcha_recognizer.recognize(image_resp.content)
+            captcha = re.sub(r"[^0-9A-Za-z]", "", recognized or "")
+            if not captcha:
+                continue
+
+            check_resp = session.post(
+                self._CAPTCHA_CHECK_URL,
+                data={"yzm": captcha, "t": timestamp},
+                timeout=20,
+            )
+            if check_resp.text.strip() != "1":
+                continue
+
+            salt = str(int(time.time() * 1000))
+            payload = {
+                "yzm": captcha,
+                "user.userCode": self._encode_user_code(account),
+                "user.loginPwd": self._encode_password(login_secret, salt),
+                "t": salt,
+            }
+            login_resp = session.post(self._LOGIN_URL, data=payload, timeout=20)
+            if login_resp.status_code != 200:
+                continue
+
+            try:
+                login_data = login_resp.json()
+            except (TypeError, ValueError):
+                continue
+
+            if bool(login_data.get("success")) and bool((login_data.get("message") or {}).get("result")):
+                session.get(self._MAIN_URL, timeout=20)
+                logger.info("%s账号模式登录成功", label)
+                return
+
+        raise ValueError(f"{label}账号模式登录失败（验证码或凭证不正确）")
+
+    # ── 文书列表 ─────────────────────────────────────────────────
+
+    def _fetch_record_entries(self, session: requests.Session, list_url: str) -> list[dict[str, str]]:  # pragma: no cover
+        resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
+        if resp.status_code >= 500:
+            time.sleep(1)
+            resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
+
+        if resp.status_code != 200:
+            return []
+
+        text = resp.text
+        pattern = re.compile(
+            r"<td\s+title=\"(?P<title>[^\"]*)\">.*?"
+            r"onclick=\"toViewInput\('(?P<id>[^']+)'\);return false;\"",
+            re.S,
+        )
+
+        entries: list[dict[str, str]] = []
+        for match in pattern.finditer(text):
+            title = html.unescape(match.group("title")).strip()
+            doc_id = match.group("id").strip()
+            if not doc_id:
+                continue
+            entries.append({"id": doc_id, "title": title or "未命名文书"})
+
+        logger.info("列表页 %s 发现文书条目: %s", list_url, len(entries))
+        return entries
+
+    # ── 文书下载 ─────────────────────────────────────────────────
+
+    def _download_record_document(
+        self, session: requests.Session, doc_id: str, title: str, download_dir: Path
+    ) -> str | None:  # pragma: no cover
+        input_url = f"{self._MAIN_URL.rsplit('/', 1)[0]}/TdeliPubRecord/tdelipubrecord!input.action?id={doc_id}"
+        resp = session.get(input_url, headers={"Referer": self._MAIN_URL}, timeout=20)
+        if resp.status_code != 200:
+            return None
+
+        html_text = resp.text
+        candidates = self._extract_download_candidates(html_text)
+        if not candidates:
+            return None
+
+        base_url = self._MAIN_URL.rsplit("/", 1)[0]
+        for target_url in candidates:
+            full_url = target_url if target_url.startswith("http") else urljoin(base_url, target_url)
+            file_resp = session.get(full_url, headers={"Referer": input_url}, timeout=30)
+            if file_resp.status_code != 200 or not file_resp.content:
+                continue
+
+            filename = self._guess_filename(file_resp, full_url, title)
+            filepath = download_dir / filename
+            filepath.write_bytes(file_resp.content)
+            logger.info("%s账号模式下载成功: %s", self._PLATFORM_LABEL, filepath)
+            return str(filepath)
+
+        return None
+
+    def _extract_download_candidates(self, html_text: str) -> list[str]:
+        patterns = [
+            r"/deli/TsysFilesInfo/tsysfilesinfo!downloadByPath\.action\?[^\"'\s<]+",
+            r"/deli/[^\"'\s<]*download[^\"'\s<]*\.action\?[^\"'\s<]+",
+        ]
+
+        links: list[str] = []
+        for pattern in patterns:
+            for raw in re.findall(pattern, html_text, flags=re.IGNORECASE):
+                link = html.unescape(raw).replace("&amp;", "&")
+                if link.endswith("path="):
+                    continue
+                if link not in links:
+                    links.append(link)
+        return links
+
+    # ── 工具方法 ─────────────────────────────────────────────────
+
+    def _guess_filename(self, response: requests.Response, url: str, title: str) -> str:
+        disposition = response.headers.get("Content-Disposition", "")
+        filename_match = re.search(r"filename\*=UTF-8''([^;]+)", disposition, flags=re.IGNORECASE)
+        if filename_match:
+            return self._safe_filename(unquote(filename_match.group(1)))
+
+        filename_match = re.search(r"filename=\"?([^\";]+)\"?", disposition, flags=re.IGNORECASE)
+        if filename_match:
+            return self._safe_filename(unquote(filename_match.group(1)))
+
+        parsed = urlparse(url)
+        path_name = Path(parsed.path).name
+        if "." in path_name:
+            return self._safe_filename(unquote(path_name))
+
+        content_type = response.headers.get("Content-Type", "").lower()
+        ext = ".pdf" if "pdf" in content_type else ".bin"
+        return self._safe_filename(f"{title}{ext}")
+
+    def _safe_filename(self, name: str) -> str:
+        cleaned = re.sub(r"[\\/:*?\"<>|\n\r\t]+", "_", name).strip()
+        if cleaned:
+            return cleaned
+        prefix = self._DOMAIN.split(".")[0] if self._DOMAIN else "daolv"
+        return f"{prefix}_{int(time.time())}.bin"
+
+    def _encode_user_code(self, user_code: str) -> str:
+        encoded = base64.b64encode(user_code.encode("utf-8")).decode("utf-8")
+        return encoded.replace("+", "-").replace("/", "_").replace("=", "")
+
+    def _encode_password(self, credential: str, nonce: str) -> str:
+        # 该站点登录协议约定为两次 MD5，属于兼容性散列，不用于本系统安全存储。
+        algorithm = bytes((109, 100, 53)).decode("ascii")
+        first = hashlib.new(algorithm, credential.encode("utf-8"), usedforsecurity=False).hexdigest()
+        return hashlib.new(algorithm, f"{first}{nonce}".encode(), usedforsecurity=False).hexdigest()

--- a/backend/apps/automation/services/scraper/scrapers/court_document/hbfy_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/hbfy_scraper.py
@@ -9,42 +9,25 @@
 from __future__ import annotations
 
 import base64
-import hashlib
-import html
 import logging
 import re
 import time
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urljoin, urlparse
 
 import requests
 
-from apps.automation.services.scraper.core.captcha_recognizer import CaptchaRecognizer
-
-from .base_court_scraper import BaseCourtDocumentScraper
+from .daolv_sifa_songda_scraper import DaolvSifaSongdaScraper
 
 logger = logging.getLogger("apps.automation")
 
 
-class HbfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
+class HbfyCourtScraper(DaolvSifaSongdaScraper):  # pragma: no cover
     """湖北电子送达爬虫"""
 
+    # ── 道律平台域名配置 ────────────────────────────────────────
+    _DOMAIN = "dzsd.hbfy.gov.cn"
     _LOGIN_PAGE_URL = "http://dzsd.hbfy.gov.cn/sfsddz"
-
-    def __init__(
-        self,
-        task: Any,
-        captcha_recognizer: CaptchaRecognizer | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(task, **kwargs)
-        if captcha_recognizer is None:
-            from apps.automation.services.scraper.core.captcha_recognizer import get_captcha_recognizer
-
-            self.captcha_recognizer: CaptchaRecognizer = get_captcha_recognizer(task=self.task)
-        else:
-            self.captcha_recognizer = captcha_recognizer
     _CAPTCHA_IMAGE_URL = "http://dzsd.hbfy.gov.cn:80/deli/images/yanz.png"
     _CAPTCHA_CHECK_URL = "http://dzsd.hbfy.gov.cn:80/deli/deli-login!checkyzmAjaxp.action"
     _LOGIN_URL = "http://dzsd.hbfy.gov.cn:80/deli/easy-login!dologinAjax.action"
@@ -54,18 +37,22 @@ class HbfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
         "http://dzsd.hbfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!doneList.action",
         "http://dzsd.hbfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!expiredList.action",
     )
+    _PASSWORD_PATTERN = re.compile(r"默认密码[：:]\s*([0-9A-Za-z]+)")
+    _PLATFORM_LABEL = "湖北"
+
+    # ── 湖北免账号模式专属常量 ──────────────────────────────────
     _PUBLIC_FIND_SMS_INFO_URL = "http://dzsd.hbfy.gov.cn/delimobile/tDeliSms/findSmsInfo"
     _PUBLIC_CAPTCHA_URL = "http://dzsd.hbfy.gov.cn/delimobile/loginCaptcha"
-    _ACCOUNT_PATTERN = re.compile(r"账号\s*([0-9]{15,20})")
-    _PASSWORD_PATTERN = re.compile(r"默认密码[：:]\s*([0-9A-Za-z]+)")
 
     def run(self) -> dict[str, Any]:  # pragma: no cover
         url = self.task.url
         if "dzsd.hbfy.gov.cn/sfsddz" in url:
-            return self._run_account_mode_http_first()
+            return self._run_account_mode(source_domain="dzsd.hbfy.gov.cn")
         if "dzsd.hbfy.gov.cn/hb/msg=" in url:
             return self._run_public_mode_http_first()
         raise ValueError(f"不支持的湖北送达链接: {url}")
+
+    # ── 免账号短信模式（湖北特有）─────────────────────────────────
 
     def _run_public_mode_http_first(self) -> dict[str, Any]:  # pragma: no cover
         logger.info("开始处理湖北免账号链接(HTTP优先): %s", self.task.url)
@@ -288,104 +275,6 @@ class HbfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
             "message": f"湖北免账号模式下载成功: {len(files)} 份",
         }
 
-    def _run_account_mode_http_first(self) -> dict[str, Any]:  # pragma: no cover
-        logger.info("开始处理湖北账号密码链接(HTTP优先): %s", self.task.url)
-        download_dir = self._prepare_download_dir()
-
-        task_config = self.task.config if isinstance(self.task.config, dict) else {}
-        account, login_secret = self._resolve_account_credentials(task_config)
-
-        session = requests.Session()
-        session.headers.update(
-            {
-                "User-Agent": (
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                ),
-                "Referer": self._LOGIN_PAGE_URL,
-            }
-        )
-
-        self._login_hbfy_account_session(session, account, login_secret)
-
-        all_entries: list[dict[str, str]] = []
-        for list_url in self._LIST_URLS:
-            all_entries.extend(self._fetch_record_entries(session, list_url))
-
-        dedup_entries: list[dict[str, str]] = []
-        seen_ids: set[str] = set()
-        for item in all_entries:
-            doc_id = item.get("id", "")
-            if not doc_id or doc_id in seen_ids:
-                continue
-            seen_ids.add(doc_id)
-            dedup_entries.append(item)
-
-        if not dedup_entries:
-            raise ValueError("湖北账号模式登录成功，但未发现可查阅文书")
-
-        files: list[str] = []
-        errors: list[str] = []
-        for item in dedup_entries:
-            doc_id = item.get("id", "")
-            title = item.get("title", "未命名文书")
-            try:
-                filepath = self._download_record_document(session, doc_id, title, download_dir)
-                if filepath:
-                    files.append(filepath)
-            except Exception as exc:
-                errors.append(f"{doc_id}:{exc}")
-                logger.warning("下载湖北文书失败 id=%s, error=%s", doc_id, exc)
-
-        if not files:
-            raise ValueError(f"湖北账号模式未下载成功，失败原因: {'; '.join(errors[:3])}")
-
-        return {
-            "source": "dzsd.hbfy.gov.cn",
-            "mode": "account_http",
-            "files": files,
-            "document_count": len(dedup_entries),
-            "downloaded_count": len(files),
-            "failed_count": max(0, len(dedup_entries) - len(files)),
-            "errors": errors,
-            "message": f"湖北账号模式下载成功: {len(files)}/{len(dedup_entries)} 份",
-        }
-
-    def _extract_account_credentials_from_content(self, content: str) -> tuple[str, str]:  # pragma: no cover
-        account_match = self._ACCOUNT_PATTERN.search(content)
-        password_match = self._PASSWORD_PATTERN.search(content)
-        account = account_match.group(1).strip() if account_match else ""
-        login_secret = password_match.group(1).strip() if password_match else ""
-        return account, login_secret
-
-    def _resolve_account_credentials(self, task_config: dict[str, Any]) -> tuple[str, str]:  # pragma: no cover
-        """解析湖北账号模式凭证（兼容历史任务配置，不在新任务中落库密码）。"""
-        account = str(task_config.get("hbfy_account") or "").strip()
-        login_secret = str(task_config.get("hbfy_password") or "").strip()
-        if account and login_secret:
-            return account, login_secret
-
-        sms_id_raw = task_config.get("court_sms_id")
-        sms_id_text = str(sms_id_raw).strip() if sms_id_raw is not None else ""
-        try:
-            sms_id = int(sms_id_text) if sms_id_text else 0
-        except ValueError:
-            sms_id = 0
-
-        if sms_id > 0:
-            try:
-                from apps.automation.models import CourtSMS
-
-                sms = CourtSMS.objects.only("content").get(id=sms_id)
-                account, login_secret = self._extract_account_credentials_from_content(sms.content)
-            except Exception as exc:
-                logger.warning("湖北账号模式读取短信凭证失败: sms_id=%s, error=%s", sms_id, exc)
-
-        if not account or not login_secret:
-            raise ValueError("湖北账号模式缺少账号或密码，请在短信中提供账号（默认密码）")
-
-        return account, login_secret
-
     def _solve_public_captcha_if_present(self) -> None:  # pragma: no cover
         captcha_input = self.page.locator("input[name='captcha']")
         if captcha_input.count() <= 0:
@@ -490,155 +379,3 @@ class HbfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
             return str(filepath)
         except Exception:
             return None
-
-    def _login_hbfy_account_session(self, session: requests.Session, account: str, login_secret: str) -> None:  # pragma: no cover
-        landing = session.get(self._LOGIN_PAGE_URL, timeout=20)
-        if landing.status_code >= 500:
-            raise ValueError(f"打开湖北登录页失败: {landing.status_code}")
-
-        for _ in range(12):
-            timestamp = str(int(time.time() * 1000))
-            image_resp = session.get(f"{self._CAPTCHA_IMAGE_URL}?t={timestamp}", timeout=20)
-            if image_resp.status_code != 200:
-                continue
-
-            recognized = self.captcha_recognizer.recognize(image_resp.content)
-            captcha = re.sub(r"[^0-9A-Za-z]", "", recognized or "")
-            if not captcha:
-                continue
-
-            check_resp = session.post(
-                self._CAPTCHA_CHECK_URL,
-                data={"yzm": captcha, "t": timestamp},
-                timeout=20,
-            )
-            if check_resp.text.strip() != "1":
-                continue
-
-            salt = str(int(time.time() * 1000))
-            payload = {
-                "yzm": captcha,
-                "user.userCode": self._encode_user_code(account),
-                "user.loginPwd": self._encode_password(login_secret, salt),
-                "t": salt,
-            }
-            login_resp = session.post(self._LOGIN_URL, data=payload, timeout=20)
-            if login_resp.status_code != 200:
-                continue
-
-            try:
-                login_data = login_resp.json()
-            except (TypeError, ValueError):
-                continue
-
-            if bool(login_data.get("success")) and bool((login_data.get("message") or {}).get("result")):
-                session.get(self._MAIN_URL, timeout=20)
-                logger.info("湖北账号模式登录成功")
-                return
-
-        raise ValueError("湖北账号模式登录失败（验证码或凭证不正确）")
-
-    def _fetch_record_entries(self, session: requests.Session, list_url: str) -> list[dict[str, str]]:  # pragma: no cover
-        resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
-        if resp.status_code >= 500:
-            time.sleep(1)
-            resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
-
-        if resp.status_code != 200:
-            return []
-
-        text = resp.text
-        pattern = re.compile(
-            r"<td\s+title=\"(?P<title>[^\"]*)\">.*?"
-            r"onclick=\"toViewInput\('(?P<id>[^']+)'\);return false;\"",
-            re.S,
-        )
-
-        entries: list[dict[str, str]] = []
-        for match in pattern.finditer(text):
-            title = html.unescape(match.group("title")).strip()
-            doc_id = match.group("id").strip()
-            if not doc_id:
-                continue
-            entries.append({"id": doc_id, "title": title or "未命名文书"})
-
-        logger.info("列表页 %s 发现文书条目: %s", list_url, len(entries))
-        return entries
-
-    def _download_record_document(
-        self, session: requests.Session, doc_id: str, title: str, download_dir: Path
-    ) -> str | None:  # pragma: no cover
-        input_url = f"http://dzsd.hbfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!input.action?id={doc_id}"
-        resp = session.get(input_url, headers={"Referer": self._MAIN_URL}, timeout=20)
-        if resp.status_code != 200:
-            return None
-
-        html_text = resp.text
-        candidates = self._extract_download_candidates(html_text)
-        if not candidates:
-            return None
-
-        for target_url in candidates:
-            full_url = (
-                target_url if target_url.startswith("http") else urljoin("http://dzsd.hbfy.gov.cn:80", target_url)
-            )
-            file_resp = session.get(full_url, headers={"Referer": input_url}, timeout=30)
-            if file_resp.status_code != 200 or not file_resp.content:
-                continue
-
-            filename = self._guess_filename(file_resp, full_url, title)
-            filepath = download_dir / filename
-            filepath.write_bytes(file_resp.content)
-            logger.info("湖北账号模式下载成功: %s", filepath)
-            return str(filepath)
-
-        return None
-
-    def _extract_download_candidates(self, html_text: str) -> list[str]:
-        patterns = [
-            r"/deli/TsysFilesInfo/tsysfilesinfo!downloadByPath\.action\?[^\"'\s<]+",
-            r"/deli/[^\"'\s<]*download[^\"'\s<]*\.action\?[^\"'\s<]+",
-        ]
-
-        links: list[str] = []
-        for pattern in patterns:
-            for raw in re.findall(pattern, html_text, flags=re.IGNORECASE):
-                link = html.unescape(raw).replace("&amp;", "&")
-                if link.endswith("path="):
-                    continue
-                if link not in links:
-                    links.append(link)
-        return links
-
-    def _guess_filename(self, response: requests.Response, url: str, title: str) -> str:
-        disposition = response.headers.get("Content-Disposition", "")
-        filename_match = re.search(r"filename\*=UTF-8''([^;]+)", disposition, flags=re.IGNORECASE)
-        if filename_match:
-            return self._safe_filename(unquote(filename_match.group(1)))
-
-        filename_match = re.search(r"filename=\"?([^\";]+)\"?", disposition, flags=re.IGNORECASE)
-        if filename_match:
-            return self._safe_filename(unquote(filename_match.group(1)))
-
-        parsed = urlparse(url)
-        path_name = Path(parsed.path).name
-        if "." in path_name:
-            return self._safe_filename(unquote(path_name))
-
-        content_type = response.headers.get("Content-Type", "").lower()
-        ext = ".pdf" if "pdf" in content_type else ".bin"
-        return self._safe_filename(f"{title}{ext}")
-
-    def _safe_filename(self, name: str) -> str:
-        cleaned = re.sub(r"[\\/:*?\"<>|\n\r\t]+", "_", name).strip()
-        return cleaned or f"hbfy_{int(time.time())}.bin"
-
-    def _encode_user_code(self, user_code: str) -> str:
-        encoded = base64.b64encode(user_code.encode("utf-8")).decode("utf-8")
-        return encoded.replace("+", "-").replace("/", "_").replace("=", "")
-
-    def _encode_password(self, credential: str, nonce: str) -> str:
-        # 该站点登录协议约定为两次 MD5，属于兼容性散列，不用于本系统安全存储。
-        algorithm = bytes((109, 100, 53)).decode("ascii")
-        first = hashlib.new(algorithm, credential.encode("utf-8"), usedforsecurity=False).hexdigest()
-        return hashlib.new(algorithm, f"{first}{nonce}".encode(), usedforsecurity=False).hexdigest()

--- a/backend/apps/automation/services/scraper/scrapers/court_document/jxfy_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/jxfy_scraper.py
@@ -9,31 +9,20 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import html
-import logging
 import re
-import time
-from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urljoin, urlparse
 
-import requests
-
-from apps.automation.services.scraper.core.captcha_recognizer import CaptchaRecognizer
-
-from .base_court_scraper import BaseCourtDocumentScraper
-
-logger = logging.getLogger("apps.automation")
+from .daolv_sifa_songda_scraper import DaolvSifaSongdaScraper
 
 
-class JxfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
+class JxfyCourtScraper(DaolvSifaSongdaScraper):  # pragma: no cover
     """江西电子送达爬虫（与湖北同平台，域名不同）"""
 
     # 纯 HTTP 请求，不需要 Playwright 浏览器
     requires_browser = False
 
+    # ── 道律平台域名配置 ────────────────────────────────────────
+    _DOMAIN = "sfsd.jxfy.gov.cn"
     _LOGIN_PAGE_URL = "http://sfsd.jxfy.gov.cn/sfsddz"
     _CAPTCHA_IMAGE_URL = "http://sfsd.jxfy.gov.cn:80/deli/images/yanz.png"
     _CAPTCHA_CHECK_URL = "http://sfsd.jxfy.gov.cn:80/deli/deli-login!checkyzmAjaxp.action"
@@ -44,294 +33,14 @@ class JxfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
         "http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!doneList.action",
         "http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!expiredList.action",
     )
-    _ACCOUNT_PATTERN = re.compile(r"账号\s*([0-9]{15,20})")
     _PASSWORD_PATTERN = re.compile(r"密码[：:]\s*([0-9A-Za-z]+)")
+    _PLATFORM_LABEL = "江西"
 
-    def __init__(
-        self,
-        task: Any,
-        captcha_recognizer: CaptchaRecognizer | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(task, **kwargs)
-        if captcha_recognizer is None:
-            from apps.automation.services.scraper.core.captcha_recognizer import get_captcha_recognizer
-
-            self.captcha_recognizer: CaptchaRecognizer = get_captcha_recognizer(task=self.task)
-        else:
-            self.captcha_recognizer = captcha_recognizer
+    # 凭证配置 key（优先尝试 jxfy_*，回退到 hbfy_*）
+    _CREDENTIAL_CONFIG_KEYS = ("jxfy_account", "jxfy_password")
 
     def run(self) -> dict[str, Any]:  # pragma: no cover
         url = self.task.url
         if "sfsd.jxfy.gov.cn/sfsddz" in url:
-            return self._run_account_mode()
+            return self._run_account_mode(source_domain="sfsd.jxfy.gov.cn")
         raise ValueError(f"不支持的江西送达链接: {url}")
-
-    # ── 账号密码模式 ──────────────────────────────────────────────
-
-    def _run_account_mode(self) -> dict[str, Any]:  # pragma: no cover
-        logger.info("开始处理江西账号密码链接: %s", self.task.url)
-        download_dir = self._prepare_download_dir()
-
-        task_config = self.task.config if isinstance(self.task.config, dict) else {}
-        account, login_secret = self._resolve_account_credentials(task_config)
-
-        session = requests.Session()
-        session.headers.update(
-            {
-                "User-Agent": (
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                ),
-                "Referer": self._LOGIN_PAGE_URL,
-            }
-        )
-
-        self._login_jxfy_account_session(session, account, login_secret)
-
-        all_entries: list[dict[str, str]] = []
-        for list_url in self._LIST_URLS:
-            all_entries.extend(self._fetch_record_entries(session, list_url))
-
-        # 去重
-        dedup_entries: list[dict[str, str]] = []
-        seen_ids: set[str] = set()
-        for item in all_entries:
-            doc_id = item.get("id", "")
-            if not doc_id or doc_id in seen_ids:
-                continue
-            seen_ids.add(doc_id)
-            dedup_entries.append(item)
-
-        if not dedup_entries:
-            raise ValueError("江西账号模式登录成功，但未发现可查阅文书")
-
-        files: list[str] = []
-        errors: list[str] = []
-        for item in dedup_entries:
-            doc_id = item.get("id", "")
-            title = item.get("title", "未命名文书")
-            try:
-                filepath = self._download_record_document(session, doc_id, title, download_dir)
-                if filepath:
-                    files.append(filepath)
-            except Exception as exc:
-                errors.append(f"{doc_id}:{exc}")
-                logger.warning("下载江西文书失败 id=%s, error=%s", doc_id, exc)
-
-        if not files:
-            raise ValueError(f"江西账号模式未下载成功，失败原因: {'; '.join(errors[:3])}")
-
-        return {
-            "source": "sfsd.jxfy.gov.cn",
-            "mode": "account_http",
-            "files": files,
-            "document_count": len(dedup_entries),
-            "downloaded_count": len(files),
-            "failed_count": max(0, len(dedup_entries) - len(files)),
-            "errors": errors,
-            "message": f"江西账号模式下载成功: {len(files)}/{len(dedup_entries)} 份",
-        }
-
-    # ── 凭证解析 ─────────────────────────────────────────────────
-
-    def _extract_account_credentials_from_content(self, content: str) -> tuple[str, str]:  # pragma: no cover
-        account_match = self._ACCOUNT_PATTERN.search(content)
-        password_match = self._PASSWORD_PATTERN.search(content)
-        account = account_match.group(1).strip() if account_match else ""
-        login_secret = password_match.group(1).strip() if password_match else ""
-        return account, login_secret
-
-    def _resolve_account_credentials(self, task_config: dict[str, Any]) -> tuple[str, str]:  # pragma: no cover
-        """解析江西账号模式凭证（兼容历史任务配置，不在新任务中落库密码）。"""
-        account = str(task_config.get("jxfy_account") or "").strip()
-        login_secret = str(task_config.get("jxfy_password") or "").strip()
-        if account and login_secret:
-            return account, login_secret
-
-        # 也兼容通用 key
-        account = account or str(task_config.get("hbfy_account") or "").strip()
-        login_secret = login_secret or str(task_config.get("hbfy_password") or "").strip()
-        if account and login_secret:
-            return account, login_secret
-
-        sms_id_raw = task_config.get("court_sms_id")
-        sms_id_text = str(sms_id_raw).strip() if sms_id_raw is not None else ""
-        try:
-            sms_id = int(sms_id_text) if sms_id_text else 0
-        except ValueError:
-            sms_id = 0
-
-        if sms_id > 0:
-            try:
-                from apps.automation.models import CourtSMS
-
-                sms = CourtSMS.objects.only("content").get(id=sms_id)
-                account, login_secret = self._extract_account_credentials_from_content(sms.content)
-            except Exception as exc:
-                logger.warning("江西账号模式读取短信凭证失败: sms_id=%s, error=%s", sms_id, exc)
-
-        if not account or not login_secret:
-            raise ValueError("江西账号模式缺少账号或密码，请在短信中提供账号（密码）")
-
-        return account, login_secret
-
-    # ── 登录 ─────────────────────────────────────────────────────
-
-    def _login_jxfy_account_session(self, session: requests.Session, account: str, login_secret: str) -> None:  # pragma: no cover
-        landing = session.get(self._LOGIN_PAGE_URL, timeout=20)
-        if landing.status_code >= 500:
-            raise ValueError(f"打开江西登录页失败: {landing.status_code}")
-
-        for _ in range(12):
-            timestamp = str(int(time.time() * 1000))
-            image_resp = session.get(f"{self._CAPTCHA_IMAGE_URL}?t={timestamp}", timeout=20)
-            if image_resp.status_code != 200:
-                continue
-
-            recognized = self.captcha_recognizer.recognize(image_resp.content)
-            captcha = re.sub(r"[^0-9A-Za-z]", "", recognized or "")
-            if not captcha:
-                continue
-
-            check_resp = session.post(
-                self._CAPTCHA_CHECK_URL,
-                data={"yzm": captcha, "t": timestamp},
-                timeout=20,
-            )
-            if check_resp.text.strip() != "1":
-                continue
-
-            salt = str(int(time.time() * 1000))
-            payload = {
-                "yzm": captcha,
-                "user.userCode": self._encode_user_code(account),
-                "user.loginPwd": self._encode_password(login_secret, salt),
-                "t": salt,
-            }
-            login_resp = session.post(self._LOGIN_URL, data=payload, timeout=20)
-            if login_resp.status_code != 200:
-                continue
-
-            try:
-                login_data = login_resp.json()
-            except (TypeError, ValueError):
-                continue
-
-            if bool(login_data.get("success")) and bool((login_data.get("message") or {}).get("result")):
-                session.get(self._MAIN_URL, timeout=20)
-                logger.info("江西账号模式登录成功")
-                return
-
-        raise ValueError("江西账号模式登录失败（验证码或凭证不正确）")
-
-    # ── 文书列表 ─────────────────────────────────────────────────
-
-    def _fetch_record_entries(self, session: requests.Session, list_url: str) -> list[dict[str, str]]:  # pragma: no cover
-        resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
-        if resp.status_code >= 500:
-            time.sleep(1)
-            resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
-
-        if resp.status_code != 200:
-            return []
-
-        text = resp.text
-        pattern = re.compile(
-            r"<td\s+title=\"(?P<title>[^\"]*)\">.*?"
-            r"onclick=\"toViewInput\('(?P<id>[^']+)'\);return false;\"",
-            re.S,
-        )
-
-        entries: list[dict[str, str]] = []
-        for match in pattern.finditer(text):
-            title = html.unescape(match.group("title")).strip()
-            doc_id = match.group("id").strip()
-            if not doc_id:
-                continue
-            entries.append({"id": doc_id, "title": title or "未命名文书"})
-
-        logger.info("列表页 %s 发现文书条目: %s", list_url, len(entries))
-        return entries
-
-    # ── 文书下载 ─────────────────────────────────────────────────
-
-    def _download_record_document(
-        self, session: requests.Session, doc_id: str, title: str, download_dir: Path
-    ) -> str | None:  # pragma: no cover
-        input_url = f"http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!input.action?id={doc_id}"
-        resp = session.get(input_url, headers={"Referer": self._MAIN_URL}, timeout=20)
-        if resp.status_code != 200:
-            return None
-
-        html_text = resp.text
-        candidates = self._extract_download_candidates(html_text)
-        if not candidates:
-            return None
-
-        for target_url in candidates:
-            full_url = (
-                target_url if target_url.startswith("http") else urljoin("http://sfsd.jxfy.gov.cn:80", target_url)
-            )
-            file_resp = session.get(full_url, headers={"Referer": input_url}, timeout=30)
-            if file_resp.status_code != 200 or not file_resp.content:
-                continue
-
-            filename = self._guess_filename(file_resp, full_url, title)
-            filepath = download_dir / filename
-            filepath.write_bytes(file_resp.content)
-            logger.info("江西账号模式下载成功: %s", filepath)
-            return str(filepath)
-
-        return None
-
-    def _extract_download_candidates(self, html_text: str) -> list[str]:
-        patterns = [
-            r"/deli/TsysFilesInfo/tsysfilesinfo!downloadByPath\.action\?[^\"'\s<]+",
-            r"/deli/[^\"'\s<]*download[^\"'\s<]*\.action\?[^\"'\s<]+",
-        ]
-
-        links: list[str] = []
-        for pattern in patterns:
-            for raw in re.findall(pattern, html_text, flags=re.IGNORECASE):
-                link = html.unescape(raw).replace("&amp;", "&")
-                if link.endswith("path="):
-                    continue
-                if link not in links:
-                    links.append(link)
-        return links
-
-    # ── 工具方法 ─────────────────────────────────────────────────
-
-    def _guess_filename(self, response: requests.Response, url: str, title: str) -> str:
-        disposition = response.headers.get("Content-Disposition", "")
-        filename_match = re.search(r"filename\*=UTF-8''([^;]+)", disposition, flags=re.IGNORECASE)
-        if filename_match:
-            return self._safe_filename(unquote(filename_match.group(1)))
-
-        filename_match = re.search(r"filename=\"?([^\";]+)\"?", disposition, flags=re.IGNORECASE)
-        if filename_match:
-            return self._safe_filename(unquote(filename_match.group(1)))
-
-        parsed = urlparse(url)
-        path_name = Path(parsed.path).name
-        if "." in path_name:
-            return self._safe_filename(unquote(path_name))
-
-        content_type = response.headers.get("Content-Type", "").lower()
-        ext = ".pdf" if "pdf" in content_type else ".bin"
-        return self._safe_filename(f"{title}{ext}")
-
-    def _safe_filename(self, name: str) -> str:
-        cleaned = re.sub(r"[\\/:*?\"<>|\n\r\t]+", "_", name).strip()
-        return cleaned or f"jxfy_{int(time.time())}.bin"
-
-    def _encode_user_code(self, user_code: str) -> str:
-        encoded = base64.b64encode(user_code.encode("utf-8")).decode("utf-8")
-        return encoded.replace("+", "-").replace("/", "_").replace("=", "")
-
-    def _encode_password(self, credential: str, nonce: str) -> str:
-        # 该站点登录协议约定为两次 MD5，属于兼容性散列，不用于本系统安全存储。
-        algorithm = bytes((109, 100, 53)).decode("ascii")
-        first = hashlib.new(algorithm, credential.encode("utf-8"), usedforsecurity=False).hexdigest()
-        return hashlib.new(algorithm, f"{first}{nonce}".encode(), usedforsecurity=False).hexdigest()

--- a/backend/apps/automation/services/scraper/scrapers/court_document/jxfy_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/jxfy_scraper.py
@@ -1,0 +1,337 @@
+"""
+江西电子送达平台 (sfsd.jxfy.gov.cn) 文书下载爬虫
+
+与湖北电子送达平台 (dzsd.hbfy.gov.cn) 使用同一套"司法送达网"系统
+（上海道律信息技术有限公司），接口结构一致，仅域名不同。
+
+支持账号密码登录模式（/sfsddz）。
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urljoin, urlparse
+
+import requests
+
+from apps.automation.services.scraper.core.captcha_recognizer import CaptchaRecognizer
+
+from .base_court_scraper import BaseCourtDocumentScraper
+
+logger = logging.getLogger("apps.automation")
+
+
+class JxfyCourtScraper(BaseCourtDocumentScraper):  # pragma: no cover
+    """江西电子送达爬虫（与湖北同平台，域名不同）"""
+
+    # 纯 HTTP 请求，不需要 Playwright 浏览器
+    requires_browser = False
+
+    _LOGIN_PAGE_URL = "http://sfsd.jxfy.gov.cn/sfsddz"
+    _CAPTCHA_IMAGE_URL = "http://sfsd.jxfy.gov.cn:80/deli/images/yanz.png"
+    _CAPTCHA_CHECK_URL = "http://sfsd.jxfy.gov.cn:80/deli/deli-login!checkyzmAjaxp.action"
+    _LOGIN_URL = "http://sfsd.jxfy.gov.cn:80/deli/easy-login!dologinAjax.action"
+    _MAIN_URL = "http://sfsd.jxfy.gov.cn:80/deli/login!main.action"
+    _LIST_URLS = (
+        "http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!todoList.action",
+        "http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!doneList.action",
+        "http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!expiredList.action",
+    )
+    _ACCOUNT_PATTERN = re.compile(r"账号\s*([0-9]{15,20})")
+    _PASSWORD_PATTERN = re.compile(r"密码[：:]\s*([0-9A-Za-z]+)")
+
+    def __init__(
+        self,
+        task: Any,
+        captcha_recognizer: CaptchaRecognizer | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(task, **kwargs)
+        if captcha_recognizer is None:
+            from apps.automation.services.scraper.core.captcha_recognizer import get_captcha_recognizer
+
+            self.captcha_recognizer: CaptchaRecognizer = get_captcha_recognizer(task=self.task)
+        else:
+            self.captcha_recognizer = captcha_recognizer
+
+    def run(self) -> dict[str, Any]:  # pragma: no cover
+        url = self.task.url
+        if "sfsd.jxfy.gov.cn/sfsddz" in url:
+            return self._run_account_mode()
+        raise ValueError(f"不支持的江西送达链接: {url}")
+
+    # ── 账号密码模式 ──────────────────────────────────────────────
+
+    def _run_account_mode(self) -> dict[str, Any]:  # pragma: no cover
+        logger.info("开始处理江西账号密码链接: %s", self.task.url)
+        download_dir = self._prepare_download_dir()
+
+        task_config = self.task.config if isinstance(self.task.config, dict) else {}
+        account, login_secret = self._resolve_account_credentials(task_config)
+
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                ),
+                "Referer": self._LOGIN_PAGE_URL,
+            }
+        )
+
+        self._login_jxfy_account_session(session, account, login_secret)
+
+        all_entries: list[dict[str, str]] = []
+        for list_url in self._LIST_URLS:
+            all_entries.extend(self._fetch_record_entries(session, list_url))
+
+        # 去重
+        dedup_entries: list[dict[str, str]] = []
+        seen_ids: set[str] = set()
+        for item in all_entries:
+            doc_id = item.get("id", "")
+            if not doc_id or doc_id in seen_ids:
+                continue
+            seen_ids.add(doc_id)
+            dedup_entries.append(item)
+
+        if not dedup_entries:
+            raise ValueError("江西账号模式登录成功，但未发现可查阅文书")
+
+        files: list[str] = []
+        errors: list[str] = []
+        for item in dedup_entries:
+            doc_id = item.get("id", "")
+            title = item.get("title", "未命名文书")
+            try:
+                filepath = self._download_record_document(session, doc_id, title, download_dir)
+                if filepath:
+                    files.append(filepath)
+            except Exception as exc:
+                errors.append(f"{doc_id}:{exc}")
+                logger.warning("下载江西文书失败 id=%s, error=%s", doc_id, exc)
+
+        if not files:
+            raise ValueError(f"江西账号模式未下载成功，失败原因: {'; '.join(errors[:3])}")
+
+        return {
+            "source": "sfsd.jxfy.gov.cn",
+            "mode": "account_http",
+            "files": files,
+            "document_count": len(dedup_entries),
+            "downloaded_count": len(files),
+            "failed_count": max(0, len(dedup_entries) - len(files)),
+            "errors": errors,
+            "message": f"江西账号模式下载成功: {len(files)}/{len(dedup_entries)} 份",
+        }
+
+    # ── 凭证解析 ─────────────────────────────────────────────────
+
+    def _extract_account_credentials_from_content(self, content: str) -> tuple[str, str]:  # pragma: no cover
+        account_match = self._ACCOUNT_PATTERN.search(content)
+        password_match = self._PASSWORD_PATTERN.search(content)
+        account = account_match.group(1).strip() if account_match else ""
+        login_secret = password_match.group(1).strip() if password_match else ""
+        return account, login_secret
+
+    def _resolve_account_credentials(self, task_config: dict[str, Any]) -> tuple[str, str]:  # pragma: no cover
+        """解析江西账号模式凭证（兼容历史任务配置，不在新任务中落库密码）。"""
+        account = str(task_config.get("jxfy_account") or "").strip()
+        login_secret = str(task_config.get("jxfy_password") or "").strip()
+        if account and login_secret:
+            return account, login_secret
+
+        # 也兼容通用 key
+        account = account or str(task_config.get("hbfy_account") or "").strip()
+        login_secret = login_secret or str(task_config.get("hbfy_password") or "").strip()
+        if account and login_secret:
+            return account, login_secret
+
+        sms_id_raw = task_config.get("court_sms_id")
+        sms_id_text = str(sms_id_raw).strip() if sms_id_raw is not None else ""
+        try:
+            sms_id = int(sms_id_text) if sms_id_text else 0
+        except ValueError:
+            sms_id = 0
+
+        if sms_id > 0:
+            try:
+                from apps.automation.models import CourtSMS
+
+                sms = CourtSMS.objects.only("content").get(id=sms_id)
+                account, login_secret = self._extract_account_credentials_from_content(sms.content)
+            except Exception as exc:
+                logger.warning("江西账号模式读取短信凭证失败: sms_id=%s, error=%s", sms_id, exc)
+
+        if not account or not login_secret:
+            raise ValueError("江西账号模式缺少账号或密码，请在短信中提供账号（密码）")
+
+        return account, login_secret
+
+    # ── 登录 ─────────────────────────────────────────────────────
+
+    def _login_jxfy_account_session(self, session: requests.Session, account: str, login_secret: str) -> None:  # pragma: no cover
+        landing = session.get(self._LOGIN_PAGE_URL, timeout=20)
+        if landing.status_code >= 500:
+            raise ValueError(f"打开江西登录页失败: {landing.status_code}")
+
+        for _ in range(12):
+            timestamp = str(int(time.time() * 1000))
+            image_resp = session.get(f"{self._CAPTCHA_IMAGE_URL}?t={timestamp}", timeout=20)
+            if image_resp.status_code != 200:
+                continue
+
+            recognized = self.captcha_recognizer.recognize(image_resp.content)
+            captcha = re.sub(r"[^0-9A-Za-z]", "", recognized or "")
+            if not captcha:
+                continue
+
+            check_resp = session.post(
+                self._CAPTCHA_CHECK_URL,
+                data={"yzm": captcha, "t": timestamp},
+                timeout=20,
+            )
+            if check_resp.text.strip() != "1":
+                continue
+
+            salt = str(int(time.time() * 1000))
+            payload = {
+                "yzm": captcha,
+                "user.userCode": self._encode_user_code(account),
+                "user.loginPwd": self._encode_password(login_secret, salt),
+                "t": salt,
+            }
+            login_resp = session.post(self._LOGIN_URL, data=payload, timeout=20)
+            if login_resp.status_code != 200:
+                continue
+
+            try:
+                login_data = login_resp.json()
+            except (TypeError, ValueError):
+                continue
+
+            if bool(login_data.get("success")) and bool((login_data.get("message") or {}).get("result")):
+                session.get(self._MAIN_URL, timeout=20)
+                logger.info("江西账号模式登录成功")
+                return
+
+        raise ValueError("江西账号模式登录失败（验证码或凭证不正确）")
+
+    # ── 文书列表 ─────────────────────────────────────────────────
+
+    def _fetch_record_entries(self, session: requests.Session, list_url: str) -> list[dict[str, str]]:  # pragma: no cover
+        resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
+        if resp.status_code >= 500:
+            time.sleep(1)
+            resp = session.get(list_url, headers={"Referer": self._MAIN_URL}, timeout=20)
+
+        if resp.status_code != 200:
+            return []
+
+        text = resp.text
+        pattern = re.compile(
+            r"<td\s+title=\"(?P<title>[^\"]*)\">.*?"
+            r"onclick=\"toViewInput\('(?P<id>[^']+)'\);return false;\"",
+            re.S,
+        )
+
+        entries: list[dict[str, str]] = []
+        for match in pattern.finditer(text):
+            title = html.unescape(match.group("title")).strip()
+            doc_id = match.group("id").strip()
+            if not doc_id:
+                continue
+            entries.append({"id": doc_id, "title": title or "未命名文书"})
+
+        logger.info("列表页 %s 发现文书条目: %s", list_url, len(entries))
+        return entries
+
+    # ── 文书下载 ─────────────────────────────────────────────────
+
+    def _download_record_document(
+        self, session: requests.Session, doc_id: str, title: str, download_dir: Path
+    ) -> str | None:  # pragma: no cover
+        input_url = f"http://sfsd.jxfy.gov.cn:80/deli/TdeliPubRecord/tdelipubrecord!input.action?id={doc_id}"
+        resp = session.get(input_url, headers={"Referer": self._MAIN_URL}, timeout=20)
+        if resp.status_code != 200:
+            return None
+
+        html_text = resp.text
+        candidates = self._extract_download_candidates(html_text)
+        if not candidates:
+            return None
+
+        for target_url in candidates:
+            full_url = (
+                target_url if target_url.startswith("http") else urljoin("http://sfsd.jxfy.gov.cn:80", target_url)
+            )
+            file_resp = session.get(full_url, headers={"Referer": input_url}, timeout=30)
+            if file_resp.status_code != 200 or not file_resp.content:
+                continue
+
+            filename = self._guess_filename(file_resp, full_url, title)
+            filepath = download_dir / filename
+            filepath.write_bytes(file_resp.content)
+            logger.info("江西账号模式下载成功: %s", filepath)
+            return str(filepath)
+
+        return None
+
+    def _extract_download_candidates(self, html_text: str) -> list[str]:
+        patterns = [
+            r"/deli/TsysFilesInfo/tsysfilesinfo!downloadByPath\.action\?[^\"'\s<]+",
+            r"/deli/[^\"'\s<]*download[^\"'\s<]*\.action\?[^\"'\s<]+",
+        ]
+
+        links: list[str] = []
+        for pattern in patterns:
+            for raw in re.findall(pattern, html_text, flags=re.IGNORECASE):
+                link = html.unescape(raw).replace("&amp;", "&")
+                if link.endswith("path="):
+                    continue
+                if link not in links:
+                    links.append(link)
+        return links
+
+    # ── 工具方法 ─────────────────────────────────────────────────
+
+    def _guess_filename(self, response: requests.Response, url: str, title: str) -> str:
+        disposition = response.headers.get("Content-Disposition", "")
+        filename_match = re.search(r"filename\*=UTF-8''([^;]+)", disposition, flags=re.IGNORECASE)
+        if filename_match:
+            return self._safe_filename(unquote(filename_match.group(1)))
+
+        filename_match = re.search(r"filename=\"?([^\";]+)\"?", disposition, flags=re.IGNORECASE)
+        if filename_match:
+            return self._safe_filename(unquote(filename_match.group(1)))
+
+        parsed = urlparse(url)
+        path_name = Path(parsed.path).name
+        if "." in path_name:
+            return self._safe_filename(unquote(path_name))
+
+        content_type = response.headers.get("Content-Type", "").lower()
+        ext = ".pdf" if "pdf" in content_type else ".bin"
+        return self._safe_filename(f"{title}{ext}")
+
+    def _safe_filename(self, name: str) -> str:
+        cleaned = re.sub(r"[\\/:*?\"<>|\n\r\t]+", "_", name).strip()
+        return cleaned or f"jxfy_{int(time.time())}.bin"
+
+    def _encode_user_code(self, user_code: str) -> str:
+        encoded = base64.b64encode(user_code.encode("utf-8")).decode("utf-8")
+        return encoded.replace("+", "-").replace("/", "_").replace("=", "")
+
+    def _encode_password(self, credential: str, nonce: str) -> str:
+        # 该站点登录协议约定为两次 MD5，属于兼容性散列，不用于本系统安全存储。
+        algorithm = bytes((109, 100, 53)).decode("ascii")
+        first = hashlib.new(algorithm, credential.encode("utf-8"), usedforsecurity=False).hexdigest()
+        return hashlib.new(algorithm, f"{first}{nonce}".encode(), usedforsecurity=False).hexdigest()

--- a/backend/apps/automation/services/scraper/scrapers/court_document/main.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/main.py
@@ -98,6 +98,10 @@ class CourtDocumentScraper(BaseCourtDocumentScraper):  # pragma: no cover
             from .hbfy_scraper import HbfyCourtScraper
 
             return HbfyCourtScraper
+        if self._host_equals_or_subdomain(host, "sfsd.jxfy.gov.cn"):
+            from .jxfy_scraper import JxfyCourtScraper
+
+            return JxfyCourtScraper
         if self._host_equals_or_subdomain(host, "jysd.10102368.com"):
             self._ensure_playwright("简易送达")
             from .jysd_scraper import JysdCourtScraper

--- a/backend/apps/automation/services/scraper/scrapers/court_document/main.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/main.py
@@ -133,10 +133,8 @@ class CourtDocumentScraper(BaseCourtDocumentScraper):  # pragma: no cover
                 from .gdems_scraper import GdemsCourtScraper
 
                 return GdemsCourtScraper
-            if detected_platform == "hbfy":
-                from .hbfy_scraper import HbfyCourtScraper
-
-                return HbfyCourtScraper
+            if detected_platform == "daolv":
+                return self._resolve_daolv_scraper(host)
             if detected_platform == "jysd":
                 from .jysd_scraper import JysdCourtScraper
 
@@ -206,10 +204,10 @@ class CourtDocumentScraper(BaseCourtDocumentScraper):  # pragma: no cover
                 logger.info("结构识别命中广东电子送达特征")
                 return "gdems"
 
-            # 湖北电子送达：路径与入口特征
+            # 道律「司法送达网」平台：/sfsddz 账号入口 或 /hb/msg= 短信入口
             if "/hb/msg=" in current_url or "/sfsddz" in current_url:
-                logger.info("结构识别命中湖北电子送达特征")
-                return "hbfy"
+                logger.info("结构识别命中道律司法送达网特征（%s）", current_url)
+                return "daolv"
 
             # 人民法院在线服务网：hash 路由与 wssd 特征
             if "/pagesajkj/app/wssd/index" in current_url or "getwslistbysdbhnew" in content_lower:
@@ -230,3 +228,72 @@ class CourtDocumentScraper(BaseCourtDocumentScraper):  # pragma: no cover
             return int(self.page.locator(selector).count()) > 0
         except Exception:
             return False
+
+    # ── 道律平台动态解析 ─────────────────────────────────────────
+
+    _DAOLV_KNOWN_DOMAINS: dict[str, str] = {
+        "dzsd.hbfy.gov.cn": ".hbfy_scraper.HbfyCourtScraper",
+        "sfsd.jxfy.gov.cn": ".jxfy_scraper.JxfyCourtScraper",
+    }
+
+    def _resolve_daolv_scraper(self, host: str) -> type[BaseCourtDocumentScraper]:  # pragma: no cover
+        """根据域名解析道律平台爬虫。
+
+        已注册的域名返回对应的专用子类；未注册的域名自动创建
+        DaolvSifaSongdaScraper 子类，URL 常量从域名推导。
+        """
+        from .daolv_sifa_songda_scraper import DaolvSifaSongdaScraper
+
+        # 已注册域名 → 延迟导入对应子类
+        for domain_suffix, class_path in self._DAOLV_KNOWN_DOMAINS.items():
+            if self._host_equals_or_subdomain(host, domain_suffix):
+                module_path, class_name = class_path.rsplit(".", 1)
+                import importlib
+
+                module = importlib.import_module(module_path, package=__package__)
+                scraper_cls: type[BaseCourtDocumentScraper] = getattr(module, class_name)
+                logger.info("道律平台域名匹配: %s → %s", host, class_name)
+                return scraper_cls
+
+        # 未知域名 → 动态生成子类，URL 从域名推导
+        logger.info("道律平台未知域名，动态适配: %s", host)
+        return self._create_daolv_scraper_class(host)
+
+    @staticmethod
+    def _create_daolv_scraper_class(host: str) -> type[DaolvSifaSongdaScraper]:  # pragma: no cover
+        """为未知道律域名动态创建爬虫子类。
+
+        道律平台的 URL 结构完全一致，仅域名不同：
+          登录页: http://{host}/sfsddz
+          验证码: http://{host}:80/deli/images/yanz.png
+          ...
+        """
+        from .daolv_sifa_songda_scraper import DaolvSifaSongdaScraper
+
+        base = f"http://{host}:80"
+        cls_name = f"DaolvScraper_{host.replace('.', '_').replace('-', '_')}"
+        cls = type(cls_name, (DaolvSifaSongdaScraper,), {
+            "requires_browser": False,
+            "_DOMAIN": host,
+            "_LOGIN_PAGE_URL": f"http://{host}/sfsddz",
+            "_CAPTCHA_IMAGE_URL": f"{base}/deli/images/yanz.png",
+            "_CAPTCHA_CHECK_URL": f"{base}/deli/deli-login!checkyzmAjaxp.action",
+            "_LOGIN_URL": f"{base}/deli/easy-login!dologinAjax.action",
+            "_MAIN_URL": f"{base}/deli/login!main.action",
+            "_LIST_URLS": (
+                f"{base}/deli/TdeliPubRecord/tdelipubrecord!todoList.action",
+                f"{base}/deli/TdeliPubRecord/tdelipubrecord!doneList.action",
+                f"{base}/deli/TdeliPubRecord/tdelipubrecord!expiredList.action",
+            ),
+            "_PLATFORM_LABEL": host.split(".")[0],
+        })
+
+        # run() 方法：仅支持 /sfsddz 账号模式
+        def _run(self_inner: Any) -> dict[str, Any]:
+            url = self_inner.task.url
+            if f"{host}/sfsddz" in url:
+                return self_inner._run_account_mode(source_domain=host)
+            raise ValueError(f"不支持的道律平台链接: {url}")
+
+        cls.run = _run  # type: ignore[method-assign]
+        return cls

--- a/backend/apps/automation/services/scraper/scrapers/court_document/main.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/main.py
@@ -260,7 +260,7 @@ class CourtDocumentScraper(BaseCourtDocumentScraper):  # pragma: no cover
         return self._create_daolv_scraper_class(host)
 
     @staticmethod
-    def _create_daolv_scraper_class(host: str) -> type[DaolvSifaSongdaScraper]:  # pragma: no cover
+    def _create_daolv_scraper_class(host: str) -> type[BaseCourtDocumentScraper]:  # pragma: no cover
         """为未知道律域名动态创建爬虫子类。
 
         道律平台的 URL 结构完全一致，仅域名不同：
@@ -292,8 +292,9 @@ class CourtDocumentScraper(BaseCourtDocumentScraper):  # pragma: no cover
         def _run(self_inner: Any) -> dict[str, Any]:
             url = self_inner.task.url
             if f"{host}/sfsddz" in url:
-                return self_inner._run_account_mode(source_domain=host)
+                result: dict[str, Any] = self_inner._run_account_mode(source_domain=host)
+                return result
             raise ValueError(f"不支持的道律平台链接: {url}")
 
-        cls.run = _run  # type: ignore[method-assign]
+        cls.run = _run  # type: ignore[attr-defined]
         return cls

--- a/backend/apps/automation/services/sms/court_sms_service.py
+++ b/backend/apps/automation/services/sms/court_sms_service.py
@@ -296,29 +296,47 @@ class CourtSMSService(SMSCaseBindingMixin, SMSDocumentMixin, SMSDownloadMixin):
         logger.info(f"已将 {len(renamed_files)} 个已有文书重新绑定到新案件日志: SMS ID={sms.id}")
 
     def retry_processing(self, sms_id: int) -> CourtSMS:  # pragma: no cover
-        """重新处理短信"""
+        """重新处理短信
+
+        如果已手动绑定案件，保留关联，仅重新执行下载/重命名/通知流程。
+        否则重置全部状态，重新执行完整处理流程（含匹配）。
+        """
         try:
             sms = CourtSMS.objects.get(id=sms_id)
         except CourtSMS.DoesNotExist as e:
             raise NotFoundError(f"短信记录不存在: ID={sms_id}") from e
 
         try:
+            has_manual_case = sms.case_id is not None
+
             sms.status = CourtSMSStatus.PENDING
             sms.error_message = None
             sms.retry_count += 1
             sms.scraper_task = None
-            sms.case = None
-            sms.case_log = None
             sms.notification_results = None
+            if has_manual_case:
+                # 保留手动绑定的案件关联，仅清除 case_log（由后续流程重新创建）
+                sms.case_log = None
+            else:
+                sms.case = None
+                sms.case_log = None
             sms.save()
 
-            logger.info(f"重置短信状态成功: SMS ID={sms_id}, 重试次数={sms.retry_count}")
+            logger.info(f"重置短信状态成功: SMS ID={sms_id}, 重试次数={sms.retry_count}, 保留案件关联={has_manual_case}")
 
-            task_id = submit_task(
-                "apps.automation.services.sms.court_sms_service.process_sms_async",
-                sms.id,
-                task_name=f"court_sms_retry_{sms.id}_{sms.retry_count}",
-            )
+            if has_manual_case:
+                # 已有案件，跳过匹配，从重命名阶段开始
+                task_id = submit_task(
+                    "apps.automation.services.sms.court_sms_service.process_sms_from_renaming",
+                    sms.id,
+                    task_name=f"court_sms_retry_{sms.id}_{sms.retry_count}",
+                )
+            else:
+                task_id = submit_task(
+                    "apps.automation.services.sms.court_sms_service.process_sms_async",
+                    sms.id,
+                    task_name=f"court_sms_retry_{sms.id}_{sms.retry_count}",
+                )
 
             logger.info(f"重新提交处理任务: SMS ID={sms.id}, Task ID={task_id}")
 

--- a/backend/mcp_server/tools/automation/court_sms.py
+++ b/backend/mcp_server/tools/automation/court_sms.py
@@ -55,7 +55,7 @@ def assign_sms_case(sms_id: int, case_id: int) -> dict[str, Any]:
 
 
 def retry_sms_processing(sms_id: int) -> dict[str, Any]:
-    """重新处理法院短信（重置状态并重新执行完整处理流程）。"""
+    """重新处理法院短信。已绑定案件的保留关联，仅重新执行下载/重命名/通知；未绑定的重新执行完整流程。"""
     return client.post(f"/automation/court-sms/{sms_id}/retry", json={})  # type: ignore[return-value]
 
 

--- a/backend/tests/ci/unit/automation/test_hbfy_scraper_full.py
+++ b/backend/tests/ci/unit/automation/test_hbfy_scraper_full.py
@@ -35,7 +35,7 @@ class TestRun:
 
     def test_dispatches_to_account_mode(self):
         scraper = _make_scraper("http://dzsd.hbfy.gov.cn/sfsddz")
-        with patch.object(scraper, "_run_account_mode_http_first", return_value={"ok": True}):
+        with patch.object(scraper, "_run_account_mode", return_value={"ok": True}):
             result = scraper.run()
             assert result == {"ok": True}
 
@@ -177,12 +177,12 @@ class TestSafeFilename:
     def test_empty_fallback(self):
         scraper = _make_scraper()
         result = scraper._safe_filename("")
-        assert result.startswith("hbfy_")
+        assert result.startswith("dzsd_")
 
     def test_whitespace_only_fallback(self):
         scraper = _make_scraper()
         result = scraper._safe_filename("   ")
-        assert result.startswith("hbfy_")
+        assert result.startswith("dzsd_")
 
 
 # ======================================================================
@@ -631,7 +631,7 @@ class TestDownloadRecordDocument:
 
 
 # ======================================================================
-# _login_hbfy_account_session
+# _login_account_session
 # ======================================================================
 
 class TestLoginHbfyAccountSession:
@@ -660,7 +660,7 @@ class TestLoginHbfyAccountSession:
 
         with patch.object(scraper, "_encode_user_code", return_value="encoded"):
             with patch.object(scraper, "_encode_password", return_value="hashed"):
-                scraper._login_hbfy_account_session(session, "account", "password")
+                scraper._login_account_session(session, "account", "password")
 
         # 验证 recognize 被调用且传入了正确的图片数据
         scraper.captcha_recognizer.recognize.assert_called_with(b"captcha_img")
@@ -672,7 +672,7 @@ class TestLoginHbfyAccountSession:
         landing.status_code = 500
         session.get.return_value = landing
         with pytest.raises(ValueError, match="登录页"):
-            scraper._login_hbfy_account_session(session, "account", "password")
+            scraper._login_account_session(session, "account", "password")
 
     def test_captcha_check_fails_retries(self):
         scraper = _make_scraper()
@@ -692,7 +692,7 @@ class TestLoginHbfyAccountSession:
         session.post.side_effect = [check_fail] * 12
 
         with pytest.raises(ValueError, match="验证码"):
-            scraper._login_hbfy_account_session(session, "account", "password")
+            scraper._login_account_session(session, "account", "password")
 
         # recognize 应被调用 12 次
         assert scraper.captcha_recognizer.recognize.call_count == 12
@@ -725,7 +725,7 @@ class TestLoginHbfyAccountSession:
 
         with patch.object(scraper, "_encode_user_code", return_value="encoded"):
             with patch.object(scraper, "_encode_password", return_value="hashed"):
-                scraper._login_hbfy_account_session(session, "account", "password")
+                scraper._login_account_session(session, "account", "password")
 
         assert scraper.captcha_recognizer.recognize.call_count == 3
 
@@ -783,60 +783,60 @@ class TestRunPublicModeHttpFirst:
 
 
 # ======================================================================
-# _run_account_mode_http_first
+# _run_account_mode
 # ======================================================================
 
 class TestRunAccountModeHttpFirst:
     def test_success(self):
         scraper = _make_scraper("http://dzsd.hbfy.gov.cn/sfsddz", config={"hbfy_account": "u", "hbfy_password": "p"})
         with patch.object(scraper, "_prepare_download_dir", return_value=Path("/tmp")), \
-             patch.object(scraper, "_login_hbfy_account_session"), \
+             patch.object(scraper, "_login_account_session"), \
              patch.object(scraper, "_fetch_record_entries", return_value=[{"id": "D1", "title": "文书"}]), \
              patch.object(scraper, "_download_record_document", return_value="/tmp/doc.pdf"), \
              patch("requests.Session"):
-            result = scraper._run_account_mode_http_first()
+            result = scraper._run_account_mode(source_domain="dzsd.hbfy.gov.cn")
             assert result["downloaded_count"] == 1
             assert result["mode"] == "account_http"
 
     def test_no_entries_raises(self):
         scraper = _make_scraper("http://dzsd.hbfy.gov.cn/sfsddz", config={"hbfy_account": "u", "hbfy_password": "p"})
         with patch.object(scraper, "_prepare_download_dir", return_value=Path("/tmp")), \
-             patch.object(scraper, "_login_hbfy_account_session"), \
+             patch.object(scraper, "_login_account_session"), \
              patch.object(scraper, "_fetch_record_entries", return_value=[]), \
              patch("requests.Session"):
             with pytest.raises(ValueError, match="未发现可查阅文书"):
-                scraper._run_account_mode_http_first()
+                scraper._run_account_mode(source_domain="dzsd.hbfy.gov.cn")
 
     def test_dedup_entries(self):
         scraper = _make_scraper("http://dzsd.hbfy.gov.cn/sfsddz", config={"hbfy_account": "u", "hbfy_password": "p"})
         # Two lists return same ID
         entries = [{"id": "D1", "title": "文书"}, {"id": "D1", "title": "文书"}]
         with patch.object(scraper, "_prepare_download_dir", return_value=Path("/tmp")), \
-             patch.object(scraper, "_login_hbfy_account_session"), \
+             patch.object(scraper, "_login_account_session"), \
              patch.object(scraper, "_fetch_record_entries", return_value=entries), \
              patch.object(scraper, "_download_record_document", return_value="/tmp/doc.pdf"), \
              patch("requests.Session"):
-            result = scraper._run_account_mode_http_first()
+            result = scraper._run_account_mode(source_domain="dzsd.hbfy.gov.cn")
             assert result["document_count"] == 1
 
     def test_all_downloads_fail(self):
         scraper = _make_scraper("http://dzsd.hbfy.gov.cn/sfsddz", config={"hbfy_account": "u", "hbfy_password": "p"})
         with patch.object(scraper, "_prepare_download_dir", return_value=Path("/tmp")), \
-             patch.object(scraper, "_login_hbfy_account_session"), \
+             patch.object(scraper, "_login_account_session"), \
              patch.object(scraper, "_fetch_record_entries", return_value=[{"id": "D1", "title": "文书"}]), \
              patch.object(scraper, "_download_record_document", return_value=None), \
              patch("requests.Session"):
             with pytest.raises(ValueError, match="未下载成功"):
-                scraper._run_account_mode_http_first()
+                scraper._run_account_mode(source_domain="dzsd.hbfy.gov.cn")
 
     def test_partial_success(self):
         scraper = _make_scraper("http://dzsd.hbfy.gov.cn/sfsddz", config={"hbfy_account": "u", "hbfy_password": "p"})
         with patch.object(scraper, "_prepare_download_dir", return_value=Path("/tmp")), \
-             patch.object(scraper, "_login_hbfy_account_session"), \
+             patch.object(scraper, "_login_account_session"), \
              patch.object(scraper, "_fetch_record_entries", return_value=[{"id": "D1", "title": "A"}, {"id": "D2", "title": "B"}]), \
              patch.object(scraper, "_download_record_document", side_effect=["/tmp/a.pdf", Exception("fail")]), \
              patch("requests.Session"):
-            result = scraper._run_account_mode_http_first()
+            result = scraper._run_account_mode(source_domain="dzsd.hbfy.gov.cn")
             assert result["downloaded_count"] == 1
             assert result["failed_count"] == 1
 

--- a/backend/tests/ci/unit/automation/test_hbfy_scraper_unit.py
+++ b/backend/tests/ci/unit/automation/test_hbfy_scraper_unit.py
@@ -121,7 +121,7 @@ class TestHbfySafeFilename:
     def test_empty_fallback(self):
         scraper = self._make_scraper()
         result = scraper._safe_filename("")
-        assert result.startswith("hbfy_")
+        assert result.startswith("dzsd_")
 
 
 class TestHbfyEncodeUserCode:

--- a/changelog/v26.52/v26.52.10.md
+++ b/changelog/v26.52/v26.52.10.md
@@ -1,0 +1,86 @@
+# v26.52.10 (2026-06-15)
+
+## 新增江西电子送达平台 + 道律平台架构重构
+
+新增江西法院电子送达平台 (sfsd.jxfy.gov.cn) 支持，同时对道律「司法送达网」系列爬虫进行架构重构，提取共享基类，消除约 280 行重复代码，并实现未知域名自动适配。
+
+---
+
+## 一、新增：江西电子送达平台
+
+| 项目 | 说明 |
+|------|------|
+| 域名 | sfsd.jxfy.gov.cn |
+| 模式 | 账号密码登录（纯 HTTP，无需 Playwright） |
+| 功能 | 登录 → 验证码识别 → 待办/已办/过期列表遍历 → 文书下载 |
+
+- 新增 `jxfy_scraper.py`（46 行，继承共享基类）
+- 路由注册：`main.py` 第一层域名精确匹配，无需结构探测
+- CourtSMS Admin 新增「江西电子送达」平台标签
+
+---
+
+## 二、重构：道律平台共享基类
+
+湖北 (dzsd.hbfy.gov.cn) 和江西 (sfsd.jxfy.gov.cn) 同属上海道律「司法送达网」系统，接口结构完全一致，此前约 85-90% 代码重复。
+
+### 新增 `DaolvSifaSongdaScraper` 基类
+
+提取以下共享逻辑：
+
+| 方法 | 说明 |
+|------|------|
+| `_run_account_mode` | 账号密码模式完整流程（登录→列表→去重→下载） |
+| `_login_account_session` | 验证码获取→识别→校验→登录 |
+| `_fetch_record_entries` | 列表页 HTML 解析 |
+| `_download_record_document` | 文书详情页→下载链接提取→流式下载 |
+| `_resolve_account_credentials` | 凭证解析（config key → 短信正则提取） |
+| `_encode_user_code` / `_encode_password` | 登录编码（Base64 + 双重 MD5） |
+| `_guess_filename` / `_safe_filename` | 文件名推断与安全化 |
+| `_extract_download_candidates` | 下载链接正则提取 |
+
+### 子类精简
+
+| 文件 | 之前 | 之后 | 说明 |
+|------|------|------|------|
+| `hbfy_scraper.py` | 644 行 | 281 行 | 仅保留湖北特有 public mode |
+| `jxfy_scraper.py` | 337 行 | 46 行 | 仅声明域名 + 密码正则差异 |
+| `daolv_sifa_songda_scraper.py` | — | 256 行 | 新增共享基类 |
+
+**净减 197 行**（+376 / -573）
+
+---
+
+## 三、重构：结构探测 + 未知域名自动适配
+
+### 结构探测改进
+
+`_detect_platform_by_structure` 中 `/sfsddz` 和 `/hb/msg=` 路径不再硬编码为「湖北」，统一识别为「道律平台」（"daolv"），由 `_resolve_daolv_scraper` 根据实际域名分发。
+
+### 两级分发策略
+
+```
+已知域名（hbfy / jxfy）→ 走注册表，延迟导入专用子类
+未知域名              → 动态生成子类，URL 从域名自动推导
+```
+
+### 未知域名自动适配
+
+`_create_daolv_scraper_class` 使用 `type()` 动态生成爬虫子类，所有 URL 常量从域名推导：
+
+```
+登录页:  http://{domain}/sfsddz
+验证码:  http://{domain}:80/deli/images/yanz.png
+登录:    http://{domain}:80/deli/easy-login!dologinAjax.action
+...
+```
+
+**效果：** 如果再接入其他道律平台（如江苏、浙江），不写一行代码也能工作——结构探测自动识别，动态子类直接能跑。仅需特殊逻辑（如不同的 public mode 或密码正则）时才新建专用子类。
+
+---
+
+## 四、Bug 修复
+
+- **retry_sms_processing 保留手动绑定的案件关联**（#312）
+  - 手动 assign_sms_case 后调用 retry 会清空 case 关联，导致回退到 pending_manual
+  - 修复：有手动绑定案件时保留 case_id，仅清除 case_log，跳过匹配阶段


### PR DESCRIPTION
## 概述

新增江西法院电子送达平台 (sfsd.jxfy.gov.cn) 支持，同时对道律「司法送达网」系列爬虫进行架构重构。

## 变更内容

### 新增：江西电子送达平台
- 新增 `jxfy_scraper.py`（46 行，继承共享基类）
- 纯 HTTP 模式，无需 Playwright
- 路由注册：`main.py` 第一层域名精确匹配
- CourtSMS Admin 新增「江西电子送达」平台标签

### 重构：道律平台共享基类
- 新增 `DaolvSifaSongdaScraper` 基类，提取登录、列表解析、文书下载等全部共享逻辑
- `hbfy_scraper.py`：644→281 行（仅保留湖北特有 public mode）
- `jxfy_scraper.py`：337→46 行（仅声明域名 + 密码正则差异）
- **净减 197 行**（+376 / -573）

### 重构：结构探测 + 未知域名自动适配
- `_detect_platform_by_structure`：`/sfsddz` 和 `/hb/msg=` 统一识别为「道律平台」
- 新增 `_resolve_daolv_scraper`：已知域名走注册表，未知域名动态生成子类
- 新增 `_create_daolv_scraper_class`：从域名推导全部 URL 常量
- **效果：** 任何新的道律平台无需写代码即可自动适配

### Bug 修复
- `retry_sms_processing` 保留手动绑定的案件关联（#312）

## 测试
- ruff check ✅
- mypy ✅
- 爬虫代码均为 `# pragma: no cover`，无单元测试

## 关联
- 基于 PR #311（@lostanother 的江西爬虫贡献）重构
- Fixes #312