### PR TITLE
fix: 归档占位符覆盖值保存时合并而非替换

### DIFF
--- a/backend/apps/contracts/services/archive/override_service.py
+++ b/backend/apps/contracts/services/archive/override_service.py
@@ -18,12 +18,21 @@ def get_override(contract_id: int, template_subtype: str) -> ArchivePlaceholderO
 def save_override(
     contract_id: int, template_subtype: str, overrides: dict[str, str]
 ) -> tuple[ArchivePlaceholderOverride, bool]:
-    """保存（创建或更新）归档占位符覆盖值。"""
-    return ArchivePlaceholderOverride.objects.update_or_create(
+    """保存（创建或更新）归档占位符覆盖值。
+
+    新的覆盖值会 **合并** 到已有值中，而不是整体替换，
+    以保证多次局部编辑不会丢失之前保存的内容。
+    """
+    obj, created = ArchivePlaceholderOverride.objects.get_or_create(
         contract_id=contract_id,
         template_subtype=template_subtype,
-        defaults={"overrides": overrides},
     )
+    if not created:
+        obj.overrides = {**obj.overrides, **overrides}
+    else:
+        obj.overrides = overrides
+    obj.save(update_fields=["overrides", "updated_at"])
+    return obj, created
 
 
 def delete_override(contract_id: int, template_subtype: str) -> int:

--- a/backend/tests/ci/unit/contracts/test_contracts_coverage.py
+++ b/backend/tests/ci/unit/contracts/test_contracts_coverage.py
@@ -197,19 +197,33 @@ class TestArchiveOverrideService:
         assert result is None
 
     @patch("apps.contracts.services.archive.override_service.ArchivePlaceholderOverride")
-    def test_save_override(self, mock_model):
+    def test_save_override_new(self, mock_model):
+        """新建时直接使用传入的 overrides。"""
         from apps.contracts.services.archive.override_service import save_override
 
         mock_obj = MagicMock()
-        mock_model.objects.update_or_create.return_value = (mock_obj, True)
+        mock_model.objects.get_or_create.return_value = (mock_obj, True)
         result, created = save_override(1, "subtype", {"key": "val"})
         assert result == mock_obj
         assert created is True
-        mock_model.objects.update_or_create.assert_called_once_with(
+        mock_model.objects.get_or_create.assert_called_once_with(
             contract_id=1,
             template_subtype="subtype",
-            defaults={"overrides": {"key": "val"}},
         )
+        mock_obj.save.assert_called_once_with(update_fields=["overrides", "updated_at"])
+
+    @patch("apps.contracts.services.archive.override_service.ArchivePlaceholderOverride")
+    def test_save_override_merge(self, mock_model):
+        """更新时应合并已有覆盖值，而非整体替换。"""
+        from apps.contracts.services.archive.override_service import save_override
+
+        mock_obj = MagicMock()
+        mock_obj.overrides = {"old_key": "old_val"}
+        mock_model.objects.get_or_create.return_value = (mock_obj, False)
+        result, created = save_override(1, "subtype", {"new_key": "new_val"})
+        assert created is False
+        assert mock_obj.overrides == {"old_key": "old_val", "new_key": "new_val"}
+        mock_obj.save.assert_called_once_with(update_fields=["overrides", "updated_at"])
 
     @patch("apps.contracts.services.archive.override_service.ArchivePlaceholderOverride")
     def test_delete_override(self, mock_model):


### PR DESCRIPTION
## 问题

案卷封面（及其他归档模板）的手动修改功能存在数据丢失 bug：第一次修改字段 A 并保存，第二次修改字段 B 并保存后，字段 A 的修改内容会丢失。

## 根因

`override_service.save_override()` 使用 `update_or_create` + `defaults={"overrides": overrides}`，每次保存都将前端传入的 diff **整体替换** overrides JSONField，而不是合并到已有值中。

前端每次只发送本次编辑的 diff（`editValue !== value` 的字段），后端整体替换 → 之前保存的覆盖值被静默丢弃。

## 修复

将 `save_override()` 从 `update_or_create` + 全量替换改为 `get_or_create` + dict merge：

- 新建时：直接赋值
- 更新时：`{**existing.overrides, **new_overrides}`（新值覆盖同 key 旧值，保留其余 key）

## 影响范围

修复 `save_override()` 一个函数，所有调用方自动受益：
- API 端点 `POST /contracts/{id}/archive-placeholder-overrides`
- Admin 生成律师工作日志
- MCP 工具 `save_archive_overrides`

## 测试

- 更新现有单元测试以匹配新实现
- 新增 `test_save_override_merge` 覆盖合并行为
