### PR TITLE
fix: 修复 ruff 未使用导入错误

### DIFF
--- a/backend/apps/automation/services/scraper/core/captcha_recognizer.py
+++ b/backend/apps/automation/services/scraper/core/captcha_recognizer.py
@@ -4,7 +4,6 @@
 提供可插拔的验证码识别功能，支持多种识别服务。
 """
 
-import json
 import logging
 import time
 import uuid

--- a/backend/apps/automation/services/scraper/sites/court_zxfw.py
+++ b/backend/apps/automation/services/scraper/sites/court_zxfw.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from playwright.sync_api import BrowserContext
-from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page
 
 if TYPE_CHECKING:

--- a/backend/tests/ci/unit/automation/test_captcha_recognizer.py
+++ b/backend/tests/ci/unit/automation/test_captcha_recognizer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,7 +50,6 @@ class TestManualCaptchaRecognizerRecognize:
         r = ManualCaptchaRecognizer(task=task, timeout=0, poll_interval=0.01)
 
         with patch("apps.automation.services.scraper.core.captcha_recognizer.Path") as mock_path_cls:
-            mock_dir = MagicMock()
             mock_path_instance = MagicMock()
             mock_path_instance.__truediv__ = MagicMock(return_value=MagicMock())
             mock_path_cls.return_value = mock_path_instance

--- a/backend/tests/ci/unit/automation/test_captcha_recognizer_coverage.py
+++ b/backend/tests/ci/unit/automation/test_captcha_recognizer_coverage.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/backend/tests/ci/unit/automation/test_manual_captcha_recognizer.py
+++ b/backend/tests/ci/unit/automation/test_manual_captcha_recognizer.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch, call
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 
 # ======================================================================


### PR DESCRIPTION
## 修复内容

### 修复 ruff 未使用导入错误

| 文件 | 修复 |
|------|------|
| captcha_recognizer.py | 移除未使用的 `import json` |
| court_zxfw.py | 移除未使用的 `PlaywrightError` 导入 |
| test_captcha_recognizer.py | 移除未使用的 `SimpleNamespace`、`mock_dir` |
| test_captcha_recognizer_coverage.py | 移除未使用的 `SimpleNamespace` |
| test_manual_captcha_recognizer.py | 移除未使用的 `time`、`call`、`pytest` |

## 测试

- [x] ruff check 通过

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
