### PR TITLE
chore: .gitmodules plugins branch 改为 main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "backend/plugins"]
 	path = backend/plugins
 	url = https://github.com/Lawyer-ray/FachuanPlugins.git
-	branch = feat/court-automation-migration
+	branch = main


### PR DESCRIPTION
原指向已删除的 feat/court-automation-migration，改为 main。