### PR TITLE
fix: backend CI 超时从 30 分钟增加到 45 分钟

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -282,19 +282,6 @@ jobs:
           PYTHONPATH: "apiSystem:."
         run: uv run pytest -c pytest.ini --no-cov --collect-only -q tests/ci/structure/
 
-      - name: Tests (unit)
-        env:
-          DJANGO_DEBUG: "1"
-          DB_ENGINE: "postgresql"
-          TEST_DB_ENGINE: "postgresql"
-          TEST_DB_NAME: "fachuan_ci_test"
-          TEST_DB_USER: "postgres"
-          TEST_DB_PASSWORD: "postgres"  # pragma: allowlist secret  # pragma: allowlist secret
-          TEST_DB_HOST: "127.0.0.1"
-          TEST_DB_PORT: "5432"
-          PYTHONPATH: "apiSystem:."
-        run: uv run pytest -c pytest.ini -o "addopts=--reuse-db --import-mode=importlib -q --tb=short --strict-markers --timeout=30" --capture=fd --no-cov -q tests/ci/unit/
-
       - name: Smoke check (minimal)
         env:
           DJANGO_DEBUG: "1"


### PR DESCRIPTION
## 问题

`backend` job 持续超时（30 分钟限制）。原因是 backend job 和 `backend-unit-coverage` job **重复跑了全部 25000+ 单元测试**。

## 修复

从 `backend` job 中移除 `Tests (unit)` 步骤。单元测试由 `backend-unit-coverage` 负责（含 coverage 检查），`backend` job 只负责：

- Repository hygiene
- Pre-commit / Ruff lint
- Mypy type check
- Collection smoke
- Smoke check (minimal)
- pip-audit
- bandit

恢复 30 分钟超时（去掉重复测试后绰绰有余）。
