### PR TITLE
fix: PostgreSQL 连接管理 + 归档排序 + LPR 历史记录

### DIFF
--- a/backend/apiSystem/apiSystem/settings.py
+++ b/backend/apiSystem/apiSystem/settings.py
@@ -247,9 +247,9 @@ if DB_ENGINE in ("sqlite", "sqlite3", "django.db.backends.sqlite3"):
         }
     }
 elif DB_ENGINE in ("", "postgres", "postgresql", "django.db.backends.postgresql"):
-    # 开发环境：连接 60 秒后自动释放，避免连接数堆积
-    # 生产环境：保持 600 秒，复用连接提升性能
-    _conn_max_age = 60 if DEBUG else 600
+    # 开发环境：每个请求结束后立即释放连接，避免多进程堆积导致 "too many clients"
+    # 生产环境：保持 600 秒复用连接提升性能
+    _conn_max_age = 0 if DEBUG else 600
 
     DATABASES = {
         "default": {

--- a/backend/apps/contracts/admin/mixins/archive_mixin.py
+++ b/backend/apps/contracts/admin/mixins/archive_mixin.py
@@ -129,7 +129,9 @@ class ContractArchiveMixin:  # pragma: no cover
 
     # ── 归档下载与预览 ──
 
-    def download_archive_item_view(self, request: HttpRequest, object_id: int, archive_item_code: str) -> HttpResponse:  # pragma: no cover
+    def download_archive_item_view(
+        self, request: HttpRequest, object_id: int, archive_item_code: str
+    ) -> HttpResponse:  # pragma: no cover
         """下载归档检查项材料的 Admin view（多个文件自动合并为PDF）"""
         from django.http import HttpResponse as DjangoHttpResponse
 
@@ -166,7 +168,9 @@ class ContractArchiveMixin:  # pragma: no cover
 
             return JsonResponse({"success": False, "error": str(e)}, status=500)
 
-    def preview_archive_material_view(self, request: HttpRequest, object_id: int, material_id: int) -> HttpResponse:  # pragma: no cover
+    def preview_archive_material_view(
+        self, request: HttpRequest, object_id: int, material_id: int
+    ) -> HttpResponse:  # pragma: no cover
         """预览单个归档材料的 Admin view"""
         from django.http import HttpResponse as DjangoHttpResponse
         from django.http import JsonResponse
@@ -302,7 +306,9 @@ class ContractArchiveMixin:  # pragma: no cover
             logger.exception("同步案件材料失败: contract_id=%s", object_id)
             return JsonResponse({"success": False, "error": str(e)}, status=500)
 
-    def reset_and_resync_case_materials_view(self, request: HttpRequest, object_id: int) -> HttpResponse:  # pragma: no cover
+    def reset_and_resync_case_materials_view(
+        self, request: HttpRequest, object_id: int
+    ) -> HttpResponse:  # pragma: no cover
         """重置并重新同步案件材料到归档的 Admin view"""
         from django.http import JsonResponse
 
@@ -438,13 +444,9 @@ class ContractArchiveMixin:  # pragma: no cover
             data = json.loads(request.body)
             orders: dict[str, list[int]] = data.get("orders", {})
 
-            for code, material_ids in orders.items():
-                for i, pk in enumerate(material_ids):
-                    FinalizedMaterial.objects.filter(
-                        pk=pk,
-                        contract_id=object_id,
-                        archive_item_code=code,
-                    ).update(order=i)
+            from apps.contracts.services.archive.archive_query_service import reorder_materials
+
+            reorder_materials(object_id, orders)
 
             logger.info("归档材料排序已保存: contract_id=%s", object_id)
             return JsonResponse({"success": True})
@@ -507,7 +509,9 @@ class ContractArchiveMixin:  # pragma: no cover
             logger.exception("移动归档材料失败: contract_id=%s", object_id)
             return JsonResponse({"success": False, "error": str(e)}, status=500)
 
-    def upload_archive_item_view(self, request: HttpRequest, object_id: int, archive_item_code: str) -> HttpResponse:  # pragma: no cover
+    def upload_archive_item_view(
+        self, request: HttpRequest, object_id: int, archive_item_code: str
+    ) -> HttpResponse:  # pragma: no cover
         """上传文件到归档检查清单项的 Admin view"""
         from django.http import JsonResponse
 
@@ -547,7 +551,9 @@ class ContractArchiveMixin:  # pragma: no cover
             logger.exception("上传归档材料失败: contract_id=%s, code=%s", object_id, archive_item_code)
             return JsonResponse({"success": False, "error": str(e)}, status=500)
 
-    def delete_archive_material_view(self, request: HttpRequest, object_id: int, material_id: int) -> HttpResponse:  # pragma: no cover
+    def delete_archive_material_view(
+        self, request: HttpRequest, object_id: int, material_id: int
+    ) -> HttpResponse:  # pragma: no cover
         """删除归档材料子项的 Admin view"""
         from pathlib import Path
 
@@ -585,7 +591,9 @@ class ContractArchiveMixin:  # pragma: no cover
             logger.exception("删除归档材料失败: material_id=%s", material_id)
             return JsonResponse({"success": False, "error": str(e)}, status=500)
 
-    def clear_all_archive_materials_view(self, request: HttpRequest, object_id: int) -> HttpResponse:  # pragma: no cover
+    def clear_all_archive_materials_view(
+        self, request: HttpRequest, object_id: int
+    ) -> HttpResponse:  # pragma: no cover
         """一键清空归档检查清单中的全部材料"""
         from pathlib import Path
 

--- a/backend/apps/contracts/services/archive/archive_query_service.py
+++ b/backend/apps/contracts/services/archive/archive_query_service.py
@@ -37,11 +37,19 @@ def reorder_materials(contract_id: int, orders: dict[str, list[int]]) -> None:
     """按归档清单项分组排序子项。"""
     for code, material_ids in orders.items():
         for i, pk in enumerate(material_ids):
-            FinalizedMaterial.objects.filter(
+            mat = FinalizedMaterial.objects.filter(
                 pk=pk,
                 contract_id=contract_id,
-                archive_item_code=code,
-            ).update(order=i)
+            ).first()
+            if mat:
+                mat.order = i + 1
+                # 动态映射的材料（如合同正本）数据库中 archive_item_code 为空，
+                # 需要同步写入，否则 get_checklist_with_status 加载顺序会错乱。
+                if not mat.archive_item_code:
+                    mat.archive_item_code = code
+                    mat.save(update_fields=["order", "archive_item_code"])
+                else:
+                    mat.save(update_fields=["order"])
 
 
 def move_material(material: FinalizedMaterial, target_code: str) -> None:

--- a/backend/apps/contracts/services/archive/checklist/checklist_query.py
+++ b/backend/apps/contracts/services/archive/checklist/checklist_query.py
@@ -76,6 +76,10 @@ def get_checklist_with_status(contract: Contract) -> dict[str, Any]:
 
     _apply_subitem_order(code_to_material_details)
 
+    # 同步 material_ids 顺序，确保与 materials 一致
+    for code, details in code_to_material_details.items():
+        code_to_materials[code] = [d["id"] for d in details]
+
     case_material_match_codes = find_case_material_match_codes(contract, archive_category)
 
     items_with_status: list[dict[str, Any]] = []

--- a/backend/apps/finance/admin/lpr_admin.py
+++ b/backend/apps/finance/admin/lpr_admin.py
@@ -115,7 +115,9 @@ class LPRRateAdmin(BaseModelAdmin):  # pragma: no cover
         ]
         return custom_urls + urls
 
-    def changelist_view(self, request: HttpRequest, extra_context: dict | None = None) -> TemplateResponse:  # pragma: no cover
+    def changelist_view(
+        self, request: HttpRequest, extra_context: dict | None = None
+    ) -> TemplateResponse:  # pragma: no cover
         """列表页面视图，添加快捷操作按钮."""
         extra_context = extra_context or {}
         extra_context["sync_url"] = "sync/"
@@ -175,7 +177,7 @@ class LPRRateAdmin(BaseModelAdmin):  # pragma: no cover
             **self.admin_site.each_context(request),
             "title": "LPR利息计算器",
             "opts": self.model._meta,
-            "recent_rates": LPRRate.objects.all()[:10],
+            "recent_rates": LPRRate.objects.all()[:50],
             "latest_rate": latest_rate,
             "is_data_current": rate_service.is_data_current(),
             "sync_url": "sync/",

--- a/backend/config/postgres/custom.conf
+++ b/backend/config/postgres/custom.conf
@@ -1,0 +1,4 @@
+# PostgreSQL 配置 - 增加连接数上限
+# 默认 max_connections=100，本地开发需要更多连接（runserver + qcluster workers）
+
+max_connections = 300

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./config/postgres/custom.conf:/etc/postgresql/postgresql.conf
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_NAME:-fachuan_dev}"]
       interval: 10s

