### PR TITLE
fix: 修复询价任务自动触发 + 新增 Valkey 队列管理页面

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -410,7 +410,7 @@ jobs:
           TEST_DB_HOST: "127.0.0.1"
           TEST_DB_PORT: "5432"
           PYTHONPATH: "apiSystem:."
-        run: uv run pytest -c pytest.ini --no-cov -q tests/ci/integration/
+        run: uv run pytest -c pytest.ini -o "addopts=--reuse-db --import-mode=importlib -q --tb=short --strict-markers --timeout=60" --no-cov -q tests/ci/integration/
 
   backend-property-smoke:
     runs-on: ubuntu-latest

--- a/backend/apiSystem/apiSystem/admin_customization.py
+++ b/backend/apiSystem/apiSystem/admin_customization.py
@@ -141,7 +141,7 @@ _OTHER_TOOLS_APPS = [
             {"name": _("LPR计算器"), "url": "/admin/finance/calculator/"},
         ],
     },
-    {"app_label": "django_q", "name": _("任务队列"), "url": "/admin/django_q/"},
+    {"app_label": "core", "name": _("Redis 任务队列"), "url": "/admin/core/redisqueuetool/"},
     {"app_label": "organization", "name": _("组织管理"), "url": "/admin/organization/"},
     {"app_label": "auth", "name": _("用户与权限"), "url": "/admin/auth/"},
     {"app_label": "core", "name": _("核心系统"), "url": "/admin/core/"},

--- a/backend/apiSystem/apiSystem/admin_customization.py
+++ b/backend/apiSystem/apiSystem/admin_customization.py
@@ -141,7 +141,7 @@ _OTHER_TOOLS_APPS = [
             {"name": _("LPR计算器"), "url": "/admin/finance/calculator/"},
         ],
     },
-    {"app_label": "core", "name": _("Redis 任务队列"), "url": "/admin/core/redisqueuetool/"},
+    {"app_label": "core", "name": _("Valkey 任务队列"), "url": "/admin/core/redisqueuetool/"},
     {"app_label": "organization", "name": _("组织管理"), "url": "/admin/organization/"},
     {"app_label": "auth", "name": _("用户与权限"), "url": "/admin/auth/"},
     {"app_label": "core", "name": _("核心系统"), "url": "/admin/core/"},

--- a/backend/apps/automation/models/preservation.py
+++ b/backend/apps/automation/models/preservation.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from django.conf import settings
 from django.db import models
-from django_lifecycle import AFTER_CREATE, LifecycleModel, hook
+from django_lifecycle import LifecycleModel
 
 if TYPE_CHECKING:
     from django.db.models.fields.related_descriptors import RelatedManager
@@ -80,36 +80,6 @@ class PreservationQuote(LifecycleModel):
         if self.total_companies == 0:
             return 0.0
         return (self.success_count / self.total_companies) * 100
-
-    @hook(AFTER_CREATE)
-    def on_create_auto_submit(self) -> None:
-        """创建时若 status=PENDING，自动提交异步询价任务"""
-        if self.status != QuoteStatus.PENDING:
-            return
-
-        try:
-            from apps.core.tasking import submit_task
-
-            task_id = submit_task(
-                "apps.automation.tasks.execute_preservation_quote_task",
-                self.id,
-                task_name=f"询价任务 #{self.id}",
-                timeout=600,
-            )
-            logger.info(
-                "✅ 询价任务 #%s 已自动提交到队列，Task ID: %s",
-                self.id,
-                task_id,
-                extra={"action": "auto_submit_quote", "quote_id": self.id, "task_id": task_id},
-            )
-        except Exception as e:
-            logger.error(
-                "❌ 自动提交询价任务 #%s 失败: %s",
-                self.id,
-                e,
-                extra={"action": "auto_submit_quote_failed", "quote_id": self.id, "error": str(e)},
-                exc_info=True,
-            )
 
 
 class InsuranceQuote(models.Model):

--- a/backend/apps/core/admin/__init__.py
+++ b/backend/apps/core/admin/__init__.py
@@ -1,7 +1,7 @@
 """Core 模块 Admin 配置"""
 
 from ..cloud_storage import admin as cloud_storage_admin
-from . import cause_of_action_admin, court_admin
+from . import cause_of_action_admin, court_admin, redis_queue_admin
 from .system_config_admin import SystemConfigAdmin
 
 __all__ = ["SystemConfigAdmin"]

