### PR TITLE
fix: CaseLogUpdate model_fields_set 污染导致 update_case_log API 400

### DIFF
--- a/backend/apps/cases/schemas/log_schemas.py
+++ b/backend/apps/cases/schemas/log_schemas.py
@@ -39,15 +39,19 @@ class _CaseLogReminderMixin(Schema):
 
     @model_validator(mode="after")
     def validate_reminder_fields(self) -> _CaseLogReminderMixin:
-        fields_set: set[str] = getattr(self, "model_fields_set", set())
-        reminder_type_set = "reminder_type" in fields_set
-        reminder_time_set = "reminder_time" in fields_set
+        # Pydantic v2: self.field = ... in model_validator(mode="after")
+        # mutates model_fields_set, leaking defaults into exclude_unset=True.
+        # Snapshot the original set and restore after assignments.
+        original_fields_set = set(self.model_fields_set)
+        reminder_type_set = "reminder_type" in original_fields_set
+        reminder_time_set = "reminder_time" in original_fields_set
         if reminder_type_set != reminder_time_set:
             raise ValueError("提醒类型和提醒时间必须同时提供")
         if reminder_type_set and reminder_time_set:
             if (self.reminder_type is None) != (self.reminder_time is None):
                 raise ValueError("提醒类型和提醒时间必须同时为空或同时有值")
         self.reminder_type = _validate_reminder_type(self.reminder_type)
+        object.__setattr__(self, "__pydantic_fields_set__", original_fields_set)
         return self
 
 

--- a/backend/tests/ci/unit/cases/test_case_log_reminder_mixin.py
+++ b/backend/tests/ci/unit/cases/test_case_log_reminder_mixin.py
@@ -1,0 +1,76 @@
+"""Regression tests for _CaseLogReminderMixin Pydantic v2 model_fields_set leak.
+
+Bug: Pydantic v2.13.3 model_validator(mode="after") that assigns to self.field
+mutates model_fields_set, causing model_dump(exclude_unset=True) to leak
+default values that were never provided by the caller.
+
+Fix: Snapshot model_fields_set before assignments and restore after.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from apps.cases.schemas.log_schemas import CaseLogCreate, CaseLogIn, CaseLogUpdate
+
+
+class TestCaseLogReminderMixinFieldsSet:
+    """Ensure model_fields_set is not polluted by validator assignments."""
+
+    def test_update_only_content_no_reminder_leak(self) -> None:
+        """CaseLogUpdate with only content should not include reminder fields."""
+        schema = CaseLogUpdate(content="test content")
+        dumped = schema.model_dump(exclude_unset=True)
+        assert "reminder_type" not in dumped
+        assert "reminder_time" not in dumped
+        assert "content" in dumped
+
+    def test_update_empty_body_no_reminder_leak(self) -> None:
+        """CaseLogUpdate with no fields should produce empty dict."""
+        schema = CaseLogUpdate()
+        dumped = schema.model_dump(exclude_unset=True)
+        assert dumped == {}
+
+    def test_update_both_reminders_no_leak(self) -> None:
+        """CaseLogUpdate with both reminder fields should include both."""
+        now = datetime.now(tz=timezone.utc)
+        schema = CaseLogUpdate(content="x", reminder_type="hearing", reminder_time=now)
+        dumped = schema.model_dump(exclude_unset=True)
+        assert "reminder_type" in dumped
+        assert "reminder_time" in dumped
+        assert "content" in dumped
+
+    def test_in_only_content_no_reminder_leak(self) -> None:
+        """CaseLogIn with only case_id and content should not leak reminders."""
+        schema = CaseLogIn(case_id=1, content="test")
+        dumped = schema.model_dump(exclude_unset=True)
+        assert "reminder_type" not in dumped
+        assert "reminder_time" not in dumped
+        assert "case_id" in dumped
+        assert "content" in dumped
+
+    def test_create_only_content_no_reminder_leak(self) -> None:
+        """CaseLogCreate with only content should not leak reminders."""
+        schema = CaseLogCreate(content="test")
+        dumped = schema.model_dump(exclude_unset=True)
+        assert "reminder_type" not in dumped
+        assert "reminder_time" not in dumped
+        assert "content" in dumped
+
+    def test_update_reminder_type_without_time_rejected(self) -> None:
+        """Providing only reminder_type (no time) should raise."""
+        with pytest.raises(Exception, match="提醒类型和提醒时间必须同时提供"):
+            CaseLogUpdate(content="x", reminder_type="hearing")
+
+    def test_update_reminder_time_without_type_rejected(self) -> None:
+        """Providing only reminder_time (no type) should raise."""
+        now = datetime.now(tz=timezone.utc)
+        with pytest.raises(Exception, match="提醒类型和提醒时间必须同时提供"):
+            CaseLogUpdate(content="x", reminder_time=now)
+
+    def test_reminder_type_validation_preserved(self) -> None:
+        """Invalid reminder type should still be rejected."""
+        now = datetime.now(tz=timezone.utc)
+        with pytest.raises(Exception, match="无效的提醒类型"):
+            CaseLogUpdate(content="x", reminder_type="invalid_type", reminder_time=now)


### PR DESCRIPTION
## 问题

Pydantic v2.13.3 中 `model_validator(mode="after")` 对 `self.field` 赋值会将该字段注入 `model_fields_set`，即使调用方从未传过该字段。

导致 `model_dump(exclude_unset=True)` 泄漏 `reminder_type: null` 到 data dict，mutation service 误判为"只传了一个 reminder"而报错"提醒类型和提醒时间必须同时提供"。

## 修复

在 `_CaseLogReminderMixin.validate_reminder_fields` 中快照原始 `model_fields_set`，赋值后通过 `object.__setattr__(self, "__pydantic_fields_set__", ...)` 恢复。

## 影响

`CaseLogIn` / `CaseLogUpdate` / `CaseLogCreate` 三个 schema 均受益。

## 测试

- 新增 8 个回归测试覆盖各种字段组合
- 全量测试 1042 passed
