### PR TITLE
fix: backend-unit-coverage CI 超时 30→45 分钟

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -319,7 +319,7 @@ jobs:
 
   backend-unit-coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: backend


### PR DESCRIPTION
测试套件增长到 ~1050 个，30 分钟超时不够用。