### PR TITLE
fix: 修复 test_detect_batch_multiple 测试超时导致 CI 失败

### DIFF
--- a/backend/tests/ci/unit/image_rotation/test_round5_coverage.py
+++ b/backend/tests/ci/unit/image_rotation/test_round5_coverage.py
@@ -750,11 +750,12 @@ class TestOrientationDetectionServiceFull:
         assert result["rotation"] == 0
         assert "ocr_text" in result
 
-    def test_detect_batch_multiple(self):
+    @patch("apps.image_rotation.services.orientation.service.OrientationDetectionService.ocr_service",
+           new_callable=PropertyMock, return_value=None)
+    def test_detect_batch_multiple(self, _mock_ocr_prop):
         from apps.image_rotation.services.orientation.service import OrientationDetectionService
         import base64
         svc = OrientationDetectionService()
-        svc._ocr_service = None
         img_b64 = base64.b64encode(_make_test_image()).decode()
         results = svc.detect_batch([
             {"filename": "a.png", "data": img_b64},


### PR DESCRIPTION
## 问题描述

远端 CI `backend-ci` 的 `Tests (unit)` 步骤超时失败：

```
FAILED tests/ci/unit/image_rotation/test_round5_coverage.py::TestOrientationDetectionServiceFull::test_detect_batch_multiple
  - Failed: Timeout (>30.0s) from pytest-timeout.
```

## 根本原因

测试代码设置 `svc._ocr_service = None`，但被测方法 `detect_batch` → `detect_orientation_with_text` 访问的是 `ocr_service` **属性**（property），而非实例属性 `_ocr_service`。

属性 getter 发现 `_ocr_service is None` 后，会尝试**真实导入** `OCRService(use_v5=True)`。在 CI 环境中，这个导入/初始化可能涉及重型依赖加载或外部服务连接，导致超过 30 秒超时限制。

```python
# 原来的测试（会触发真实导入）
svc = OrientationDetectionService()
svc._ocr_service = None  # 设置实例属性
# 但 detect_orientation_with_text 访问 self.ocr_service 属性
# → 触发 OCRService 真实导入 → 超时
```

## 修复方案

使用 `@patch` 装饰器 + `PropertyMock` 直接 mock `ocr_service` 属性返回 `None`，完全避免触发真实导入：

```python
@patch("apps.image_rotation.services.orientation.service.OrientationDetectionService.ocr_service",
       new_callable=PropertyMock, return_value=None)
def test_detect_batch_multiple(self, _mock_ocr_prop):
    svc = OrientationDetectionService()
    # 不再需要 svc._ocr_service = None
    ...
```

## 测试结果

- 修复前：超时 (>30s) ❌
- 修复后：3.23s 通过 ✅
- 全部 image_rotation 测试：364/364 通过 ✅

## 改动范围

- `backend/tests/ci/unit/image_rotation/test_round5_coverage.py`：修复 `test_detect_batch_multiple` 测试方法

🤖 Generated with [Claude Code](https://claude.com/claude-code)