--- a/backend/apps/core/admin/redis_queue_admin.py
+++ b/backend/apps/core/admin/redis_queue_admin.py
@@ -29,8 +29,8 @@ class RedisQueueTool(models.Model):
     class Meta:
         app_label = "core"
         managed = False
-        verbose_name = "Redis 任务队列"
-        verbose_name_plural = "Redis 任务队列"
+        verbose_name = "Valkey 任务队列"
+        verbose_name_plural = "Valkey 任务队列"
 
 
 @admin.register(RedisQueueTool)
@@ -67,7 +67,7 @@ class RedisQueueAdmin(admin.ModelAdmin):  # pragma: no cover
 
     def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> TemplateResponse:
         if not is_redis_broker():
-            messages.warning(request, _("当前未使用 Redis 作为任务队列，此功能不可用。"))
+            messages.warning(request, _("当前未使用 Valkey 作为任务队列，此功能不可用。"))
             return HttpResponseRedirect("/admin/")
 
         if request.method == "POST":
@@ -109,7 +109,7 @@ class RedisQueueAdmin(admin.ModelAdmin):  # pragma: no cover
         tasks = list_tasks(limit=500)
 
         context = {
-            "title": "Redis 任务队列",
+            "title": "Valkey 任务队列",
             "tasks": tasks,
             "queue_length": queue_length,
             "has_view_permission": True,

--- a/backend/apps/core/admin/redis_queue_admin.py
+++ b/backend/apps/core/admin/redis_queue_admin.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from django.contrib import admin, messages
 from django.db import models
-from django.http import HttpRequest, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext_lazy as _
 
@@ -65,7 +65,7 @@ class RedisQueueAdmin(admin.ModelAdmin):  # pragma: no cover
 
     # ---- 主视图 ----
 
-    def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> TemplateResponse:
+    def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> HttpResponse:
         if not is_redis_broker():
             messages.warning(request, _("当前未使用 Valkey 作为任务队列，此功能不可用。"))
             return HttpResponseRedirect("/admin/")

--- a/backend/apps/core/admin/redis_queue_admin.py
+++ b/backend/apps/core/admin/redis_queue_admin.py
@@ -1,0 +1,120 @@
+"""Redis 任务队列管理 Admin。
+
+当 Django Q 使用 Redis broker 时，在 Admin 中提供队列查看/删除/清空功能。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib import admin, messages
+from django.db import models
+from django.http import HttpRequest, HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.utils.translation import gettext_lazy as _
+
+from apps.core.tasking.redis_queue import (
+    delete_task_by_index,
+    delete_tasks_by_ids,
+    get_queue_length,
+    is_redis_broker,
+    list_tasks,
+    purge_queue,
+)
+
+
+class RedisQueueTool(models.Model):
+    """虚拟模型：Redis 任务队列管理工具入口（不建数据库表）。"""
+
+    class Meta:
+        app_label = "core"
+        managed = False
+        verbose_name = "Redis 任务队列"
+        verbose_name_plural = "Redis 任务队列"
+
+
+@admin.register(RedisQueueTool)
+class RedisQueueAdmin(admin.ModelAdmin):  # pragma: no cover
+    """Redis 任务队列管理页面。"""
+
+    # ---- 权限控制 ----
+
+    def has_module_permission(self, request: HttpRequest) -> bool:
+        if not is_redis_broker():
+            return False
+        return bool(request.user and request.user.is_active and request.user.is_superuser)
+
+    def has_view_permission(self, request: HttpRequest, obj: Any | None = None) -> bool:
+        if not is_redis_broker():
+            return False
+        return bool(request.user and request.user.is_active and request.user.is_superuser)
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
+
+    def has_change_permission(self, request: HttpRequest, obj: Any | None = None) -> bool:
+        return False
+
+    def has_delete_permission(self, request: HttpRequest, obj: Any | None = None) -> bool:
+        return False
+
+    def get_model_perms(self, request: HttpRequest) -> dict[str, bool]:
+        if not self.has_view_permission(request):
+            return {}
+        return {"view": True, "add": False, "change": False, "delete": False}
+
+    # ---- 主视图 ----
+
+    def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> TemplateResponse:
+        if not is_redis_broker():
+            messages.warning(request, _("当前未使用 Redis 作为任务队列，此功能不可用。"))
+            return HttpResponseRedirect("/admin/")
+
+        if request.method == "POST":
+            return self._handle_post(request)
+
+        return self._render_list(request)
+
+    # ---- POST 处理 ----
+
+    def _handle_post(self, request: HttpRequest) -> HttpResponseRedirect:
+        action = request.POST.get("action")
+
+        if action == "purge":
+            count = purge_queue()
+            messages.success(request, _(f"已清空队列，共删除 {count} 个任务。"))
+
+        elif action == "delete_selected":
+            raw_ids = request.POST.getlist("task_ids")
+            if raw_ids:
+                count = delete_tasks_by_ids(set(raw_ids))
+                messages.success(request, _(f"已删除 {count} 个任务。"))
+
+        elif action == "delete_one":
+            try:
+                index = int(request.POST.get("index", "-1"))
+                if delete_task_by_index(index):
+                    messages.success(request, _("已删除该任务。"))
+                else:
+                    messages.warning(request, _("任务未找到，可能已被处理。"))
+            except (ValueError, TypeError):
+                messages.error(request, _("无效的任务索引。"))
+
+        return HttpResponseRedirect(request.path)
+
+    # ---- GET 渲染 ----
+
+    def _render_list(self, request: HttpRequest) -> TemplateResponse:
+        queue_length = get_queue_length()
+        tasks = list_tasks(limit=500)
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Redis 任务队列",
+            "tasks": tasks,
+            "queue_length": queue_length,
+            "opts": self.model._meta,
+            "app_label": self.model._meta.app_label,
+            "has_view_permission": True,
+        }
+        return TemplateResponse(request, "admin/core/redisqueuetool/change_list.html", context)

--- a/backend/apps/core/admin/redis_queue_admin.py
+++ b/backend/apps/core/admin/redis_queue_admin.py
@@ -109,12 +109,11 @@ class RedisQueueAdmin(admin.ModelAdmin):  # pragma: no cover
         tasks = list_tasks(limit=500)
 
         context = {
-            **self.admin_site.each_context(request),
             "title": "Redis 任务队列",
             "tasks": tasks,
             "queue_length": queue_length,
-            "opts": self.model._meta,
-            "app_label": self.model._meta.app_label,
             "has_view_permission": True,
+            "site_header": self.admin_site.site_header,
+            "site_title": self.admin_site.site_title,
         }
         return TemplateResponse(request, "admin/core/redisqueuetool/change_list.html", context)

--- a/backend/apps/core/tasking/redis_queue.py
+++ b/backend/apps/core/tasking/redis_queue.py
@@ -1,0 +1,202 @@
+"""Redis 任务队列管理服务。
+
+提供对 Django Q Redis broker 中排队任务的查看、删除、清空操作。
+仅在 Redis broker 激活时可用（即 REDIS_URL 已配置）。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger("apps.core.tasking")
+
+
+@dataclass
+class QueuedTask:
+    """从 Redis 队列中反序列化的任务信息。"""
+
+    index: int
+    task_id: str
+    name: str
+    func: str
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+    started: datetime | None
+    raw: str  # 原始签名字符串，用于 LREM 定位
+
+
+def _get_redis_connection() -> Any:
+    """获取 Django Q 使用的 Redis 连接。"""
+    from django_q.conf import Conf
+
+    if not getattr(Conf, "REDIS", None):
+        return None
+
+    import redis
+
+    return redis.Redis.from_url(Conf.REDIS)
+
+
+def _get_queue_key() -> str:
+    """获取 Redis 队列的 key 名称。"""
+    from django_q.conf import Conf
+
+    return f"django_q:{Conf.CLUSTER_NAME}:q"
+
+
+def is_redis_broker() -> bool:
+    """检查当前是否使用 Redis 作为 Django Q broker。"""
+    from django_q.conf import Conf
+
+    return bool(getattr(Conf, "REDIS", None))
+
+
+def get_queue_length() -> int:
+    """获取队列中的待处理任务数量。"""
+    conn = _get_redis_connection()
+    if conn is None:
+        return 0
+    key = _get_queue_key()
+    return conn.llen(key)
+
+
+def list_tasks(limit: int = 200) -> list[QueuedTask]:
+    """列出队列中的任务（不移除）。
+
+    Args:
+        limit: 最多返回的任务数量
+
+    Returns:
+        按入队顺序排列的任务列表
+    """
+    conn = _get_redis_connection()
+    if conn is None:
+        return []
+
+    key = _get_queue_key()
+    raw_items = conn.lrange(key, 0, limit - 1)
+    if not raw_items:
+        return []
+
+    from django_q.signing import SignedPackage
+
+    tasks: list[QueuedTask] = []
+    for idx, raw_bytes in enumerate(raw_items):
+        try:
+            raw_str = raw_bytes.decode("utf-8") if isinstance(raw_bytes, bytes) else raw_bytes
+            task_dict: dict[str, Any] = SignedPackage.loads(raw_str)
+            tasks.append(
+                QueuedTask(
+                    index=idx,
+                    task_id=task_dict.get("id", ""),
+                    name=task_dict.get("name", ""),
+                    func=task_dict.get("func", ""),
+                    args=task_dict.get("args", ()),
+                    kwargs=task_dict.get("kwargs", {}),
+                    started=task_dict.get("started"),
+                    raw=raw_str,
+                )
+            )
+        except Exception:
+            logger.warning("Failed to deserialize queued task at index %d", idx, exc_info=True)
+            tasks.append(
+                QueuedTask(
+                    index=idx,
+                    task_id="(decode error)",
+                    name="(decode error)",
+                    func="",
+                    args=(),
+                    kwargs={},
+                    started=None,
+                    raw="",
+                )
+            )
+    return tasks
+
+
+def delete_task_by_index(index: int) -> bool:
+    """根据队列位置删除单个任务。
+
+    Redis LREM 通过值匹配删除，所以需要先定位到对应 raw bytes。
+
+    Args:
+        index: 任务在队列中的位置（0-based）
+
+    Returns:
+        是否成功删除
+    """
+    conn = _get_redis_connection()
+    if conn is None:
+        return False
+
+    key = _get_queue_key()
+    raw_bytes = conn.lindex(key, index)
+    if raw_bytes is None:
+        return False
+
+    removed = conn.lrem(key, 1, raw_bytes)
+    return removed > 0
+
+
+def delete_tasks_by_ids(task_ids: set[str]) -> int:
+    """根据 task_id 批量删除任务。
+
+    策略：读取全部 -> 过滤 -> 删除 key -> 重新推入幸存者。
+
+    Args:
+        task_ids: 要删除的 task_id 集合
+
+    Returns:
+        成功删除的数量
+    """
+    conn = _get_redis_connection()
+    if conn is None:
+        return 0
+
+    key = _get_queue_key()
+    all_raw = conn.lrange(key, 0, -1)
+    if not all_raw:
+        return 0
+
+    from django_q.signing import SignedPackage
+
+    survivors: list[bytes] = []
+    removed = 0
+
+    for raw_bytes in all_raw:
+        try:
+            raw_str = raw_bytes.decode("utf-8") if isinstance(raw_bytes, bytes) else raw_bytes
+            task_dict = SignedPackage.loads(raw_str)
+            if task_dict.get("id") in task_ids:
+                removed += 1
+            else:
+                survivors.append(raw_bytes)
+        except Exception:
+            survivors.append(raw_bytes)
+
+    # 原子替换：先删再推（非事务性，但 Django Q worker 会容忍空队列）
+    conn.delete(key)
+    if survivors:
+        conn.rpush(key, *survivors)
+
+    return removed
+
+
+def purge_queue() -> int:
+    """清空整个队列。
+
+    Returns:
+        被清除的任务数量
+    """
+    conn = _get_redis_connection()
+    if conn is None:
+        return 0
+
+    key = _get_queue_key()
+    count = conn.llen(key)
+    if count > 0:
+        conn.delete(key)
+    return count

--- a/backend/apps/core/tasking/redis_queue.py
+++ b/backend/apps/core/tasking/redis_queue.py
@@ -60,7 +60,7 @@ def get_queue_length() -> int:
     if conn is None:
         return 0
     key = _get_queue_key()
-    return conn.llen(key)
+    return int(conn.llen(key))
 
 
 def list_tasks(limit: int = 200) -> list[QueuedTask]:
@@ -138,7 +138,7 @@ def delete_task_by_index(index: int) -> bool:
         return False
 
     removed = conn.lrem(key, 1, raw_bytes)
-    return removed > 0
+    return bool(removed > 0)
 
 
 def delete_tasks_by_ids(task_ids: set[str]) -> int:
@@ -196,7 +196,7 @@ def purge_queue() -> int:
         return 0
 
     key = _get_queue_key()
-    count = conn.llen(key)
+    count = int(conn.llen(key))
     if count > 0:
         conn.delete(key)
     return count

--- a/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
+++ b/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
@@ -12,88 +12,77 @@
 {% endblock %}
 
 {% block content %}
-<div style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
-  <h1 style="margin: 0; font-size: 20px;">Valkey 任务队列</h1>
-  <span style="font-size: 14px; color: var(--body-quiet-color);">
-    待处理：<strong>{{ queue_length }}</strong> 个
-  </span>
+<div id="content-main">
+  <div style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
+    <span style="font-size: 14px;">
+      待处理任务：<strong>{{ queue_length }}</strong> 个
+    </span>
 
-  {% if queue_length > 0 %}
-  <form method="post" style="display: inline;"
-        onsubmit="return confirm('确定要清空全部 {{ queue_length }} 个待处理任务吗？此操作不可撤销。');">
-    {% csrf_token %}
-    <input type="hidden" name="action" value="purge">
-    <button type="submit"
-            style="background: #ba2121; color: #fff; border: none; padding: 6px 14px;
-                   border-radius: 4px; cursor: pointer; font-size: 13px;">
-      清空全部
-    </button>
-  </form>
+    {% if queue_length > 0 %}
+    <form method="post" style="display: inline;"
+          onsubmit="return confirm('确定要清空全部 {{ queue_length }} 个待处理任务吗？此操作不可撤销。');">
+      {% csrf_token %}
+      <input type="hidden" name="action" value="purge">
+      <button type="submit" class="button" style="background: #ba2121; border-color: #ba2121;">
+        清空全部
+      </button>
+    </form>
+    {% endif %}
+  </div>
+
+  {% if tasks %}
+  <div class="results">
+    <table id="result_list">
+      <thead>
+        <tr>
+          <th scope="col"><div class="text">#</div></th>
+          <th scope="col"><div class="text">任务名称</div></th>
+          <th scope="col"><div class="text">函数路径</div></th>
+          <th scope="col"><div class="text">参数</div></th>
+          <th scope="col"><div class="text">入队时间</div></th>
+          <th scope="col"><div class="text">操作</div></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for task in tasks %}
+        <tr>
+          <td>{{ forloop.counter }}</td>
+          <td><strong>{{ task.name|default:"-" }}</strong></td>
+          <td><code>{{ task.func }}</code></td>
+          <td style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+            {% if task.args %}<span title="{{ task.args }}">args={{ task.args }}</span>{% endif %}
+            {% if task.kwargs %}<span title="{{ task.kwargs }}"> kwargs={{ task.kwargs }}</span>{% endif %}
+            {% if not task.args and not task.kwargs %}-{% endif %}
+          </td>
+          <td>{% if task.started %}{{ task.started|date:"Y-m-d H:i:s" }}{% else %}-{% endif %}</td>
+          <td>
+            <form method="post" style="display: inline;"
+                  onsubmit="return confirm('确定要删除此任务吗？');">
+              {% csrf_token %}
+              <input type="hidden" name="action" value="delete_one">
+              <input type="hidden" name="index" value="{{ task.index }}">
+              <button type="submit" class="button" style="padding: 2px 8px; font-size: 12px;">
+                删除
+              </button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% if queue_length > tasks|length %}
+  <p class="paginator" style="margin-top: 8px;">
+    仅显示前 {{ tasks|length }} 条，队列共 {{ queue_length }} 个任务。
+  </p>
+  {% endif %}
+
+  {% else %}
+  <div style="text-align: center; padding: 60px 20px; color: var(--body-quiet-color);">
+    <p style="font-size: 16px; margin-bottom: 8px;">队列为空</p>
+    <p style="font-size: 13px;">当前没有待处理的异步任务。</p>
+  </div>
   {% endif %}
 </div>
