### PR TITLE
fix: 一张网立案材料上传与送达地址确认书修复（v26.54.10）

### DIFF
--- a/changelog/v26.54/v26.54.10.md
+++ b/changelog/v26.54/v26.54.10.md
@@ -1,0 +1,25 @@
+# v26.54.10
+
+## 修复
+
+### 一张网立案：补充对方当事人身份证明材料
+
+立案上传材料时，原先只收集 `side=OUR`（我方当事人材料），导致被告/第三人/被申请人的身份证明材料（`side=OPPONENT`）不会被上传到"当事人身份证明"槽位。
+
+修改 `helpers.py` 中 `_build_materials_map` / `_abuild_materials_map`：
+- 新增 `opponent_client_ids` 参数
+- 从 `CaseMaterial(side=OPPONENT)` 中收集身份证明材料
+- 若 CaseMaterial 中无对方材料，回退到 `ClientIdentityDoc` 获取证件文件（身份证、营业执照等）
+- `api_endpoint.py` 计算对方当事人 ID 并传入
+
+影响范围：HTTP 主链路和 Playwright 两条立案路径。
+
+### 一张网立案：送达地址确认书签名选择逻辑修正
+
+`dzqmList` 返回的签名列表中，`osspath` 为空的记录其 `url` 字段会含 `/null`（OSS 空路径构造的无效 URL）。原代码选了第一条（无效），导致签名下载失败、上传 400。
+
+修改 `_fetch_signature_info`：优先选择有有效 `osspath` 的签名记录，过滤含 `/null` 的 URL。
+
+### 一张网立案：送达地址确认书无签名时回退上传
+
+当签名不可用时，`/ssclfj/upload` 端点因缺少 `qmPath` 返回 400。新增 `_upload_address_confirmation_via_ssclfj` 方法，回退到通用 `/ssclfj` 端点上传（不需要 `qmPath`）。


### PR DESCRIPTION
## 修改内容

### 1. 立案上传补充对方当事人身份证明材料
- `_build_materials_map` / `_abuild_materials_map` 新增 `opponent_client_ids` 参数
- 从 `CaseMaterial(side=OPPONENT)` 收集身份证明材料到身份证明槽位
- 若 CaseMaterial 中无对方材料，回退到 `ClientIdentityDoc` 获取证件文件
- `api_endpoint.py` 计算对方当事人 ID 并传入
- 影响 HTTP 主链路和 Playwright 两条立案路径

### 2. 送达地址确认书签名选择逻辑修正
- `dzqmList` 返回的签名列表中，`osspath` 为空的记录 URL 含 `/null`
- 优先选择有有效 `osspath` 的签名记录，过滤含 `/null` 的 URL

### 3. 送达地址确认书无签名时回退上传
- 新增 `_upload_address_confirmation_via_ssclfj` 方法
- 无签名时回退到通用 `/ssclfj` 端点（不需要 `qmPath`）

## 关联 PR

- Plugins 子模块: https://github.com/Lawyer-ray/FachuanPlugins/pull/9（需先合并）

🤖 Generated with [Claude Code](https://claude.com/claude-code)