### PR TITLE
docs: 日历订阅弹窗添加各平台使用说明&& fix: ICS 日历 Feed 端点因父路由 auth 继承导致 401

### DIFF
--- a/backend/apps/reminders/api/__init__.py
+++ b/backend/apps/reminders/api/__init__.py
@@ -8,6 +8,6 @@ from .calendar_feed_api import router as calendar_feed_router
 # 支持 JWT 和 Session 认证
 router = Router(auth=JWTOrSessionAuth())
 router.add_router("", reminder_router, tags=["重要日期提醒"])
-router.add_router("", calendar_feed_router, tags=["日历订阅"])
+router.add_router("", calendar_feed_router, tags=["日历订阅"], auth=None)
 
 __all__ = ["router"]

--- a/backend/apps/reminders/api/calendar_feed_api.py
+++ b/backend/apps/reminders/api/calendar_feed_api.py
@@ -206,13 +206,22 @@ async def calendar_feed(request: Any, token: str = "") -> HttpResponse:
     return response
 
 
-@router.get("/ics/feed/token", auth=_session_auth)
+def _require_session_user(request: Any) -> Any | None:
+    """检查请求是否带有 Django Session 认证的用户。返回 user 或 None。"""
+    if hasattr(request, "user") and request.user and request.user.is_authenticated:
+        return request.user
+    return None
+
+
+@router.get("/ics/feed/token")
 async def get_or_create_token(request: Any) -> dict[str, str]:
     """获取当前用户的日历订阅 Token（不存在则自动创建）。"""
-    from apps.core.security import get_request_access_context
+    user = _require_session_user(request)
+    if user is None:
+        from django.http import JsonResponse
+        return JsonResponse({"detail": "Authentication required"}, status=401)
 
-    ctx = get_request_access_context(request)
-    feed_token = await sync_to_async(CalendarFeedToken.get_or_create_for_user)(ctx.user)
+    feed_token = await sync_to_async(CalendarFeedToken.get_or_create_for_user)(user)
 
     # 构造完整订阅 URL
     scheme = "https" if request.is_secure() else "http"
@@ -226,17 +235,19 @@ async def get_or_create_token(request: Any) -> dict[str, str]:
     }
 
 
-@router.post("/ics/feed/token/regenerate", auth=_session_auth)
+@router.post("/ics/feed/token/regenerate")
 async def regenerate_token(request: Any) -> dict[str, str]:
     """重新生成当前用户的日历订阅 Token（旧 Token 立即失效）。"""
-    from apps.core.security import get_request_access_context
+    user = _require_session_user(request)
+    if user is None:
+        from django.http import JsonResponse
+        return JsonResponse({"detail": "Authentication required"}, status=401)
 
-    ctx = get_request_access_context(request)
     new_token = secrets.token_urlsafe(48)
 
     def _regenerate() -> CalendarFeedToken:
         obj, created = CalendarFeedToken.objects.get_or_create(
-            user=ctx.user,
+            user=user,
             defaults={"token": new_token},
         )
         if not created:

--- a/backend/apps/reminders/api/calendar_feed_api.py
+++ b/backend/apps/reminders/api/calendar_feed_api.py
@@ -18,6 +18,7 @@ from django.db.models import Q
 from django.http import HttpResponse
 from django.utils import timezone
 from ninja import Router
+from ninja.errors import HttpError
 
 from apps.core.infrastructure.throttling import rate_limit_from_settings
 from apps.reminders.models import CalendarFeedToken, Reminder, ReminderType
@@ -218,8 +219,7 @@ async def get_or_create_token(request: Any) -> dict[str, str]:
     """获取当前用户的日历订阅 Token（不存在则自动创建）。"""
     user = _require_session_user(request)
     if user is None:
-        from django.http import JsonResponse
-        return JsonResponse({"detail": "Authentication required"}, status=401)
+        raise HttpError(401, "Authentication required")
 
     feed_token = await sync_to_async(CalendarFeedToken.get_or_create_for_user)(user)
 
@@ -240,8 +240,7 @@ async def regenerate_token(request: Any) -> dict[str, str]:
     """重新生成当前用户的日历订阅 Token（旧 Token 立即失效）。"""
     user = _require_session_user(request)
     if user is None:
-        from django.http import JsonResponse
-        return JsonResponse({"detail": "Authentication required"}, status=401)
+        raise HttpError(401, "Authentication required")
 
     new_token = secrets.token_urlsafe(48)
 

--- a/backend/apps/reminders/templates/admin/reminders/reminder/calendar.html
+++ b/backend/apps/reminders/templates/admin/reminders/reminder/calendar.html
@@ -1799,6 +1799,13 @@
                             将以下链接添加到日历 App 的"订阅日历"中，法穿提醒会自动同步。
                         </p>
                         <input type="text" readonly value="${feedUrl}" style="width:100%;padding:8px 10px;border:1px solid var(--fc-border-input,#d1d5db);border-radius:6px;font-size:12px;box-sizing:border-box;background:var(--fc-bg-secondary,#f9fafb);" id="sub-feed-url" />
+                        <div style="margin-top:10px;padding:10px;background:var(--fc-bg-muted,#f3f4f6);border-radius:8px;font-size:12px;color:var(--fc-text-secondary,#666);line-height:1.7;">
+                            <strong style="display:block;margin-bottom:4px;color:var(--fc-text-primary,#333);">各平台添加方式：</strong>
+                            <b>Apple 日历 (macOS/iOS)：</b> 设置 → 日历 → 账户 → 添加订阅日历 → 粘贴链接<br>
+                            <b>Google 日历：</b> 左侧"其他日历"→ + → 来自网址 → 粘贴链接<br>
+                            <b>Outlook：</b> 添加日历 → 从 Internet 订阅 → 粘贴链接<br>
+                            <b>提醒数据：</b> 系统每隔4小时自动同步一次，仅含未来1年内的提醒。
+                        </div>
                         <div style="display:flex;gap:8px;margin-top:12px;justify-content:flex-end;">
                             <button id="sub-copy-btn" style="padding:6px 14px;border-radius:6px;border:none;background:#2563eb;color:#fff;font-size:13px;cursor:pointer;">复制链接</button>
                             <button id="sub-close-btn" style="padding:6px 14px;border-radius:6px;border:1px solid var(--fc-border-input,#d1d5db);background:var(--fc-bg-card,#fff);font-size:13px;cursor:pointer;">关闭</button>


### PR DESCRIPTION
在日历页面的"获取订阅"弹窗中，添加 Apple 日历、Google 日历、Outlook 的订阅操作指引。