-
-{% if tasks %}
-<table style="width: 100%; border-collapse: collapse;">
-  <thead>
-    <tr>
-      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">#</th>
-      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">任务名称</th>
-      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">函数路径</th>
-      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">参数</th>
-      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">入队时间</th>
-      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">操作</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for task in tasks %}
-    <tr style="border-bottom: 1px solid var(--hairline-color);">
-      <td style="padding: 8px 10px;">{{ forloop.counter }}</td>
-      <td style="padding: 8px 10px; font-weight: 600;">{{ task.name|default:"-" }}</td>
-      <td style="padding: 8px 10px;">
-        <code style="font-size: 12px; background: var(--darkened-bg); padding: 2px 6px; border-radius: 3px;">
-          {{ task.func }}
-        </code>
-      </td>
-      <td style="padding: 8px 10px; font-size: 12px; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-        {% if task.args %}
-          <span title="{{ task.args }}">args={{ task.args }}</span>
-        {% endif %}
-        {% if task.kwargs %}
-          <span title="{{ task.kwargs }}">kwargs={{ task.kwargs }}</span>
-        {% endif %}
-        {% if not task.args and not task.kwargs %}-{% endif %}
-      </td>
-      <td style="padding: 8px 10px; font-size: 12px;">
-        {% if task.started %}{{ task.started|date:"Y-m-d H:i:s" }}{% else %}-{% endif %}
-      </td>
-      <td style="padding: 8px 10px;">
-        <form method="post" style="display: inline;"
-              onsubmit="return confirm('确定要删除此任务吗？');">
-          {% csrf_token %}
-          <input type="hidden" name="action" value="delete_one">
-          <input type="hidden" name="index" value="{{ task.index }}">
-          <button type="submit"
-                  style="background: none; border: 1px solid #ba2121; color: #ba2121;
-                         padding: 3px 10px; border-radius: 3px; cursor: pointer; font-size: 12px;">
-            删除
-          </button>
-        </form>
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-
-{% if queue_length > tasks|length %}
-<p style="margin-top: 12px; color: var(--body-quiet-color); font-size: 13px;">
-  仅显示前 {{ tasks|length }} 条，队列共 {{ queue_length }} 个任务。
-</p>
-{% endif %}
-
-{% else %}
-<div style="text-align: center; padding: 60px 20px; color: var(--body-quiet-color);">
-  <p style="font-size: 16px; margin-bottom: 8px;">队列为空</p>
-  <p style="font-size: 13px;">当前没有待处理的异步任务。</p>
-</div>
-{% endif %}
 {% endblock %}

