### PR TITLE
feat: v26.53.14 常法顾问工作日记自动生成 + 合同当事人防呆 + Admin 体验优化

### DIFF
--- a/backend/apps/cases/admin/case_admin.py
+++ b/backend/apps/cases/admin/case_admin.py
@@ -286,7 +286,8 @@ class CaseAdmin(
     def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> Any:  # pragma: no cover
         from django.http import HttpResponseRedirect
 
-        if "status__exact" not in request.GET and not request.GET:
+        if "status__exact" not in request.GET and not request.session.get("case_changelist_visited"):
+            request.session["case_changelist_visited"] = True
             return HttpResponseRedirect(f"{request.path}?status__exact=active")
         return super().changelist_view(request, extra_context=extra_context)
 

--- a/backend/apps/cases/admin/case_admin.py
+++ b/backend/apps/cases/admin/case_admin.py
@@ -286,7 +286,7 @@ class CaseAdmin(
     def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> Any:  # pragma: no cover
         from django.http import HttpResponseRedirect
 
-        if "status__exact" not in request.GET:
+        if "status__exact" not in request.GET and not request.GET:
             return HttpResponseRedirect(f"{request.path}?status__exact=active")
         return super().changelist_view(request, extra_context=extra_context)
 

--- a/backend/apps/contracts/admin/contract_admin.py
+++ b/backend/apps/contracts/admin/contract_admin.py
@@ -230,7 +230,8 @@ class ContractAdmin(
     def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> Any:  # pragma: no cover
         from django.http import HttpResponseRedirect
 
-        if "status__exact" not in request.GET and not request.GET:
+        if "status__exact" not in request.GET and not request.session.get("contract_changelist_visited"):
+            request.session["contract_changelist_visited"] = True
             return HttpResponseRedirect(f"{request.path}?status__exact=active")
         # 保存筛选状态到 session，供详情页"返回列表"使用
         if request.GET:

--- a/backend/apps/contracts/admin/contract_admin.py
+++ b/backend/apps/contracts/admin/contract_admin.py
@@ -121,7 +121,7 @@ class ContractAdmin(
     )
     list_per_page = 50
     list_filter = ("case_type", "status", "fee_mode", "is_filed", ("specified_date", admin.DateFieldListFilter))
-    search_fields = ("name", "filing_number", "contract_parties__client__name")
+    search_fields = ("name", "filing_number", "law_firm_oa_case_number", "contract_parties__client__name")
     date_hierarchy = "specified_date"
     readonly_fields = (
         "get_primary_lawyer_display",

--- a/backend/apps/contracts/admin/contract_admin.py
+++ b/backend/apps/contracts/admin/contract_admin.py
@@ -230,7 +230,7 @@ class ContractAdmin(
     def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> Any:  # pragma: no cover
         from django.http import HttpResponseRedirect
 
-        if "status__exact" not in request.GET:
+        if "status__exact" not in request.GET and not request.GET:
             return HttpResponseRedirect(f"{request.path}?status__exact=active")
         # 保存筛选状态到 session，供详情页"返回列表"使用
         if request.GET:

--- a/backend/apps/contracts/admin/mixins/archive_mixin.py
+++ b/backend/apps/contracts/admin/mixins/archive_mixin.py
@@ -617,3 +617,62 @@ class ContractArchiveMixin:  # pragma: no cover
         except Exception as e:
             logger.exception("清空归档材料失败: contract_id=%s", object_id)
             return JsonResponse({"success": False, "error": str(e)}, status=500)
+
+    # ── 常法顾问工作日志生成 ──
+
+    def generate_work_log_content_view(self, request: HttpRequest, object_id: int) -> HttpResponse:  # pragma: no cover
+        """为常法顾问合同自动生成律师办案工作日记内容
+
+        优先使用真实 CaseLog，无日志时根据合同起止日期随机生成。
+        生成结果保存为 ArchivePlaceholderOverride，供预览和编辑使用。
+        """
+        from django.http import JsonResponse
+
+        if request.method != "POST":
+            return JsonResponse({"success": False, "error": "仅支持 POST"}, status=405)
+
+        if not self.has_change_permission(request):
+            return JsonResponse({"success": False, "error": "无权限"}, status=403)
+
+        try:
+            admin_service = _get_contract_admin_service()
+            contract = admin_service.query_service.get_contract_detail(object_id)
+
+            # 校验：仅常法顾问 + 日期齐全
+            if contract.case_type != "advisor":
+                return JsonResponse({"success": False, "error": "仅适用于常法顾问合同"}, status=400)
+            if not contract.start_date or not contract.end_date:
+                return JsonResponse({"success": False, "error": "请先填写开始日期和结束日期"}, status=400)
+            if contract.start_date > contract.end_date:
+                return JsonResponse({"success": False, "error": "开始日期不能晚于结束日期"}, status=400)
+
+            # 尝试真实 CaseLog（contract.cases 已在 get_contract_detail 中 prefetch_related）
+            from apps.documents.services.placeholders.archive import ArchivePlaceholderService
+
+            has_real_log = False
+            content = ""
+            for case in contract.cases.all():
+                content = ArchivePlaceholderService._get_lawyer_work_log_content(case)
+                if content:
+                    has_real_log = True
+                    break
+
+            # Fallback：随机生成
+            if not content:
+                content = ArchivePlaceholderService._generate_random_work_log_content(
+                    contract.start_date, contract.end_date
+                )
+
+            if not content:
+                return JsonResponse({"success": False, "error": "无法生成内容"}, status=500)
+
+            # 持久化为 override
+            from apps.contracts.services.archive.override_service import save_override
+
+            save_override(contract.id, "lawyer_work_log", {"律师工作日志内容": content})
+
+            logger.info("已生成工作日志内容: contract_id=%s, is_real=%s", object_id, has_real_log)
+            return JsonResponse({"success": True, "content_preview": content[:200]})
+        except Exception as e:
+            logger.exception("生成工作日志失败: contract_id=%s", object_id)
+            return JsonResponse({"success": False, "error": str(e)}, status=500)

--- a/backend/apps/contracts/admin/mixins/display_mixin.py
+++ b/backend/apps/contracts/admin/mixins/display_mixin.py
@@ -128,6 +128,11 @@ class ContractDisplayMixin(ContractArchiveMixin, ContractDisplayFormatMixin):  #
                 name="contracts_contract_clear_all_archive_materials",
             ),
             path(
+                "<int:object_id>/generate-work-log-content/",
+                self.admin_site.admin_view(self.generate_work_log_content_view),
+                name="contracts_contract_generate_work_log_content",
+            ),
+            path(
                 "<int:object_id>/open-folder/",
                 self.admin_site.admin_view(self.open_folder_view),
                 name="contracts_contract_open_folder",

--- a/backend/apps/contracts/models/party.py
+++ b/backend/apps/contracts/models/party.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import ClassVar
 
 from django.db import models
 
 from .contract import Contract
+
+logger = logging.getLogger(__name__)
 
 
 class PartyRole(models.TextChoices):
@@ -39,6 +42,27 @@ class ContractParty(models.Model):
 
     def __str__(self) -> str:
         return f"{self.contract_id}-{self.client_id}-{self.role}"
+
+    def save(self, *args: object, **kwargs: object) -> None:
+        """保存前自动校正 role：非我方当事人的 role 不应为 PRINCIPAL。
+
+        防止因前端 JS 未触发、API 直接创建、或 add_party 未传 role
+        等场景导致对方当事人被错误标记为 PRINCIPAL（甲方）。
+        """
+        if self.client_id and self.role == PartyRole.PRINCIPAL:
+            # 访问 client.is_our_client，若 client 未加载则跳过
+            try:
+                is_our = self.client.is_our_client
+            except Exception:
+                is_our = None
+            if is_our is False:
+                logger.warning(
+                    "ContractParty.role 自动校正: contract=%s, client=%s, PRINCIPAL→OPPOSING（is_our_client=False）",
+                    self.contract_id,
+                    self.client_id,
+                )
+                self.role = PartyRole.OPPOSING
+        super().save(*args, **kwargs)
 
 
 class ContractAssignment(models.Model):

--- a/backend/apps/contracts/models/party.py
+++ b/backend/apps/contracts/models/party.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from django.db import models
 
@@ -43,7 +43,7 @@ class ContractParty(models.Model):
     def __str__(self) -> str:
         return f"{self.contract_id}-{self.client_id}-{self.role}"
 
-    def save(self, *args: object, **kwargs: object) -> None:
+    def save(self, *args: Any, **kwargs: Any) -> None:
         """保存前自动校正 role：非我方当事人的 role 不应为 PRINCIPAL。
 
         防止因前端 JS 未触发、API 直接创建、或 add_party 未传 role

--- a/backend/apps/contracts/static/contracts/js/party_role_auto.js
+++ b/backend/apps/contracts/static/contracts/js/party_role_auto.js
@@ -10,18 +10,31 @@
 
   // ─── 功能一：自动设置身份 ───────────────────────────────────────────
 
+  // 记录正在进行的请求，支持取消和提交守卫
+  var pendingRequests = new Map();
+
   function checkAndSetRole(clientSelect, clientId) {
     if (!clientId) return;
-    const row = clientSelect.closest("tr");
-    if (!row) return;
-    const roleSelect = row.querySelector('select[name*="-role"]');
+    // 找到同行或同 group 内的 role select
+    var roleSelect = findRoleSelect(clientSelect);
     if (!roleSelect) return;
+
+    // 取消该行之前的请求
+    var key = clientSelect.name;
+    if (pendingRequests.has(key)) {
+      pendingRequests.get(key).abort();
+    }
+
+    var controller = new AbortController();
+    pendingRequests.set(key, controller);
 
     fetch("/api/v1/client/clients/" + clientId, {
       headers: { "X-Requested-With": "XMLHttpRequest" },
+      signal: controller.signal,
     })
       .then(function (res) { return res.ok ? res.json() : null; })
       .then(function (data) {
+        pendingRequests.delete(key);
         if (data) {
           // 非我方当事人（is_our_client 为 false 或 null）自动设为对方当事人
           if (data.is_our_client === false || data.is_our_client === null) {
@@ -29,11 +42,29 @@
           }
         }
       })
-      .catch(function () {});
+      .catch(function () { pendingRequests.delete(key); });
+  }
+
+  /**
+   * 从 client select 出发，找到对应的 role select。
+   * 优先在同一个 <tr> 内查找，找不到则向上找 group 容器。
+   */
+  function findRoleSelect(clientSelect) {
+    var row = clientSelect.closest("tr");
+    if (row) {
+      var sel = row.querySelector('select[name*="-role"]');
+      if (sel) return sel;
+    }
+    // fallback：向上找 group 容器
+    var group = clientSelect.closest(".dynamic-contract_parties, .dynamic-supplementary_agreements_parties, [id*='parties-group']");
+    if (group) {
+      return group.querySelector('select[name*="-role"]');
+    }
+    return null;
   }
 
   function bindClientSelect(select) {
-    const $ = window.django && window.django.jQuery;
+    var $ = window.django && window.django.jQuery;
 
     // 普通 change 事件（只绑定一次）
     if (!select.dataset.partyRoleBound) {
@@ -45,11 +76,9 @@
 
     // select2 事件（每次都重新绑定，因为 select2 可能被重新初始化）
     if ($ && select.classList.contains("admin-autocomplete")) {
-      // 先解绑旧事件，避免重复绑定
       $(select).off("select2:select.partyRole");
-      // 重新绑定，使用命名空间避免冲突
       $(select).on("select2:select.partyRole", function (e) {
-        const id = e.params && e.params.data && e.params.data.id;
+        var id = e.params && e.params.data && e.params.data.id;
         checkAndSetRole(select, id || select.value);
       });
     }
@@ -57,33 +86,67 @@
 
   function bindAllClientSelects() {
     document.querySelectorAll('select[name*="-client"]').forEach(function (sel) {
-      // 跳过模板行
       if (sel.name.includes("__prefix__")) return;
-      const row = sel.closest("tr");
+      var row = sel.closest("tr");
       if (row && row.querySelector('select[name*="-role"]')) {
         bindClientSelect(sel);
       }
     });
   }
 
+  // ─── 补充机制：当 role select 被插入 DOM 时，检查 client 是否已选 ──
+
+  function checkExistingClientOnRoleInsert(addedNode) {
+    if (!addedNode.querySelectorAll) return;
+    // 检查新增节点内的 role select
+    var roleSelects = addedNode.querySelectorAll('select[name*="-role"]');
+    roleSelects.forEach(function (roleSelect) {
+      if (roleSelect.name.includes("__prefix__")) return;
+      var row = roleSelect.closest("tr");
+      if (!row) return;
+      var clientSelect = row.querySelector('select[name*="-client"]');
+      if (clientSelect && !clientSelect.name.includes("__prefix__") && clientSelect.value) {
+        // client 已选但 role 还是默认值，触发一次检查
+        if (roleSelect.value === "PRINCIPAL") {
+          checkAndSetRole(clientSelect, clientSelect.value);
+        }
+      }
+    });
+  }
+
+  // ─── 提交守卫：确保 AJAX 完成后再提交 ──────────────────────────────
+
+  function setupSubmitGuard() {
+    document.addEventListener("submit", function (e) {
+      if (pendingRequests.size === 0) return;
+      e.preventDefault();
+      // 等待所有请求完成后再提交
+      var form = e.target;
+      var promises = Array.from(pendingRequests.values()).map(function (ctrl) {
+        return new Promise(function (resolve) {
+          // 请求会在 abort 或完成后 resolve
+          var check = setInterval(function () {
+            if (!pendingRequests.has(ctrl)) { clearInterval(check); resolve(); }
+          }, 50);
+          setTimeout(function () { clearInterval(check); resolve(); }, 3000);
+        });
+      });
+      Promise.all(promises).then(function () { form.submit(); });
+    }, true);
+  }
+
   // ─── 功能二：填充当事人按钮 ─────────────────────────────────────────
 
-  /**
-   * 读取来源当事人列表
-   * @param {number} suppIndex - 当前补充协议的 index（0=第一个）
-   * @returns {Array<{id: string, text: string, role: string}>}
-   */
   function getSourceParties(suppIndex) {
-    const parties = [];
-    const $ = window.django && window.django.jQuery;
+    var parties = [];
+    var $ = window.django && window.django.jQuery;
 
     if (suppIndex === 0) {
-      // 从合同当事人读取（普通 select，有完整 option text）
       document.querySelectorAll('select[name^="contract_parties-"][name$="-client"]').forEach(function (sel) {
         if (sel.name.includes("__prefix__") || !sel.value) return;
-        const row = sel.closest("tr");
-        const roleSelect = row && row.querySelector('select[name*="-role"]');
-        const selectedOption = sel.options[sel.selectedIndex];
+        var row = sel.closest("tr");
+        var roleSelect = row && row.querySelector('select[name*="-role"]');
+        var selectedOption = sel.options[sel.selectedIndex];
         parties.push({
           id: sel.value,
           text: selectedOption ? selectedOption.text : sel.value,
@@ -91,19 +154,18 @@
         });
       });
     } else {
-      // 从上一份补充协议当事人读取（select2，用 select2('data') 取 text）
-      const prevIndex = suppIndex - 1;
-      const prefix = "supplementary_agreements-" + prevIndex + "-parties-";
+      var prevIndex = suppIndex - 1;
+      var prefix = "supplementary_agreements-" + prevIndex + "-parties-";
       document.querySelectorAll('select[name^="' + prefix + '"][name$="-client"]').forEach(function (sel) {
         if (sel.name.includes("__prefix__") || !sel.value) return;
-        const row = sel.closest("tr");
-        const roleSelect = row && row.querySelector('select[name*="-role"]');
-        let text = sel.value;
+        var row = sel.closest("tr");
+        var roleSelect = row && row.querySelector('select[name*="-role"]');
+        var text = sel.value;
         if ($ && sel.classList.contains("admin-autocomplete")) {
-          const data = $(sel).select2("data");
+          var data = $(sel).select2("data");
           if (data && data[0]) text = data[0].text;
         } else {
-          const opt = sel.options[sel.selectedIndex];
+          var opt = sel.options[sel.selectedIndex];
           if (opt) text = opt.text;
         }
         parties.push({
@@ -116,68 +178,46 @@
     return parties;
   }
 
-  /**
-   * 向目标 parties-group 填充当事人
-   * @param {string} groupId - 如 "supplementary_agreements-1-parties-group"
-   * @param {Array} parties
-   */
   function fillParties(groupId, parties) {
     if (!parties.length) return;
-    const $ = window.django && window.django.jQuery;
-    const group = document.getElementById(groupId);
+    var $ = window.django && window.django.jQuery;
+    var group = document.getElementById(groupId);
     if (!group) return;
 
-    // 解析 prefix，如 "supplementary_agreements-1-parties"
-    const prefix = groupId.replace("-group", "");
-
-    // 获取当前已有的空行（TOTAL_FORMS - INITIAL_FORMS 个）
-    // 需要点击"添加"按钮来创建足够的行
-    const addBtn = group.querySelector(".djn-add-item a");
+    var prefix = groupId.replace("-group", "");
+    var addBtn = group.querySelector(".djn-add-item a");
     if (!addBtn) return;
 
-    // 当前已有的行（非 empty-form、非 __prefix__）
     function getExistingRows() {
       return Array.from(
         group.querySelectorAll('select[name^="' + prefix + '-"][name$="-client"]:not([name*="__prefix__"])')
       );
     }
 
-    const existingRows = getExistingRows();
-    // 需要的行数
-    const needed = parties.length;
-    // 已有行数（包括空行）
-    let current = existingRows.length;
+    var needed = parties.length;
+    var current = getExistingRows().length;
 
-    // 点击添加按钮补足行数
     function addRowsAndFill(remaining) {
-      if (remaining <= 0) {
-        doFill();
-        return;
-      }
+      if (remaining <= 0) { doFill(); return; }
       addBtn.click();
-      // 等 nested_admin 渲染新行
-      setTimeout(function () {
-        addRowsAndFill(remaining - 1);
-      }, 50);
+      setTimeout(function () { addRowsAndFill(remaining - 1); }, 50);
     }
 
     function doFill() {
-      const rows = getExistingRows();
+      var rows = getExistingRows();
       parties.forEach(function (party, i) {
-        const sel = rows[i];
+        var sel = rows[i];
         if (!sel) return;
-        const row = sel.closest("tr");
-        const roleSelect = row && row.querySelector('select[name*="-role"]');
+        var row = sel.closest("tr");
+        var roleSelect = row && row.querySelector('select[name*="-role"]');
 
-        // 设置 select2 值
         if ($ && sel.classList.contains("admin-autocomplete")) {
-          const option = new Option(party.text, party.id, true, true);
+          var option = new Option(party.text, party.id, true, true);
           $(sel).append(option).trigger("change");
         } else {
           sel.value = party.id;
         }
 
-        // 设置 role
         if (roleSelect) roleSelect.value = party.role;
       });
     }
@@ -185,31 +225,26 @@
     addRowsAndFill(Math.max(0, needed - current));
   }
 
-  /**
-   * 在 parties-group 的 add-item 旁插入填充按钮
-   * @param {HTMLElement} group
-   */
   function insertFillButton(group) {
     if (group.dataset.fillBtnAdded) return;
     group.dataset.fillBtnAdded = "1";
 
-    // 解析 index：supplementary_agreements-N-parties-group
-    const match = group.id.match(/supplementary_agreements-(\d+)-parties-group/);
+    var match = group.id.match(/supplementary_agreements-(\d+)-parties-group/);
     if (!match) return;
-    const suppIndex = parseInt(match[1], 10);
+    var suppIndex = parseInt(match[1], 10);
 
-    const i18n = window.CONTRACTS_I18N || {};
-    const label = suppIndex === 0
+    var i18n = window.CONTRACTS_I18N || {};
+    var label = suppIndex === 0
       ? (i18n.fillContractParties || "填充合同当事人")
       : (i18n.fillPrevSuppParties || "填充上一份补充协议当事人");
 
-    const btn = document.createElement("a");
+    var btn = document.createElement("a");
     btn.href = "javascript://";
     btn.textContent = label;
     btn.style.cssText = "margin-left:12px;color:var(--fc-admin-blue);cursor:pointer;font-size:13px;";
     btn.addEventListener("click", function (e) {
       e.preventDefault();
-      const parties = getSourceParties(suppIndex);
+      var parties = getSourceParties(suppIndex);
       if (!parties.length) {
         alert(suppIndex === 0 ? "合同当事人为空" : "上一份补充协议当事人为空");
         return;
@@ -217,13 +252,12 @@
       fillParties(group.id, parties);
     });
 
-    const addItem = group.querySelector(".djn-add-item");
+    var addItem = group.querySelector(".djn-add-item");
     if (addItem) addItem.appendChild(btn);
   }
 
   function bindAllFillButtons() {
     document.querySelectorAll('[id*="supplementary_agreements-"][id$="-parties-group"]').forEach(function (group) {
-      // 排除 empty template
       if (group.id.includes("-empty-")) return;
       insertFillButton(group);
     });
@@ -234,17 +268,33 @@
   function init() {
     bindAllClientSelects();
     bindAllFillButtons();
+    setupSubmitGuard();
 
-    const observer = new MutationObserver(function () {
+    // 监听 DOM 变化：新行插入时重新绑定 + 检查已选 client
+    var observer = new MutationObserver(function (mutations) {
       bindAllClientSelects();
       bindAllFillButtons();
+      mutations.forEach(function (m) {
+        m.addedNodes.forEach(function (node) {
+          checkExistingClientOnRoleInsert(node);
+        });
+      });
     });
     observer.observe(document.body, { childList: true, subtree: true });
+
+    // document 级 select2 事件委托（兜底：即使 bindClientSelect 没绑定到也能捕获）
+    var $ = window.django && window.django.jQuery;
+    if ($) {
+      $(document).on("select2:select.partyRoleDelegation", 'select[name*="-client"]', function (e) {
+        var id = e.params && e.params.data && e.params.data.id;
+        checkAndSetRole(this, id || this.value);
+      });
+    }
   }
 
-  // 隐藏 inline 行里的 __str__ 显示文字（td.original > p）
+  // 隐藏 inline 行里的 __str__ 显示文字
   (function () {
-    const style = document.createElement("style");
+    var style = document.createElement("style");
     style.textContent =
       "#contract_parties-group td.original p," +
       "#assignments-group td.original p," +
@@ -254,6 +304,7 @@
 
   document.addEventListener("DOMContentLoaded", function () {
     init();
+    // 延迟再绑定一次，确保 nested_admin 渲染完成
     setTimeout(function () {
       bindAllClientSelects();
       bindAllFillButtons();

--- a/backend/apps/contracts/templates/admin/contracts/contract/partials/finalized_materials.html
+++ b/backend/apps/contracts/templates/admin/contracts/contract/partials/finalized_materials.html
@@ -131,6 +131,13 @@
                     </span>
                     <span class="ac-item-actions" @click.stop>
                         {% if item.template %}
+                        {% if item.template == 'lawyer_work_log' and contract.case_type == 'advisor' and contract.start_date and contract.end_date %}
+                        <button type="button" class="ac-btn-icon ac-btn-icon--generate"
+                                title="{% trans '自动生成工作日志内容' %}"
+                                onclick="generateWorkLogContent({{ contract.pk }})">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4m0 12v4M4.93 4.93l2.83 2.83m8.48 8.48l2.83 2.83M2 12h4m12 0h4M4.93 19.07l2.83-2.83m8.48-8.48l2.83-2.83"/></svg>
+                        </button>
+                        {% endif %}
                         <button type="button" class="ac-btn-icon" title="{% trans '预览替换词' %}"
                                 onclick="previewArchiveTemplate({{ contract.pk }}, '{{ item.template }}', '{{ item.name }}')">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
@@ -453,6 +460,7 @@ html { scrollbar-gutter: stable; }
 }
 .ac-btn-icon:hover { background: var(--fc-info-bg); color: var(--fc-primary); }
 .ac-btn-icon--upload:hover { background: var(--fc-success-bg); color: var(--fc-success-text); }
+.ac-btn-icon--generate:hover { background: var(--fc-warning-bg, #fff3cd); color: #664d03; }
 
 .ac-badge {
     font-size: 12px;
@@ -970,6 +978,24 @@ function archiveChecklistApp(initialCompact, checklistItems) {
     function getCSRF() {
         return (window.FachuanCSRF && window.FachuanCSRF.getToken && window.FachuanCSRF.getToken()) || '';
     }
+
+    // 生成常法顾问工作日志内容
+    window.generateWorkLogContent = function(contractId) {
+        if (!confirm('将自动生成律师办案工作日记内容（如有案件日志将使用真实数据，否则生成示例内容）。确认生成？')) return;
+        fetch('/admin/contracts/contract/' + contractId + '/generate-work-log-content/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCSRF() },
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                previewArchiveTemplate(contractId, 'lawyer_work_log', '律师办案工作日记');
+            } else {
+                alert('生成失败: ' + (data.error || '未知错误'));
+            }
+        })
+        .catch(function(e) { alert('请求失败: ' + e.message); });
+    };
 
     // 生成归档文件夹
     window.generateArchiveDocs = function(contractId) {

--- a/backend/apps/documents/services/placeholders/archive/__init__.py
+++ b/backend/apps/documents/services/placeholders/archive/__init__.py
@@ -6,7 +6,8 @@
 """
 
 import logging
-from datetime import date
+import random
+from datetime import date, timedelta
 from typing import Any, ClassVar
 
 from apps.documents.services.placeholders.base import BasePlaceholderService
@@ -757,3 +758,75 @@ class ArchivePlaceholderService(BasePlaceholderService):
             return 1
         else:
             return 1
+
+    # ── 常法顾问工作日志随机生成 ──
+
+    _ADVISOR_WORK_ITEMS: ClassVar[list[str]] = [
+        "为客户提供劳动合规培训；",
+        "审查客户劳动合同模板；",
+        "就合同纠纷提供法律咨询意见；",
+        "参与客户公司治理会议并出具法律意见；",
+        "为客户起草员工手册；",
+        "就知识产权保护事宜提供咨询；",
+        "审查供应商合同并提出修改建议；",
+        "为客户进行合规风险排查；",
+        "出具法律意见书；",
+        "就劳动仲裁事宜提供咨询；",
+        "协助客户处理工商变更登记事宜；",
+        "参加客户管理层法律培训会；",
+        "为客户审查招投标文件；",
+        "为客户修改买卖合同；",
+        "为客户总结当前用工风险。",
+    ]
+
+    @staticmethod
+    def _generate_random_work_log_content(start_date: date, end_date: date) -> str:
+        """为常法顾问合同生成随机的律师工作日志内容。
+
+        生成 5-7 条均匀分布在服务期内的工作日志条目，
+        第一条为"开始服务"，后续从活动池随机抽取。
+        """
+        total_days = (end_date - start_date).days + 1
+        if total_days <= 0:
+            return ""
+
+        count = min(random.randint(5, 7), total_days)
+
+        # 收集日期：第一条 = start_date，后续在等分区间内随机选
+        dates: list[date] = [start_date]
+        remaining = count - 1
+        if remaining > 0 and total_days > 1:
+            # 将 start_date+1 ~ end_date 等分为 remaining 个区间
+            day_range = total_days - 1  # 排除 start_date
+            segment_size = day_range / remaining
+            for i in range(remaining):
+                seg_start = int(i * segment_size) + 1
+                seg_end = min(int((i + 1) * segment_size), day_range)
+                if seg_start > seg_end:
+                    seg_start = seg_end
+                day_offset = random.randint(seg_start, seg_end)
+                dates.append(start_date + timedelta(days=day_offset))
+
+        dates.sort()
+
+        # 分配活动内容
+        pool = ArchivePlaceholderService._ADVISOR_WORK_ITEMS
+        if count <= len(pool):
+            activities = random.sample(pool, count)
+        else:
+            activities = random.sample(pool, len(pool))
+            while len(activities) < count:
+                activities.append(random.choice(pool))
+
+        # 构建文本
+        rt = _ArchiveMaterialsRichText()
+        for i, (d, activity) in enumerate(zip(dates, activities)):
+            if i > 0:
+                rt.add_break()
+            date_str = f"{d.year}年{d.month}月{d.day}日"
+            if i == 0:
+                rt.add(f"{date_str}，开始服务；")
+            else:
+                rt.add(f"{date_str}，{activity}")
+
+        return str(rt)

--- a/backend/tests/ci/unit/contracts/test_contract_admin_extended.py
+++ b/backend/tests/ci/unit/contracts/test_contract_admin_extended.py
@@ -138,6 +138,7 @@ class TestContractAdminViews:
         request = MagicMock()
         request.GET = {}
         request.path = "/admin/contracts/contract/"
+        request.session = {}
         result = admin.changelist_view(request)
         assert result.status_code == 302
         assert "status__exact=active" in result.url

--- a/backend/tests/ci/unit/contracts/test_contracts_model.py
+++ b/backend/tests/ci/unit/contracts/test_contracts_model.py
@@ -175,7 +175,7 @@ class TestContractPartyModel:
     def test_create_party(self) -> None:
         """创建合同当事人"""
         contract = Contract.objects.create(name="合同当事人测试", case_type="civil")
-        client = Client.objects.create(name="合同当事人", client_type="natural")
+        client = Client.objects.create(name="合同当事人", client_type="natural", is_our_client=True)
         party = ContractParty.objects.create(
             contract=contract, client=client, role=PartyRole.PRINCIPAL
         )

--- a/backend/tests/ci/unit/contracts/test_contracts_services_real.py
+++ b/backend/tests/ci/unit/contracts/test_contracts_services_real.py
@@ -238,7 +238,7 @@ class TestContractPartyModels:
         from apps.client.models import Client
 
         contract = Contract.objects.create(name="Party Test Contract")
-        client = Client.objects.create(name="Party Client", client_type=Client.NATURAL)
+        client = Client.objects.create(name="Party Client", client_type=Client.NATURAL, is_our_client=True)
         party = ContractParty.objects.create(
             contract=contract,
             client=client,

--- a/changelog/v26.53/v26.53.14.md
+++ b/changelog/v26.53/v26.53.14.md
@@ -1,0 +1,44 @@
+# v26.53.14
+
+## 常法顾问工作日记自动生成 + 合同当事人防呆 + Admin 体验优化
+
+### ✨ 新功能
+
+- **常法顾问合同自动生成律师办案工作日记**
+  - 归档检查清单"律师办案工作日记"行新增"生成"按钮（仅 case_type=advisor + 有起止日期时显示）
+  - 有真实 CaseLog 时使用真实日志，无日志时根据合同起止日期随机生成 5-7 条均匀分布的工作日志
+  - 生成内容含 15 条常法顾问活动池（劳动合规培训、合同审查、法律咨询等）
+  - 生成结果保存为 ArchivePlaceholderOverride，自动打开替换词预览对话框供用户审查编辑
+
+### 🔧 修复与增强
+
+- **ContractParty 后端防呆 — 非我方当事人自动校正 role**
+  - `ContractParty.save()` 中新增校验：`client.is_our_client=False` 且 `role=PRINCIPAL` 时自动修正为 `OPPOSING`
+  - 覆盖所有创建路径（API、import、add_party），不依赖前端 JS
+  - 校正时记录 WARNING 日志便于排查
+
+- **party_role_auto.js 前端防呆增强 — 三层防护**
+  - ① document 级 select2 事件委托（兜底，不依赖 MutationObserver 时序）
+  - ② MutationObserver 检测 role select 插入时，若 client 已选则触发检查
+  - ③ 提交守卫：AJAX 未完成时阻止表单提交，等请求结束后自动 submit
+  - 附加：AbortController 取消过期请求，findRoleSelect 增加 group 容器 fallback
+
+- **合同/案件列表页"全部"筛选修复**
+  - 修复点击"全部"筛选后被强制跳回"在办"的问题
+  - 使用 session 标记替代 `not request.GET` 判断，只在首次访问时自动跳转
+
+- **ContractAdmin 搜索增强**
+  - `search_fields` 新增 `law_firm_oa_case_number`，支持按律所OA案件编号搜索
+
+### 📁 改动文件
+
+| 文件 | 改动 |
+|------|------|
+| `documents/services/placeholders/archive/__init__.py` | 新增 `_generate_random_work_log_content` 方法 + 活动池 |
+| `contracts/admin/mixins/archive_mixin.py` | 新增 `generate_work_log_content_view` admin 视图 |
+| `contracts/admin/mixins/display_mixin.py` | 注册 `generate-work-log-content/` URL |
+| `templates/.../finalized_materials.html` | 生成按钮 + CSS + JS handler |
+| `contracts/models/party.py` | `ContractParty.save()` 防呆 |
+| `contracts/static/contracts/js/party_role_auto.js` | 三层防护增强 |
+| `contracts/admin/contract_admin.py` | 搜索字段 + 列表筛选修复 |
+| `cases/admin/case_admin.py` | 列表筛选修复 |


### PR DESCRIPTION
## 改动内容

### ✨ 新功能
- **常法顾问合同自动生成律师办案工作日记**（归档标签 → 随机/真实日志 → 预览对话框）

### 🔧 修复与增强
- **ContractParty 后端防呆** — `save()` 中 `is_our_client=False` 且 `role=PRINCIPAL` 时自动修正为 `OPPOSING`
- **party_role_auto.js 前端防呆增强** — document 级 select2 事件委托 + 提交守卫 + MutationObserver 三重防护
- **合同/案件列表"全部"筛选修复** — 用 session 标记替代 `not request.GET` 判断
- **ContractAdmin 搜索增强** — `search_fields` 新增 `law_firm_oa_case_number`

### 📁 改动文件（8 个文件，+326/-84 行）
| 文件 | 改动 |
|------|------|
| `archive/__init__.py` | 新增 `_generate_random_work_log_content` 方法 |
| `archive_mixin.py` | 新增 admin 视图 |
| `display_mixin.py` | 注册 URL |
| `finalized_materials.html` | 生成按钮 + CSS + JS |
| `party.py` | `save()` 防呆 |
| `party_role_auto.js` | 三层防护增强 |
| `contract_admin.py` | 搜索 + 筛选修复 |
| `case_admin.py` | 筛选修复 |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)