### PR TITLE
fix: restore Django 6 dark mode toggle in admin header

### DIFF
--- a/backend/apiSystem/templates/admin/base_site.html
+++ b/backend/apiSystem/templates/admin/base_site.html
@@ -248,4 +248,5 @@ document.addEventListener('DOMContentLoaded', function() {
         退出
     </button>
 </form>
+{% include "admin/color_theme_toggle.html" %}
 {% endblock %}


### PR DESCRIPTION
## Problem

 overrides , which drops Django 6's built-in  — the dark/light/auto theme toggle button disappears from the admin header.

## Fix

Add  back into the overridden  block, right after the logout button.