--- a/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
+++ b/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
@@ -1,0 +1,96 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block content_title %}
+  <h1>Redis 任务队列</h1>
+{% endblock %}
+
+{% block result_list %}
+<div style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
+  <span style="font-size: 14px; color: var(--body-fg);">
+    队列中待处理任务：<strong>{{ queue_length }}</strong> 个
+  </span>
+
+  {% if queue_length > 0 %}
+  <form method="post" style="display: inline;"
+        onsubmit="return confirm('确定要清空全部 {{ queue_length }} 个待处理任务吗？此操作不可撤销。');">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="purge">
+    <button type="submit"
+            style="background: #ba2121; color: #fff; border: none; padding: 6px 14px;
+                   border-radius: 4px; cursor: pointer; font-size: 13px;">
+      清空全部
+    </button>
+  </form>
+  {% endif %}
+</div>
+
+{% if tasks %}
+<table id="result_list" style="width: 100%; border-collapse: collapse;">
+  <thead>
+    <tr>
+      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">#</th>
+      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">任务名称</th>
+      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">函数路径</th>
+      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">参数</th>
+      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">入队时间</th>
+      <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for task in tasks %}
+    <tr style="border-bottom: 1px solid var(--hairline-color);">
+      <td style="padding: 8px 10px;">{{ forloop.counter }}</td>
+      <td style="padding: 8px 10px; font-weight: 600;">{{ task.name|default:"-" }}</td>
+      <td style="padding: 8px 10px;">
+        <code style="font-size: 12px; background: var(--darkened-bg); padding: 2px 6px; border-radius: 3px;">
+          {{ task.func }}
+        </code>
+      </td>
+      <td style="padding: 8px 10px; font-size: 12px; max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+        {% if task.args %}
+          <span title="{{ task.args }}">args={{ task.args }}</span>
+        {% endif %}
+        {% if task.kwargs %}
+          <span title="{{ task.kwargs }}">kwargs={{ task.kwargs }}</span>
+        {% endif %}
+        {% if not task.args and not task.kwargs %}-{% endif %}
+      </td>
+      <td style="padding: 8px 10px; font-size: 12px;">
+        {% if task.started %}{{ task.started|date:"Y-m-d H:i:s" }}{% else %}-{% endif %}
+      </td>
+      <td style="padding: 8px 10px;">
+        <form method="post" style="display: inline;"
+              onsubmit="return confirm('确定要删除此任务吗？');">
+          {% csrf_token %}
+          <input type="hidden" name="action" value="delete_one">
+          <input type="hidden" name="index" value="{{ task.index }}">
+          <button type="submit"
+                  style="background: none; border: 1px solid #ba2121; color: #ba2121;
+                         padding: 3px 10px; border-radius: 3px; cursor: pointer; font-size: 12px;">
+            删除
+          </button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% if queue_length > tasks|length %}
+<p style="margin-top: 12px; color: var(--body-quiet-color); font-size: 13px;">
+  仅显示前 {{ tasks|length }} 条，队列共 {{ queue_length }} 个任务。
+</p>
+{% endif %}
+
+{% else %}
+<div style="text-align: center; padding: 60px 20px; color: var(--body-quiet-color);">
+  <p style="font-size: 16px; margin-bottom: 8px;">队列为空</p>
+  <p style="font-size: 13px;">当前没有待处理的异步任务。</p>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block pagination %}{% endblock %}
+{% block filters %}{% endblock %}
+{% block search %}{% endblock %}

