### PR TITLE
fix: 一张网申请担保询价流程修复（含 plugins 子模块更新）

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "django-ninja==1.6.2",
     "django-ninja-jwt==5.4.4",
     "django-ninja-extra==0.31.4",
+    "joserfc>=1.6.8",  # CVE-2026-49852
     "django-q2==1.10.0",
     "django-lifecycle==1.2.7",
     # --- ASGI / WebSocket ---

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1430,6 +1430,7 @@ dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "huggingface-hub" },
     { name = "icalendar" },
+    { name = "joserfc" },
     { name = "lxml" },
     { name = "mammoth" },
     { name = "markdown" },
@@ -1525,6 +1526,7 @@ requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = "==0.28.1" },
     { name = "huggingface-hub", specifier = ">=1.0.0" },
     { name = "icalendar", specifier = ">=7.1.0" },
+    { name = "joserfc", specifier = ">=1.6.8" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mammoth", specifier = ">=1.12.0" },
     { name = "markdown", specifier = ">=3.10.2" },
@@ -2537,14 +2539,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.5"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]

--- a/changelog/v26.53/v26.53.15.md
+++ b/changelog/v26.53/v26.53.15.md
@@ -1,0 +1,9 @@
+# v26.53.15
+
+## 修复
+
+### 一张网申请担保 — 发起询价流程修复
+
+- **发起询价按钮禁用时显示具体原因提示**：当保全金额（preservation_amount）或一张网账号凭证缺失时，按钮灰掉但没有提示文字，用户不知道为什么无法操作。现在在按钮区域下方显示对应提示。
+- **新建询价后补上 submit_task 调用**：`ensure_case_quote` 中创建 `PreservationQuote` 和绑定记录后缺少 `submit_task` 调用，导致询价任务一直处于 PENDING 状态、永远不会执行。对比重试路径已有 `submit_task`，新建路径遗漏。
+- **Playwright 自动登录不能跨线程调用**：`_single_login_attempt` 用 `run_in_executor` 把 Playwright 操作扔到线程池，但 Playwright sync API 基于 greenlet（线程本地），跨线程后上下文丢失。Django Q worker 已在独立线程中，新增 `_sync_login_attempt_in_new_playwright` 方法，在独立线程中创建全新 Playwright 实例执行登录，避免跨线程 greenlet 问题和 asyncio loop 冲突。


### PR DESCRIPTION
## 修复内容

### 1. 发起询价按钮禁用时显示具体原因提示
当保全金额（preservation_amount）或一张网账号凭证缺失时，按钮灰掉但没有提示文字。现在在按钮区域下方显示对应提示。

### 2. 新建询价后补上 submit_task 调用
`ensure_case_quote` 中创建 `PreservationQuote` 和绑定记录后缺少 `submit_task` 调用，导致询价任务一直处于 PENDING 状态、永远不会执行。

### 3. Playwright 自动登录不能跨线程调用
`_single_login_attempt` 用 `run_in_executor` 把 Playwright 操作扔到线程池，但 Playwright sync API 基于 greenlet（线程本地），跨线程后上下文丢失。新增 `_sync_login_attempt_in_new_playwright` 方法，在独立线程中创建全新 Playwright 实例执行登录。

## 关联
- plugins 子模块 PR: https://github.com/Lawyer-ray/FachuanPlugins/pull/4 （已合并）