### PR TITLE
fix: add type annotations for conditional plugin router imports

### DIFF
--- a/backend/apiSystem/apiSystem/api.py
+++ b/backend/apiSystem/apiSystem/api.py
@@ -154,14 +154,18 @@ register_exception_handlers(api_v1)
 def _register_app_routers() -> None:
     from apps.automation.api import router as automation_router
 
+    from ninja import Router
+
+    court_filing_router: Router | None = None
+    court_guarantee_router: Router | None = None
     try:
         from plugins.court_automation.filing.api_endpoint import router as court_filing_router
     except ImportError:
-        court_filing_router = None
+        pass
     try:
         from plugins.court_automation.guarantee.api_endpoint import router as court_guarantee_router
     except ImportError:
-        court_guarantee_router = None
+        pass
     from apps.batch_printing.api import router as batch_printing_router
     from apps.cases.api import router as cases_router
     from apps.chat_records.api import router as chat_records_router


### PR DESCRIPTION
## Summary

Fix mypy-curated gate failure on main caused by the court_automation plugin migration PR #333.

### Problem

`apiSystem/apiSystem/api.py` lines 160, 164: Conditional `try/except ImportError` blocks assigned `None` to `court_filing_router` and `court_guarantee_router` variables. mypy inferred the type as `Router` from the import statement and rejected the `None` assignment.

### Fix

Added explicit `Router | None` type annotations and pre-declared the variables before the `try` blocks.

## Test Results

```
CI: 10 passed, 0 failed, 12 skipped — all green
```