--- a/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
+++ b/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
@@ -1,19 +1,19 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
-{% block title %}Redis 任务队列{% endblock %}
+{% block title %}Valkey 任务队列{% endblock %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans "首页" %}</a>
     &rsaquo; <a href="{% url 'admin:app_list' app_label='core' %}">{% trans "核心系统" %}</a>
-    &rsaquo; Redis 任务队列
+    &rsaquo; Valkey 任务队列
 </div>
 {% endblock %}
 
 {% block content %}
 <div style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
-  <h1 style="margin: 0; font-size: 20px;">Redis 任务队列</h1>
+  <h1 style="margin: 0; font-size: 20px;">Valkey 任务队列</h1>
   <span style="font-size: 14px; color: var(--body-quiet-color);">
     待处理：<strong>{{ queue_length }}</strong> 个
   </span>

--- a/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
+++ b/backend/apps/core/templates/admin/core/redisqueuetool/change_list.html
@@ -1,14 +1,21 @@
-{% extends "admin/change_list.html" %}
+{% extends "admin/base_site.html" %}
 {% load i18n %}
 
-{% block content_title %}
-  <h1>Redis 任务队列</h1>
+{% block title %}Redis 任务队列{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans "首页" %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label='core' %}">{% trans "核心系统" %}</a>
+    &rsaquo; Redis 任务队列
+</div>
 {% endblock %}
 