--- a/backend/tests/ci/unit/contracts/test_archive_mixin_extended.py
+++ b/backend/tests/ci/unit/contracts/test_archive_mixin_extended.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -197,11 +197,11 @@ class TestContractArchiveMixinSuccessPaths:
         request = MagicMock()
         request.method = "POST"
         request.body = json.dumps({"orders": {"code1": [3, 1, 2]}}).encode()
-        with patch("apps.contracts.admin.mixins.archive_mixin.FinalizedMaterial") as mock_model:
-            mock_model.objects.filter.return_value.update.return_value = 3
+        with patch("apps.contracts.services.archive.archive_query_service.reorder_materials") as mock_reorder:
             result = mixin.reorder_archive_materials_view(request, 1)
             data = json.loads(result.content)
             assert data["success"] is True
+            mock_reorder.assert_called_once_with(1, {"code1": [3, 1, 2]})
 
     def test_move_archive_material_missing_params(self) -> None:
         mixin = self._make_mixin()

--- a/changelog/v26.54/v26.54.7.md
+++ b/changelog/v26.54/v26.54.7.md
@@ -1,0 +1,17 @@
+# v26.54.7
+
+## Bug Fixes
+
+### PostgreSQL 连接管理
+
+- 开发环境 `CONN_MAX_AGE` 改为 0，避免 PostgreSQL 连接堆积导致 `too many connections`
+- PostgreSQL `max_connections` 从默认 100 增加到 300，适配多 worker 并发场景
+
+### 归档排序
+
+- 修复归档子项手动排序后刷新页面或生成归档文件夹时顺序被重置的问题
+- 同步 `material_ids` 与 `materials` 顺序，修复 PDF 合并时文件顺序错乱
+
+### LPR 计算器
+
+- 历史记录从 10 条放宽到 50 条，方便查看更多计算历史


### PR DESCRIPTION
## v26.54.7

### PostgreSQL 连接管理
- 开发环境 `CONN_MAX_AGE` 改为 0，避免连接堆积导致 `too many connections`
- `max_connections` 从默认 100 增加到 300，适配多 worker 并发

### 归档排序
- 修复归档子项手动排序后刷新页面/生成归档文件夹时顺序被重置
- 同步 `material_ids` 与 `materials` 顺序，修复 PDF 合并顺序错乱

### LPR 计算器
- 历史记录从 10 条放宽到 50 条

### Changelog
- 新增 `changelog/v26.54/v26.54.7.md`