### PR TITLE
fix: 一张网登录选择器 + 案件当事人 403 + GSXT 报告按钮

### DIFF
--- a/backend/apps/automation/services/gsxt/gsxt_login_service.py
+++ b/backend/apps/automation/services/gsxt/gsxt_login_service.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 import threading
+import time
 from typing import Any, Protocol
 
 from django.utils import timezone
@@ -307,19 +307,21 @@ async def _run_full_flow(credential: GsxtCredentialProtocol, task_id: int) -> No
             # 流程：点击 #moreActionsToggle → 显示 #moreActionsMenu → 点击 #btn_send_pdf
             try:
                 await target.wait_for_selector("#moreActionsToggle", timeout=30000)
-                await target.click("#moreActionsToggle")
+                # 用 force=True 绕过可能的遮挡层（如透明 overlay）
+                await target.click("#moreActionsToggle", force=True)
                 logger.info("已点击'更多'按钮，等待下拉菜单显示...")
-                await asyncio.sleep(1)
+                # 等待下拉菜单实际可见（而非固定 sleep）
+                await target.wait_for_selector("#moreActionsMenu", state="visible", timeout=10000)
+                await asyncio.sleep(0.5)
             except Exception:
-                logger.warning("未找到'更多'按钮，尝试直接点击 #btn_send_pdf")
+                logger.warning("未找到'更多'按钮或下拉菜单未展开，尝试直接点击 #btn_send_pdf")
 
-            # 等待 #btn_send_pdf 出现（在下拉菜单中）
             try:
-                await target.wait_for_selector("#btn_send_pdf", timeout=15000)
+                await target.wait_for_selector("#btn_send_pdf", state="visible", timeout=15000)
             except Exception:
                 raise GsxtReportError("详情页未找到发送报告按钮，可能页面未完全加载")
 