-{% block result_list %}
+{% block content %}
 <div style="margin-bottom: 16px; display: flex; align-items: center; gap: 16px;">
-  <span style="font-size: 14px; color: var(--body-fg);">
-    队列中待处理任务：<strong>{{ queue_length }}</strong> 个
+  <h1 style="margin: 0; font-size: 20px;">Redis 任务队列</h1>
+  <span style="font-size: 14px; color: var(--body-quiet-color);">
+    待处理：<strong>{{ queue_length }}</strong> 个
   </span>
 
   {% if queue_length > 0 %}
@@ -26,7 +33,7 @@
 </div>
 
 {% if tasks %}
-<table id="result_list" style="width: 100%; border-collapse: collapse;">
+<table style="width: 100%; border-collapse: collapse;">
   <thead>
     <tr>
       <th style="padding: 8px 10px; text-align: left; border-bottom: 2px solid var(--hairline-color);">#</th>
@@ -90,7 +97,3 @@
 </div>
 {% endif %}
 {% endblock %}
-
-{% block pagination %}{% endblock %}
-{% block filters %}{% endblock %}
-{% block search %}{% endblock %}


### PR DESCRIPTION
## 变更内容

### 1. 修复模板语法错误（plugins 子模块）
- `{% trans %}` 标签中中文引号 `"..."` 与分隔符冲突，改用单引号分隔符

### 2. 移除询价任务自动触发机制
- 删除 `PreservationQuote` 模型上的 `@hook(AFTER_CREATE)` 自动提交
- 询价任务不再在记录创建时自动执行，必须通过 API/Admin 显式触发

### 3. 新增 Valkey 任务队列管理页面
- 新页面 `/admin/core/redisqueuetool/`，可查看、删除、清空 Valkey 队列中的待处理任务
- 仅 superuser 可见，仅 Valkey/Redis broker 激活时显示
- 使用 Django admin 原生 UI 样式

## 测试
- [x] ruff check 全量通过
- [x] mypy 检查通过
- [x] 服务层单元验证（list/delete/purge）
- [x] HTTP 端到端测试（GET 200 + POST delete/purge 302）