-            await target.click("#btn_send_pdf")
+            await target.click("#btn_send_pdf", force=True)
             logger.info("已点击发送报告，等待用户完成验证码...")
 
             done = await _wait_captcha_success(

--- a/backend/apps/automation/services/gsxt/gsxt_login_service.py
+++ b/backend/apps/automation/services/gsxt/gsxt_login_service.py
@@ -163,22 +163,33 @@ async def _click_company_detail(page: Any, company_name: str, context: Any) -> A
 
     # 新标签页优先
     if new_page and not new_page.is_closed():
-        # 详情页 #btn_send_pdf 初始可能不可见，等待加载完成
+        # URL 可能还未设置，等待页面有了 URL 再继续
+        try:
+            await new_page.wait_for_url("**/*gsxt.gov.cn**", timeout=15000)
+        except Exception:
+            logger.warning("新标签页等待 URL 超时，当前 URL: %s", new_page.url)
         try:
             await new_page.wait_for_load_state("domcontentloaded", timeout=30000)
         except Exception:
             pass
+        logger.info("新标签页就绪: %s", new_page.url[:80])
         return new_page
 
-    # 在 context 中查找详情页
-    for p in context.pages:
-        try:
-            url = p.url
-            if not p.is_closed() and "gsxt.gov.cn" in url and "search" not in url and "homepage" not in url:
-                logger.info("在 context 中找到详情页: %s", url[:80])
-                return p
-        except Exception:
-            continue
+    # 在 context 中查找详情页（等待新页面出现）
+    for _attempt in range(5):
+        for p in context.pages:
+            try:
+                url = p.url
+                if not p.is_closed() and "gsxt.gov.cn" in url and "search" not in url and "homepage" not in url:
+                    logger.info("在 context 中找到详情页: %s", url[:80])
+                    try:
+                        await p.wait_for_load_state("domcontentloaded", timeout=30000)
+                    except Exception:
+                        pass
+                    return p
+            except Exception:
+                continue
+        await asyncio.sleep(2)
 
     raise GsxtReportError("详情页未打开，可能被 WAF 拦截")
 
@@ -305,6 +316,32 @@ async def _run_full_flow(credential: GsxtCredentialProtocol, task_id: int) -> No
             target = detail_page or page
             # 详情页改版后，"发送报告"按钮藏在"更多"下拉菜单中
             # 流程：点击 #moreActionsToggle → 显示 #moreActionsMenu → 点击 #btn_send_pdf
+
+            # 等待详情页完全加载（可能因重定向/JS 渲染导致页面不稳定）
+            try:
+                await target.wait_for_load_state("domcontentloaded", timeout=30000)
+            except Exception:
+                logger.warning("等待详情页加载超时，继续尝试操作")
+            await asyncio.sleep(3)
+
+            logger.info("详情页 URL: %s", target.url)
+            # 先用 JS 检查页面上有哪些可交互元素（调试用）
+            try:
+                debug_info = await target.evaluate("""() => {
+                    const toggle = document.querySelector('#moreActionsToggle');
+                    const btnPdf = document.querySelector('#btn_send_pdf');
+                    return {
+                        hasToggle: !!toggle,
+                        toggleVisible: toggle ? toggle.offsetParent !== null : false,
+                        hasBtnPdf: !!btnPdf,
+                        btnPdfVisible: btnPdf ? btnPdf.offsetParent !== null : false,
+                        bodyLength: document.body ? document.body.innerHTML.length : 0,
+                    };
+                }""")
+                logger.info("详情页元素检查: %s", debug_info)
+            except Exception as e:
+                logger.warning("详情页元素检查失败: %s", e)
+
             try:
                 await target.wait_for_selector("#moreActionsToggle", timeout=30000)
                 # 用 force=True 绕过可能的遮挡层（如透明 overlay）

--- a/backend/apps/automation/services/gsxt/gsxt_report_service.py
+++ b/backend/apps/automation/services/gsxt/gsxt_report_service.py
@@ -129,18 +129,28 @@ async def _click_company_detail(page: Any, company_name: str, context: Any) -> A
 
     if new_page and not new_page.is_closed():
         try:
+            await new_page.wait_for_url("**/*gsxt.gov.cn**", timeout=15000)
+        except Exception:
+            logger.warning("新标签页等待 URL 超时，当前 URL: %s", new_page.url)
+        try:
             await new_page.wait_for_load_state("domcontentloaded", timeout=30000)
         except Exception:
             pass
         return new_page
 
-    for p in context.pages:
-        try:
-            url = p.url
-            if not p.is_closed() and "gsxt.gov.cn" in url and "search" not in url and "homepage" not in url:
-                return p
-        except Exception:
-            continue
+    for _attempt in range(5):
+        for p in context.pages:
+            try:
+                url = p.url
+                if not p.is_closed() and "gsxt.gov.cn" in url and "search" not in url and "homepage" not in url:
+                    try:
+                        await p.wait_for_load_state("domcontentloaded", timeout=30000)
+                    except Exception:
+                        pass
+                    return p
+            except Exception:
+                continue
+        await asyncio.sleep(2)
 
     raise GsxtReportError("详情页未打开，可能被 WAF 拦截")
 

--- a/backend/apps/automation/services/gsxt/gsxt_report_service.py
+++ b/backend/apps/automation/services/gsxt/gsxt_report_service.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 import threading
+import time
 from typing import Any
 
 from django.utils import timezone
@@ -28,7 +28,9 @@ class GsxtReportError(Exception):
     """报告申请失败异常。"""
 
 
-async def _wait_captcha_success(page: Any, captcha_selector: str, timeout: int = CAPTCHA_TIMEOUT) -> bool:  # pragma: no cover
+async def _wait_captcha_success(
+    page: Any, captcha_selector: str, timeout: int = CAPTCHA_TIMEOUT
+) -> bool:  # pragma: no cover
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         await asyncio.sleep(2)
@@ -210,18 +212,21 @@ async def _run_full_flow(task_id: int) -> None:  # pragma: no cover
             # 流程：点击 #moreActionsToggle → 显示 #moreActionsMenu → 点击 #btn_send_pdf
             try:
                 await target.wait_for_selector("#moreActionsToggle", timeout=30000)
-                await target.click("#moreActionsToggle")
+                # 用 force=True 绕过可能的遮挡层（如透明 overlay）
+                await target.click("#moreActionsToggle", force=True)
                 logger.info("已点击'更多'按钮，等待下拉菜单显示...")
-                await asyncio.sleep(1)
+                # 等待下拉菜单实际可见（而非固定 sleep）
+                await target.wait_for_selector("#moreActionsMenu", state="visible", timeout=10000)
+                await asyncio.sleep(0.5)
             except Exception:
-                logger.warning("未找到'更多'按钮，尝试直接点击 #btn_send_pdf")
+                logger.warning("未找到'更多'按钮或下拉菜单未展开，尝试直接点击 #btn_send_pdf")
 
             try:
-                await target.wait_for_selector("#btn_send_pdf", timeout=15000)
+                await target.wait_for_selector("#btn_send_pdf", state="visible", timeout=15000)
             except Exception:
                 raise GsxtReportError("详情页未找到发送报告按钮，可能页面未完全加载")
 
-            await target.click("#btn_send_pdf")
+            await target.click("#btn_send_pdf", force=True)
 
             done = await _wait_captcha_success(
                 target,

--- a/backend/apps/cases/admin/case_admin.py
+++ b/backend/apps/cases/admin/case_admin.py
@@ -49,7 +49,6 @@ class CasePartyInline(BaseTabularInline):  # pragma: no cover
     formset = CasePartyInlineFormSet
     extra = 0
     fields = ("client", "legal_status")
-    autocomplete_fields = ("client",)
     classes = ["contract-party-inline"]
 
     def formfield_for_foreignkey(self, db_field: Any, request: HttpRequest, **kwargs: Any) -> Any:  # pragma: no cover
@@ -283,7 +282,9 @@ class CaseAdmin(
             "logs__reminders",
         )
 
-    def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> Any:  # pragma: no cover
+    def changelist_view(
+        self, request: HttpRequest, extra_context: dict[str, Any] | None = None
+    ) -> Any:  # pragma: no cover
         from django.http import HttpResponseRedirect
 
         if "status__exact" not in request.GET and not request.session.get("case_changelist_visited"):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4128,11 +4128,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/1d/c7/28220d37e041fe1df
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/changelog/v26.54/v26.54.6.md
+++ b/changelog/v26.54/v26.54.6.md
@@ -1,0 +1,25 @@
+# v26.54.6
+
+## Bug Fixes
+
+### 一张网登录适配 2026-07 网站改版（plugins）
+
+- 更新一张网登录页选择器，适配 2026-07 网站改版
+- 第二轮选择器修复，覆盖更多表单字段
+- 登录填写表单改用 `page.evaluate()` 替代 Playwright 原生 fill，提升兼容性
+
+### 担保执行 API sync_to_async 修复（plugins）
+
+- 担保执行 API 的 sync ORM 调用包装 `sync_to_async`，修复异步上下文中的 ORM 调用报错
+
+### 案件编辑页当事人 403 错误
+
+- 移除 `CasePartyInline` 的 `autocomplete_fields`，修复新增当事人时 `/admin/autocomplete/` 返回 403 Forbidden
+- 移除后 `formfield_for_foreignkey` 的按合同过滤当事人逻辑生效，JS 的自动填充功能正常工作
+
+### GSXT 企业信用报告按钮点击失败
+
+- `click()` 添加 `force=True` 绕过详情页可能的遮挡层
+- 等待 `#moreActionsMenu` 可见后再点击 `#btn_send_pdf`，替代固定 `sleep(1)`
+- 新标签页 URL 为空时用 `wait_for_url` 等待就绪，context 兜底查找改为重试循环
+- 详情页操作前增加 `wait_for_load_state` + 调试日志，确保页面完全加载


### PR DESCRIPTION
## 改动内容

### plugins 子模块（已合并到 main）
- 更新一张网登录页选择器，适配 2026-07 网站改版
- 一张网登录改用 page.evaluate() 填写表单
- 担保执行 API 的 sync ORM 调用包装 sync_to_async

### 主仓库
- 移除 CasePartyInline 的 autocomplete_fields，修复案件编辑页新增当事人时 /admin/autocomplete/ 返回 403
- GSXT 企业信用报告按钮：force=True 绕过遮挡 + 等待下拉菜单可见 + 详情页加载等待

### Changelog
- 新增 changelog/v26.54/v26.54.6.md