### PR TITLE
refactor: 后端嵌套控制流全面重构（v26.54.11）

### DIFF
--- a/backend/NESTING_AUDIT.md
+++ b/backend/NESTING_AUDIT.md
@@ -254,3 +254,55 @@
 | `litigation_ai/agent/factory.py` | 1（3方法重复） |
 | `contracts/services/archive/generation/pdf_utils.py` | 1 |
 | `contracts/services/archive/generation/folder_builder.py` | 1 |
+
+---
+
+# 第三轮深度扫描追加（7 个 opus agent 并行全覆盖扫描）
+
+---
+
+## 十、HIGH 严重 — 新发现
+
+### `core/management/commands/scan_orphan_files.py` L110-127
+- **结构**：`for > try > for > if > try > for > if` — **3 层 for 循环**，遍历所有 Model × 所有 FileField × 所有行
+- **修复**：用 `values_list(field.name, flat=True)` 替代 `model.objects.all()`，加行数上限
+
+### `documents/services/generation/pipeline/preview.py` L29-43, L67-95
+- **结构**：两处 `for > if > if > if > for > if` — **6 层嵌套**
+- `_extract_context_preview` 和 `_extract_ordered_vars` 各一处
+- **修复**：提取 `_format_value(val)` helper + 拆分变量/块标签提取为两个函数
+
+### `documents/services/placeholders/litigation/preservation_property_clue_service.py` L165-205
+- **结构**：`for > for > for > if > for` — **5 层三层 for 循环**
+- 遍历当事人 > 线索类型 > 线索列表 > 内容行
+- **修复**：提取 `_format_clue_group(clue_type, clue_list, start_index)` helper
+
+---
+
+## 十一、MEDIUM 严重 — 新发现
+
+| 文件 | 行号 | 结构 | 说明 |
+|------|------|------|------|
+| `documents/services/generation/folder_generation_service.py` | L695-762 | `for > for > for > try > if` ×3段 | 3 段相同的三层 for + try，应提取 `_collect_identity_docs()` 等 helper |
+| `documents/services/external_template/filling_service.py` | L373-444 | `try > if > if > for` | 3 个分支做相同"设首行、清其余"逻辑，提取 `_set_paragraph_text()` |
+| `documents/services/extractors/judgment_pdf_extractor.py` | L342-374 | `for > if > for > if > if` | 提取 `_find_earliest_end_keyword()` |
+| `workbench/services/doc_extractor.py` | L88-103 | `try > for > for > if > if` | 提取 `_extract_table_metadata()` |
+| `workbench/tasks/parsing.py` | L30-38 | `while > if > for > if` | 提取 `_find_break_point()` |
+| `core/management/commands/analyze_performance.py` | L61-96 | `try > with > for > if > if > if` | 提取 `_parse_log_line()` |
+| `core/services/bound_folder_scan_service.py` | L367-391 | `for > if > try > with > try` | 提取 `_process_single_cloud_file()` |
+| `core/infrastructure/health/_checkers.py` | L79-107, L182-229 | `try > if > for > if > try` ×2 | 提取 `_collect_db_error_diagnostics()` 和 `_check_single_path()` |
+| `core/cloud_storage/dropbox_provider.py` | L224-238 | `for > try > except > try > if` | 提取 `_ensure_directory_exists()` |
+| `core/cloud_storage/admin.py` | L398-434 | `if > try > if > if/elif` | early return + 提取 `_set_auth_context()` |
+| `contracts/services/archive/supervision_card_extractor.py` | L59-93 | `for > if > if > if > try > if > if` | 提取 `_try_extract_from_material()` |
+| `contracts/services/archive/learning_service.py` | L82-145 | `for > if > for > if/else > if` | 提取 `_learn_keywords_for_material()` |
+| `contracts/services/archive/checklist/case_material_sync.py` | L114-158, L216-237, L242-287 | `for > for > if/else` ×3处 | 提取 `_match_case_materials()` 和 `_sync_single_material()` |
+| `contracts/admin/contract_admin.py` | L636-641 | `for > for > for > for` | **4 层 for 循环**，用 `values_list` 替代 ORM 嵌套遍历 |
+| `contracts/services/archive/archive_query_service.py` | L36-52 | `for > for > if > if` + N+1 查询 | 批量预取替代逐个查询 |
+| `court_filing_http/party_mixin.py` | L129-162 | `for > for > if > if` | 提取 `_find_matching_item()` |
+| `court_filing_http/execution_validation_mixin.py` | L144-194 | `if > for > if > if > if` | 提取 `_validate_party_fields()` |
+| `court_automation/filing/playwright_filing/party_info_handler.py` | L63-95 | `for > for > if > if > if` | 提取 `_process_single_party()` |
+| `court_automation/filing/playwright_filing/filing_steps.py` | L357-391 | `for > for > try > if` | 提取 `_upload_single_file()` |
+| `plugins/message_hub/services/court/court_fetcher.py` | L362-398, L636-674 | `for > if > for > if` sync+async | 提取 `_prepare_unsaved_messages()` |
+| `plugins/message_hub/services/imap/imap_fetcher.py` | L156-224, L268-278 | `try > try > for > if` | 提取 `_process_imap_uid_list()` |
+| `finance/services/lpr/sync_service.py` | L104-135 | `for > try > if > if` | 提取 `_parse_single_row()` |
+| `client/services/identity_extraction/extraction_service.py` | L247-270 | `try > for > try > if` | 提取 `_ocr_single_page()` |

--- a/backend/NESTING_AUDIT.md
+++ b/backend/NESTING_AUDIT.md
@@ -1,0 +1,142 @@
+# Backend 嵌套控制流审计报告
+
+扫描范围：`backend/apps/` + `backend/plugins/`，排除测试文件、migrations、`__pycache__`
+
+---
+
+## 一、HIGH 严重（5+ 层嵌套 / 三层 for 循环）
+
+### 1. `apps/oa_filing/services/oa_scripts/jtn/case_import/detail_extractor.py`
+- **L137-197**：`try > for > try > for > if > if > if` — **13 层嵌套**
+- `_extract_case_info_tab` 等 3 个方法共享同一反模式：遍历 HTML 表格行 → 嵌套 try → 遍历 cell pairs → 长 if/elif 映射
+- **修复**：抽取 `_parse_row_fields(cells) -> dict`，用字段分发 dict 替代 if/elif 链
+
+### 2. `apps/oa_filing/services/oa_scripts/jtn/case_import/html_parser.py`
+- **L292-371**：`for > for > if > if > ...` — **10 层嵌套**（3 个方法）
+- `extract_customers_from_html` 等方法：外层遍历行 → 内层遍历 label/value pairs → 深层 if/elif 映射
+- **修复**：引入 `field_matchers: dict[str, Callable]` 映射表，循环匹配替代 if/elif
+
+### 3. `apps/core/cloud_storage/webdav_provider.py`
+- **L193-224**：`for > if > for > if > for > if > for` — **4 层 for 循环**，深度 12
+- 手动逐层解析 WebDAV PROPFIND XML 响应
+- **修复**：用 `element.find()` / XPath 或提取 `_parse_webdav_response_element()` 递归解析器
+
+### 4. `apps/automation/services/scraper/sites/guarantee/upload_mixin.py`
+- **L210-489**：多处 `for > for > if > for > for > if` — **6 层嵌套**，15+ 高严重度
+- 单体函数混杂 DOM 查询、文件匹配、上传逻辑
+- **修复**：拆分为 `_resolve_label_text()`、`_pick_files_for_label()`、`_upload_single_input()`
+
+### 5. `apps/automation/services/scraper/sites/guarantee/form_filling_mixin.py`
+- **L433-440**：`except > for > for > for > if` — **三层 for-in-for**
+- L60、L75、L283、L578 也各有 4 层嵌套
+- **修复**：提取 `_fill_all_code_fields(code)` helper
+
+### 6. `apps/oa_filing/services/oa_scripts/jtn/case_import/playwright_browser.py`
+- **L293-317**：`for > try > for > try > if` — 6 层
+- **L529-544**：`try > for > try > if > for > if` — 6 层
+
+### 7. `apps/cases/services/log/email_folder_scan_service.py`
+- **L277-286**：`try > for > for > if` — 4 层，同一文件 3 处高严重度
+
+### 8. `apps/cases/services/case_import_service.py`
+- **L259-269**：`for > for > if > if > with` — 5 层
+
+### 9. `apps/cases/services/material/folder_scan_service.py`
+- **L319-321**：`for > if > if > for > if` — 5 层
+
+### 10. `apps/cases/admin/mixins/views.py`
+- **L777-803**：`try > if > if > for > if` — 5 层
+
+### 11. `apps/oa_filing/api/client_import_api.py`
+- **L40-58**：`if > try > if > if > if > try` — 6 层
+
+---
+
+## 二、HIGH 严重（三层 for-in-for 循环）
+
+| 文件 | 行号 | 结构 | 说明 |
+|------|------|------|------|
+| `apps/client/admin/client_admin.py` | L441-446 | `for > for > for > if` | 三层 for 循环 |
+| `apps/cases/services/case/case_admin_export_bridge.py` | L44-52 | `for > for > for` | 三层 for 循环 |
+| `apps/cases/services/case/case_contract_export_bridge.py` | L55-58 | `for > for > for` | 与 admin_export 共享模式，可统一 |
+| `apps/oa_filing/services/case_import_service.py` | L189-202 | `for > try > if > for > for > if` | 三层 for + 条件 |
+| `apps/contracts/services/archive/learning_service.py` | L196 | `for > for > for` | categories > codes > keywords |
+| `apps/contracts/admin/contract_admin.py` | L634-641 | `for > for > for` | payments > invoices, parties > docs |
+| `plugins/weike_api_private/law_verification.py` | L64-71 | `for > for > for` | stop chars > patterns > regex |
+
+---
+
+## 三、MEDIUM 严重（4 层 if 嵌套 / 可优化的 for-in-for）
+
+| 文件 | 行号 | 结构 | 建议 |
+|------|------|------|------|
+| `apps/documents/services/evidence/__init__.py` | L18-42 | `if > if > if × 8` | 用 dispatch dict 替代 9 层 elif |
+| `apps/documents/services/placeholders/.../execution_request_interest.py` | L80-98 | `if > if × 8` | 用 early return + handler 函数替代 |
+| `apps/legal_research/services/task/executor.py` | L260-300 | `for > if > if > if > if` | 抽取 `_process_candidate()` |
+| `apps/legal_research/services/sources/weike/search.py` | L256-269 | `if > if > if > if` | 抽取 `_try_private_api_search()` |
+| `plugins/court_automation/filing/playwright_filing/filing_steps.py` | L357-376 | `for > for` with retry | 抽取 `_upload_single_file()` |
+| `apps/core/management/commands/scan_orphan_files.py` | L112-127 | `for > try > for > if` | 先收集 FileField，再批量查询 |
+| `apps/core/config/manager.py` | L152 | `if × 6` | 用 guard clause 扁平化 |
+| `apps/client/services/client_resolve_service.py` | L92 | `for > for` | 用 dict 查找替代内层循环 |
+| `apps/client/admin/property_clue_admin.py` | L114 | `for > for` | 用 dict/defaultdict |
+| `apps/cases/admin/case_forms_admin.py` | L47-51 | `try > if > if > if > if` | 用 guard clause 扁平化 |
+| `plugins/court_filing_http/execution_validation_mixin.py` | L42-43 | `for > for` | 用 dict comprehension |
+| `apps/contracts/services/contract/integrations/contract_oa_sync_service.py` | L651-653 | `for > for` | 用 `itertools.product()` |
+| `apps/automation/admin/sms/court_sms_admin_actions.py` | L77, L109 | `if > else > try > if` | 抽取 `_process_single_sms()` |
+| `apps/automation/management/commands/optimize_token_performance.py` | L85-109 | `except > try > if > for > if` | 5 层，用 guard clause 扁平化 |
+| `apps/automation/management/commands/smoke_check.py` | L190 | `while > if > if > if` | 4 层，提取条件判断 |
+
+---
+
+## 四、按文件热点排名（高严重度数量）
+
+| 文件 | HIGH 数 |
+|------|--------|
+| `automation/scraper/sites/guarantee/upload_mixin.py` | 15+ |
+| `automation/scraper/sites/guarantee/form_filling_mixin.py` | 6 |
+| `oa_filing/jtn/case_import/detail_extractor.py` | 3（13层） |
+| `oa_filing/jtn/case_import/html_parser.py` | 3（10层） |
+| `cases/services/log/email_folder_scan_service.py` | 3 |
+| `core/cloud_storage/webdav_provider.py` | 1（12层） |
+| `cases/services/case/case_admin_export_bridge.py` | 1（三层for） |
+| `cases/services/case/case_contract_export_bridge.py` | 1（三层for） |
+| `automation/admin/sms/court_sms_admin_actions.py` | 3 |
+| `oa_filing/jtn/case_import/playwright_browser.py` | 2 |
+
+---
+
+## 补充：O(n²) 线性搜索（可预索引优化）
+
+### HIGH — for > for > keyword 匹配，应建反向索引
+
+| 文件 | 行号 | 问题 | 修复 |
+|------|------|------|------|
+| `contracts/services/contract/integrations/archive_classifier.py` | L453, L542, L562 | 3 个函数均 `for code > for keyword > if keyword in filename` — O(codes×keywords) | 预建 `{keyword: code}` dict，O(1) 查找 |
+| `contracts/services/archive/checklist/material_mapping.py` | L142-145 | `for code > for keyword > if keyword in type_name` | 同上，建反向索引 |
+
+### HIGH — N+1 查询反模式
+
+| 文件 | 行号 | 问题 | 修复 |
+|------|------|------|------|
+| `contracts/services/archive/archive_query_service.py` | L38-52 | 内层循环逐个 `filter(pk=pk).first()` — N+1 查询 | 用 `filter(pk__in=all_pks)` 批量预取，字典查找 |
+
+### MEDIUM — ORM 嵌套遍历
+
+| 文件 | 行号 | 问题 | 修复 |
+|------|------|------|------|
+| `cases/services/case/case_admin_export_bridge.py` | L43-52 | `for party > for identity_doc`，每轮单独 DB 查询 | 加 `prefetch_related` 或批量预取 |
+| `cases/services/case/case_contract_export_bridge.py` | L54-59 | 同上 | 同上 |
+| `contracts/services/archive/checklist/case_material_sync.py` | L120-146 | `for case > for material`，内层调用 O(n*m) 的 `match_type_name_to_code` | 修复 material_mapping 的 O(n²) + 批量预取 |
+
+**P0（立即修复）**：
+1. `detail_extractor.py` / `html_parser.py` — 13 层/10 层，引入字段分发 dict + 单行解析 helper
+2. `upload_mixin.py`（guarantee）— 拆分为 3 个子函数
+
+**P1（近期修复）**：
+3. `webdav_provider.py` — 用 XML XPath 或递归解析器
+4. `case_admin_export_bridge.py` + `case_contract_export_bridge.py` — 统一三层 for 循环
+5. `evidence/__init__.py` — 9 层 elif 改 dict dispatch
+6. `email_folder_scan_service.py` — 提取 inner loop body
+
+**P2（逐步优化）**：
+7. 其余 MEDIUM 级别问题，通过 guard clause 和 helper 函数逐步扁平化

--- a/backend/NESTING_AUDIT.md
+++ b/backend/NESTING_AUDIT.md
@@ -140,3 +140,117 @@
 
 **P2（逐步优化）**：
 7. 其余 MEDIUM 级别问题，通过 guard clause 和 helper 函数逐步扁平化
+
+---
+
+# 第二轮深度扫描追加（opus agent 并行扫描）
+
+---
+
+## 六、HIGH 严重 — 新发现
+
+### `plugins/court_automation/token/history_recorder.py` L69-102
+- **结构**：`try > if > if/elif 链 > try > if > for > if > if` — **6 层**
+- `record_acquisition_history()` 中错误类型用字符串 `if/elif` 匹配，应改 dict dispatch
+
+### `plugins/court_automation/login/court_zxfw_service.py` L430-546
+- **结构**：`for > try > if/elif > for > if` — 4 层，**~130 行单体方法**
+- `_try_captcha_login()` 混杂验证码识别、JS 注入、按钮点击、token 轮询、截图保存
+- **修复**：拆分为 `_recognize_captcha()`、`_inject_captcha_js()`、`_poll_for_token()` 等子步骤
+
+### `plugins/court_automation/login/captcha_recognizer.py` L242-286 / L339-347
+- **结构**：`try > while > if > with > if > try` — **5 层**（sync + async 各一处）
+- while 轮询 + 文件读取 + 条件检查 + 资源清理交织
+- **修复**：将轮询逻辑提取为独立方法
+
+### `apps/workbench/services/chat_service.py` L468-534
+- **结构**：`async for > if > async for > if > if` — **6 层**
+- `_run_agent()` 单个 try 块内混合 agent 迭代、流处理、tool-call 分发、结果处理
+
+### `apps/workbench/api/workbench_api.py` L560-601
+- **结构**：`while True > for > if > if / elif > if` — **5 层**
+- SSE 事件生成器中的 for-in-for + 条件分支
+
+### `apps/litigation_ai/agent/factory.py` L153-184
+- **结构**：`for > async for > if > if` — **4 层**
+- `astream()` 方法中 LLM 迭代嵌套流式响应 + tool-call 处理
+- L43-85 和 L96-138 的 `invoke()`/`ainvoke()` 也存在相同三层嵌套且近乎重复
+
+### `apps/contracts/services/archive/generation/pdf_utils.py` L43-112
+- **结构**：`for > try > for > if/else` — **4 层**
+- `scale_pages_to_a4()` 中 `is_a4` 计算逻辑在两个 for 循环中重复
+
+### `apps/contracts/services/archive/generation/folder_builder.py` L276-349
+- **结构**：`for > if > if > for > with` — **5 层**
+- `_compile_final_archive_pdf()` 中 temp-file 清理逻辑嵌套在条件+循环内
+
+### `apps/automation/services/scraper/sites/guarantee/base_mixin.py` L238-261 / L517-541
+- **结构**：`for > for > for > try/if/except > try/except` — **4 层 for + 双重 try**
+- `_click_first_enabled_button()` sync/async 版本完全重复
+
+### `apps/automation/services/scraper/sites/guarantee/dialog_property_clue.py` L14-182
+- **结构**：`try > for > for(retry) > if/break` — **4 层**，3 个字段类型重复相同结构
+- 170 行方法内三段几乎相同的 try/except + for + retry 模式
+
+### `apps/organization/views.py` L34-75
+- **结构**：`if POST > if action > try/except > else: if` — **4 层**
+- `register()` 混杂请求方法分支、action 分发、表单验证、异常处理、角色检查
+
+---
+
+## 七、MEDIUM 严重 — 新发现
+
+| 文件 | 行号 | 结构 | 说明 |
+|------|------|------|------|
+| `workbench/services/chat_service.py` | L340-385 | `async for > if/elif > if` | 事件分发循环，与 L468 逻辑重复 |
+| `workbench/services/doc_extractor.py` | L96-104 | `for > for > if > if` | 表格/元数据提取，for-in-for |
+| `workbench/api/workbench_api.py` | L418-462 | `with > for > if > if` | ZIP 导出构建，与 summary.py 逻辑重复 |
+| `court_automation/preservation_quote/execution_mixin.py` | L75-128 | `try > if > try > if` | token 获取，字符串匹配错误类型 |
+| `court_automation/preservation_quote/admin_service.py` | L348-369 | `try > for > try > if` | 批量操作，per-item try/except |
+| `court_automation/login/court_zxfw_service.py` | L636-689 | `try > for > if` (×2) | 两段近乎重复的选择器可见性检查 |
+| `litigation_ai/services/mock_trial/mock_trial_flow_service.py` | L758-778 | `for > if > if/elif(6分支)` | 文本配置解析，应用 dict dispatch |
+| `finance/services/calculator/interest_calculator.py` | L296-309 | `for > for > if` | 本金期间 × 利率段的 O(n×m) 嵌套 |
+| `contracts/services/archive/generation/pdf_utils.py` | L291-346 | `for > try > finally > try` | 清理逻辑 5 层嵌套 |
+| `contracts/services/archive/supervision_card_extractor.py` | L59-93 | `for > try > if > if` | 监管卡检测提取 |
+| `contracts/services/archive/generation/download_handler.py` | L192-248 | `for > try > finally > try` | 同 pdf_utils 的 try-for-try-cleanup 模式 |
+| `automation/scraper/sites/guarantee/dialog_playwright_fill.py` | L36-76 | `for > try/if > for > for` | 三段重复的 iterate-try-filter |
+| `automation/scraper/sites/guarantee/guarantee_service.py` | L133-167 | `for > if > if any` | 错误检测用 fragile 字符串匹配 |
+| `automation/scraper/core/monitor_service.py` | L142-169 | `for > if > if > if/else` | queryset vs list 双路径分支 |
+| `automation/scraper/scrapers/court_document/hbfy_scraper.py` | L182-202 | `for > if×4` | 12 次重试循环内 4 个顺序 guard |
+| `mcp_server/tools/web_search/web_search.py` | L52-67 | `for > for > if > if` | CSS 选择器遍历 |
+| `organization/admin/accountcredential_admin.py` | L105-122 | `if/elif/else > if/else` | 时间格式化，应提取 helper |
+| `organization/views.py` | L34-75 | `if > if > try > if` | register 视图函数 |
+
+---
+
+## 八、跨文件重复模式（建议统一重构）
+
+| 模式 | 出现位置 | 建议 |
+|------|----------|------|
+| `try > for > finally > try` temp-file 清理 | `pdf_utils.py`、`download_handler.py` | 抽取为 context manager |
+| `for > for > keyword 匹配` | `archive_classifier.py`、`material_mapping.py` | 统一预建 `{keyword: code}` 反向索引 |
+| sync/async 双版本完全重复嵌套 | `captcha_recognizer.py`、`base_mixin.py`、`guarantee_service.py` | 用 async 统一，或提取共享核心逻辑 |
+| `for > if/elif 长链` 字段映射 | `detail_extractor.py`、`html_parser.py`、`mock_trial_flow_service.py` | 统一用 dict dispatch |
+| ZIP 导出逻辑重复 | `workbench_api.py` L418 与 `summary.py` L131 | 去重，提取公共函数 |
+
+---
+
+## 九、最终热点文件排名（HIGH 数量，含两轮扫描）
+
+| 文件 | HIGH 数 |
+|------|--------|
+| `automation/scraper/sites/guarantee/upload_mixin.py` | 15+ |
+| `automation/scraper/sites/guarantee/form_filling_mixin.py` | 6 |
+| `oa_filing/jtn/case_import/detail_extractor.py` | 3（13层） |
+| `oa_filing/jtn/case_import/html_parser.py` | 3（10层） |
+| `cases/services/log/email_folder_scan_service.py` | 3 |
+| `core/cloud_storage/webdav_provider.py` | 1（12层） |
+| `automation/admin/sms/court_sms_admin_actions.py` | 3 |
+| `oa_filing/jtn/case_import/playwright_browser.py` | 2 |
+| `automation/scraper/sites/guarantee/base_mixin.py` | 2（sync+async） |
+| `automation/scraper/sites/guarantee/dialog_property_clue.py` | 1（170行） |
+| `plugins/court_automation/login/court_zxfw_service.py` | 2 |
+| `workbench/services/chat_service.py` | 2 |
+| `litigation_ai/agent/factory.py` | 1（3方法重复） |
+| `contracts/services/archive/generation/pdf_utils.py` | 1 |
+| `contracts/services/archive/generation/folder_builder.py` | 1 |

--- a/backend/apps/client/services/identity_extraction/extraction_service.py
+++ b/backend/apps/client/services/identity_extraction/extraction_service.py
@@ -270,7 +270,7 @@ class IdentityExtractionService:
             logger.exception("PDF 处理失败: %s", e)
             raise OCRExtractionError(_("PDF 处理失败: %(e)s") % {"e": e}) from e
 
-    def _ocr_single_page(self, page: Any) -> str:  # type: ignore[no-untyped-def]
+    def _ocr_single_page(self, page: Any) -> str:
         """渲染单页为图片并 OCR，返回文本或空字符串。"""
         import fitz as _fitz
 

--- a/backend/apps/client/services/identity_extraction/extraction_service.py
+++ b/backend/apps/client/services/identity_extraction/extraction_service.py
@@ -251,23 +251,9 @@ class IdentityExtractionService:
             max_pages = min(len(doc), 3)
 
             for page_num in range(max_pages):
-                page = doc[page_num]
-
-                # 渲染为图片(300 DPI)
-                mat = fitz.Matrix(300 / 72, 300 / 72)
-                pix = page.get_pixmap(matrix=mat)
-
-                # 保存临时文件
-                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
-                    pix.save(tmp.name)
-                    tmp_path = tmp.name
-
-                try:
-                    page_text = self._ocr_service.recognize(tmp_path)
-                    if page_text:
-                        all_texts.append(page_text)
-                finally:
-                    Path(tmp_path).unlink(missing_ok=True)
+                page_text = self._ocr_single_page(doc[page_num])
+                if page_text:
+                    all_texts.append(page_text)
 
             doc.close()
 
@@ -283,6 +269,20 @@ class IdentityExtractionService:
         except (OSError, ValueError) as e:
             logger.exception("PDF 处理失败: %s", e)
             raise OCRExtractionError(_("PDF 处理失败: %(e)s") % {"e": e}) from e
+
+    def _ocr_single_page(self, page: Any) -> str:  # type: ignore[no-untyped-def]
+        """渲染单页为图片并 OCR，返回文本或空字符串。"""
+        import fitz as _fitz
+
+        mat = _fitz.Matrix(300 / 72, 300 / 72)
+        pix = page.get_pixmap(matrix=mat)
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            pix.save(tmp.name)
+            tmp_path = tmp.name
+        try:
+            return self._ocr_service.recognize(tmp_path) or ""
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
 
     def _looks_like_json_noise(self, line: str) -> bool:
         """判断是否为结构化 JSON/调试噪声行。"""

--- a/backend/apps/contracts/admin/contract_admin.py
+++ b/backend/apps/contracts/admin/contract_admin.py
@@ -46,6 +46,20 @@ from apps.core.models.enums import CaseStage
 # --- Prefetch 优化：共享 Client queryset，避免重复查询 ---
 _client_with_nested = Client.objects.prefetch_related("identity_docs", "property_clues__attachments")
 
+
+def _client_file_path(client: Client) -> list[str]:
+    """从 Client 的证件和财产线索附件中提取所有文件路径。"""
+    paths: list[str] = []
+    for doc in client.identity_docs.all():
+        if doc.file_path:
+            paths.append(doc.file_path)
+    for clue in client.property_clues.all():
+        for att in clue.attachments.all():
+            if att.file_path:
+                paths.append(att.file_path)
+    return paths
+
+
 if TYPE_CHECKING:
     BaseModelAdmin = admin.ModelAdmin
     from django.db.models import QuerySet
@@ -227,7 +241,9 @@ class ContractAdmin(
             Contract.objects.filter(id=contract_id).update(is_filed=True, filing_number=filing_number)
         self.message_user(request, "已建档 %(count)d 个合同" % {"count": len(to_save)})
 
-    def changelist_view(self, request: HttpRequest, extra_context: dict[str, Any] | None = None) -> Any:  # pragma: no cover
+    def changelist_view(
+        self, request: HttpRequest, extra_context: dict[str, Any] | None = None
+    ) -> Any:  # pragma: no cover
         from django.http import HttpResponseRedirect
 
         if "status__exact" not in request.GET and not request.session.get("contract_changelist_visited"):
@@ -634,9 +650,6 @@ class ContractAdmin(
                 for inv in p.invoices.all():
                     _add(inv.file_path)
             for p in obj.contract_parties.all():
-                for d in p.client.identity_docs.all():
-                    _add(d.file_path)
-                for c in p.client.property_clues.all():
-                    for a in c.attachments.all():
-                        _add(a.file_path)
+                for path in _client_file_path(p.client):
+                    _add(path)
         return paths

--- a/backend/apps/contracts/services/archive/archive_query_service.py
+++ b/backend/apps/contracts/services/archive/archive_query_service.py
@@ -35,21 +35,23 @@ def delete_material(material: FinalizedMaterial) -> None:  # pragma: no cover
 
 def reorder_materials(contract_id: int, orders: dict[str, list[int]]) -> None:
     """按归档清单项分组排序子项。"""
+    all_ids = [pk for ids in orders.values() for pk in ids]
+    if not all_ids:
+        return
+    mats = {m.pk: m for m in FinalizedMaterial.objects.filter(pk__in=all_ids, contract_id=contract_id)}
     for code, material_ids in orders.items():
         for i, pk in enumerate(material_ids):
-            mat = FinalizedMaterial.objects.filter(
-                pk=pk,
-                contract_id=contract_id,
-            ).first()
-            if mat:
-                mat.order = i + 1
-                # 动态映射的材料（如合同正本）数据库中 archive_item_code 为空，
-                # 需要同步写入，否则 get_checklist_with_status 加载顺序会错乱。
-                if not mat.archive_item_code:
-                    mat.archive_item_code = code
-                    mat.save(update_fields=["order", "archive_item_code"])
-                else:
-                    mat.save(update_fields=["order"])
+            mat = mats.get(pk)
+            if not mat:
+                continue
+            mat.order = i + 1
+            # 动态映射的材料（如合同正本）数据库中 archive_item_code 为空，
+            # 需要同步写入，否则 get_checklist_with_status 加载顺序会错乱。
+            update_fields = ["order"]
+            if not mat.archive_item_code:
+                mat.archive_item_code = code
+                update_fields.append("archive_item_code")
+            mat.save(update_fields=update_fields)
 
 
 def move_material(material: FinalizedMaterial, target_code: str) -> None:

--- a/backend/apps/contracts/services/archive/checklist/material_mapping.py
+++ b/backend/apps/contracts/services/archive/checklist/material_mapping.py
@@ -139,10 +139,16 @@ def match_type_name_to_code(
     """根据 CaseMaterial.type_name 匹配 archive_item_code。"""
     if not type_name:
         return None
-    for code, keywords in keyword_map.items():
+    hit = _search_keyword_map(keyword_map, type_name)
+    return hit[0] if hit else None
+
+
+def _search_keyword_map(mapping: dict[str, list[str]], text: str) -> tuple[str, str] | None:
+    """扁平 keyword mapping 搜索，返回 (code, keyword) 或 None。"""
+    for code, keywords in mapping.items():
         for keyword in keywords:
-            if keyword in type_name:
-                return code
+            if keyword in text:
+                return code, keyword
     return None
 
 

--- a/backend/apps/contracts/services/archive/generation/folder_builder.py
+++ b/backend/apps/contracts/services/archive/generation/folder_builder.py
@@ -25,6 +25,13 @@ _ARCHIVE_CATALOG_CODES: dict[str, str] = {
 }
 
 
+def _cleanup_temp_files(temp_files: list[Path]) -> None:
+    """清理临时 PDF 文件。"""
+    for tmp in temp_files:
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+
+
 def generate_archive_folder(contract: Contract) -> dict[str, Any]:  # pragma: no cover
     """生成归档文件夹到合同绑定的文件夹根目录。
 
@@ -280,9 +287,7 @@ def _compile_final_archive_pdf(
             pdf_path = archive_dir / f"{seq_num}-{doc_name}（{contract_name}）_{today_str}.pdf"
             if not case_materials_pdf_exists or not pdf_path.exists():
                 logger.info("4-案卷材料PDF不存在，跳过Final合并")
-                for tmp in temp_pdf_files:
-                    with contextlib.suppress(OSError):
-                        tmp.unlink(missing_ok=True)
+                _cleanup_temp_files(temp_pdf_files)
                 return {
                     "written": False,
                     "skipped": True,
@@ -307,9 +312,7 @@ def _compile_final_archive_pdf(
             logger.warning("docx转PDF失败: %s", docx_path.name)
 
     if not pdf_files_to_merge:
-        for tmp in temp_pdf_files:
-            with contextlib.suppress(OSError):
-                tmp.unlink(missing_ok=True)
+        _cleanup_temp_files(temp_pdf_files)
         return {"written": False, "skipped": True, "page_count": 0, "error": None, "reason": "无可合并的PDF文件"}
 
     merged_doc = fitz.open()

--- a/backend/apps/contracts/services/archive/generation/pdf_utils.py
+++ b/backend/apps/contracts/services/archive/generation/pdf_utils.py
@@ -23,9 +23,10 @@ TOLERANCE = 1.0
 def _is_a4(page: Any) -> bool:
     """判断 PDF 页面是否为 A4 尺寸（含横竖旋转）。"""
     w, h = page.rect.width, page.rect.height
-    return (abs(w - A4_W) < TOLERANCE and abs(h - A4_H) < TOLERANCE) or (
-        abs(w - A4_H) < TOLERANCE and abs(h - A4_W) < TOLERANCE
-    )  # type: ignore[no-any-return]
+    return (  # type: ignore[no-any-return]
+        (abs(w - A4_W) < TOLERANCE and abs(h - A4_H) < TOLERANCE)
+        or (abs(w - A4_H) < TOLERANCE and abs(h - A4_W) < TOLERANCE)
+    )
 
 
 def scale_pages_to_a4(contract: Contract) -> dict[str, Any]:  # pragma: no cover

--- a/backend/apps/contracts/services/archive/generation/pdf_utils.py
+++ b/backend/apps/contracts/services/archive/generation/pdf_utils.py
@@ -20,6 +20,14 @@ A4_W, A4_H = 595.0, 842.0
 TOLERANCE = 1.0
 
 
+def _is_a4(page: Any) -> bool:  # type: ignore[no-untyped-def]
+    """判断 PDF 页面是否为 A4 尺寸（含横竖旋转）。"""
+    w, h = page.rect.width, page.rect.height
+    return (abs(w - A4_W) < TOLERANCE and abs(h - A4_H) < TOLERANCE) or (
+        abs(w - A4_H) < TOLERANCE and abs(h - A4_W) < TOLERANCE
+    )
+
+
 def scale_pages_to_a4(contract: Contract) -> dict[str, Any]:  # pragma: no cover
     """将合同所有已上传的归档 PDF 材料按 A4 尺寸缩放。"""
     import fitz
@@ -56,17 +64,8 @@ def scale_pages_to_a4(contract: Contract) -> dict[str, Any]:  # pragma: no cover
             continue
 
         try:
-            has_non_a4 = False
-            for page in src_doc:
-                page_w, page_h = page.rect.width, page.rect.height
-                is_a4 = (abs(page_w - A4_W) < TOLERANCE and abs(page_h - A4_H) < TOLERANCE) or (
-                    abs(page_w - A4_H) < TOLERANCE and abs(page_h - A4_W) < TOLERANCE
-                )
-                if not is_a4:
-                    has_non_a4 = True
-                    break
-
-            if not has_non_a4:
+            # 检查是否有非 A4 页面，无需缩放则跳过
+            if all(_is_a4(page) for page in src_doc):
                 skipped_count += 1
                 continue
 
@@ -74,11 +73,8 @@ def scale_pages_to_a4(contract: Contract) -> dict[str, Any]:  # pragma: no cover
 
             for page in src_doc:
                 page_w, page_h = page.rect.width, page.rect.height
-                is_a4 = (abs(page_w - A4_W) < TOLERANCE and abs(page_h - A4_H) < TOLERANCE) or (
-                    abs(page_w - A4_H) < TOLERANCE and abs(page_h - A4_W) < TOLERANCE
-                )
 
-                if is_a4:
+                if _is_a4(page):
                     out_doc.insert_pdf(src_doc, from_page=page.number, to_page=page.number)
                 else:
                     if page_w > page_h:

--- a/backend/apps/contracts/services/archive/generation/pdf_utils.py
+++ b/backend/apps/contracts/services/archive/generation/pdf_utils.py
@@ -20,12 +20,12 @@ A4_W, A4_H = 595.0, 842.0
 TOLERANCE = 1.0
 
 
-def _is_a4(page: Any) -> bool:  # type: ignore[no-untyped-def]
+def _is_a4(page: Any) -> bool:
     """判断 PDF 页面是否为 A4 尺寸（含横竖旋转）。"""
     w, h = page.rect.width, page.rect.height
     return (abs(w - A4_W) < TOLERANCE and abs(h - A4_H) < TOLERANCE) or (
         abs(w - A4_H) < TOLERANCE and abs(h - A4_W) < TOLERANCE
-    )
+    )  # type: ignore[no-any-return]
 
 
 def scale_pages_to_a4(contract: Contract) -> dict[str, Any]:  # pragma: no cover

--- a/backend/apps/contracts/services/contract/integrations/archive_classifier.py
+++ b/backend/apps/contracts/services/contract/integrations/archive_classifier.py
@@ -443,24 +443,38 @@ def collect_archive_item_options(archive_category: str) -> list[dict[str, str]]:
 # ============================================================
 
 
+def _search_keyword_mapping(
+    mapping: dict[str, dict[str, list[str]]],
+    archive_category: str,
+    text: str,
+) -> tuple[str, str] | None:
+    """在 keyword mapping 中搜索，返回首次命中的 (code, keyword) 或 None。
+
+    将 for > for > if 三层嵌套收拢到一处。
+    """
+    for code, keywords in mapping.get(archive_category, {}).items():
+        for keyword in keywords:
+            if _normalize_for_match(keyword) in text:
+                return code, keyword
+    return None
+
+
 def _match_by_learned_rules(
     normalized_filename: str,
     archive_category: str,
 ) -> dict[str, Any] | None:
     """学习规则匹配（先查代码文件规则，再查DB规则）。"""
     # 1. 代码文件中的学习规则（模块级缓存，无DB查询）
-    code_mapping = _LEARNED_CODE_RULES.get(archive_category, {})
-    for code, keywords in code_mapping.items():
-        for keyword in keywords:
-            if _normalize_for_match(keyword) in normalized_filename:
-                name = _get_item_name(archive_category, code)
-                return {
-                    "archive_item_code": code,
-                    "archive_item_name": name,
-                    "category": "case_material",
-                    "confidence": 0.95,
-                    "reason": f"学习规则命中：{keyword}",
-                }
+    hit = _search_keyword_mapping(_LEARNED_CODE_RULES, archive_category, normalized_filename)
+    if hit:
+        code, keyword = hit
+        return {
+            "archive_item_code": code,
+            "archive_item_name": _get_item_name(archive_category, code),
+            "category": "case_material",
+            "confidence": 0.95,
+            "reason": f"学习规则命中：{keyword}",
+        }
 
     # 2. DB 中的学习规则
     db_result = _match_by_db_learned_rules(normalized_filename, archive_category)
@@ -538,18 +552,16 @@ def _match_by_folder_keywords(
     archive_category: str,
 ) -> dict[str, Any] | None:
     """文件夹路径关键词匹配。"""
-    mapping = _FOLDER_KEYWORD_TO_ARCHIVE_CODE.get(archive_category, {})
-    for code, keywords in mapping.items():
-        for keyword in keywords:
-            if _normalize_for_match(keyword) in normalized_path:
-                name = _get_item_name(archive_category, code)
-                return {
-                    "archive_item_code": code,
-                    "archive_item_name": name,
-                    "category": "case_material",
-                    "confidence": 0.92,
-                    "reason": f"文件夹路径关键词命中：{keyword}",
-                }
+    hit = _search_keyword_mapping(_FOLDER_KEYWORD_TO_ARCHIVE_CODE, archive_category, normalized_path)
+    if hit:
+        code, keyword = hit
+        return {
+            "archive_item_code": code,
+            "archive_item_name": _get_item_name(archive_category, code),
+            "category": "case_material",
+            "confidence": 0.92,
+            "reason": f"文件夹路径关键词命中：{keyword}",
+        }
     return None
 
 
@@ -558,18 +570,16 @@ def _match_by_filename_keywords(
     archive_category: str,
 ) -> dict[str, Any] | None:
     """文件名关键词匹配。"""
-    mapping = _FILENAME_KEYWORD_TO_ARCHIVE_CODE.get(archive_category, {})
-    for code, keywords in mapping.items():
-        for keyword in keywords:
-            if _normalize_for_match(keyword) in normalized_filename:
-                name = _get_item_name(archive_category, code)
-                return {
-                    "archive_item_code": code,
-                    "archive_item_name": name,
-                    "category": "case_material",
-                    "confidence": 0.90,
-                    "reason": f"文件名关键词命中：{keyword}",
-                }
+    hit = _search_keyword_mapping(_FILENAME_KEYWORD_TO_ARCHIVE_CODE, archive_category, normalized_filename)
+    if hit:
+        code, keyword = hit
+        return {
+            "archive_item_code": code,
+            "archive_item_name": _get_item_name(archive_category, code),
+            "category": "case_material",
+            "confidence": 0.90,
+            "reason": f"文件名关键词命中：{keyword}",
+        }
     return None
 
 

--- a/backend/apps/contracts/services/contract/query/contract_details_assembler.py
+++ b/backend/apps/contracts/services/contract/query/contract_details_assembler.py
@@ -5,6 +5,29 @@ from __future__ import annotations
 from typing import Any
 
 
+def _serialize_parties(case: Any) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": party.id,
+            "client_id": party.client.id,
+            "client_name": party.client.name,
+            "legal_status": party.legal_status,
+        }
+        for party in case.parties.all()
+    ]
+
+
+def _serialize_authorities(case: Any) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": authority.id,
+            "name": authority.name,
+            "authority_type": authority.authority_type,
+        }
+        for authority in case.supervising_authorities.all()
+    ]
+
+
 class ContractDetailsAssembler:
     def to_dict(self, contract: Any) -> dict[str, Any]:
         contract_parties = []
@@ -42,36 +65,14 @@ class ContractDetailsAssembler:
 
         cases = []
         for case in contract.cases.all():
-            case_parties = []
-            for party in case.parties.all():
-                client = party.client
-                case_parties.append(
-                    {
-                        "id": party.id,
-                        "client_id": client.id,
-                        "client_name": client.name,
-                        "legal_status": party.legal_status,
-                    }
-                )
-
-            supervising_authorities = []
-            for authority in case.supervising_authorities.all():
-                supervising_authorities.append(
-                    {
-                        "id": authority.id,
-                        "name": authority.name,
-                        "authority_type": authority.authority_type,
-                    }
-                )
-
             cases.append(
                 {
                     "id": case.id,
                     "name": case.name,
                     "cause_of_action": case.cause_of_action,
                     "target_amount": float(case.target_amount) if case.target_amount else None,
-                    "parties": case_parties,
-                    "supervising_authorities": supervising_authorities,
+                    "parties": _serialize_parties(case),
+                    "supervising_authorities": _serialize_authorities(case),
                 }
             )
 

--- a/backend/apps/core/cloud_storage/webdav_provider.py
+++ b/backend/apps/core/cloud_storage/webdav_provider.py
@@ -20,6 +20,43 @@ logger = logging.getLogger(__name__)
 _DEFAULT_RATE_LIMIT_INTERVAL = 3.5  # seconds between requests (conservative)
 
 
+def _local_tag(element: Any) -> str:  # type: ignore[no-untyped-def]
+    """获取 XML 元素的本地标签名（去掉命名空间前缀）。"""
+    tag = element.tag
+    return tag.split("}")[-1] if "}" in tag else tag
+
+
+def _parse_webdav_properties(propstat: Any) -> tuple[bool, int, float]:  # type: ignore[no-untyped-def]
+    """从 <propstat> 元素提取 (is_dir, size, modified)。
+
+    原始代码在 _parse_propfind_response 中有 4 层 for + 4 层 if（最深 8 层）。
+    此函数将 propstat 内部解析收拢到一处，调用方只需 2 层嵌套。
+    """
+    is_dir = False
+    size = 0
+    modified = 0.0
+    for prop_node in propstat:
+        if _local_tag(prop_node) != "prop":
+            continue
+        for p in prop_node:
+            p_tag = _local_tag(p)
+            if p_tag == "resourcetype":
+                is_dir = any(_local_tag(c) == "collection" for c in p.iter())
+            elif p_tag == "getcontentlength":
+                try:
+                    size = int(p.text or "0")
+                except ValueError:
+                    size = 0
+            elif p_tag == "getlastmodified":
+                try:
+                    from email.utils import parsedate_to_datetime
+
+                    modified = parsedate_to_datetime(p.text or "").timestamp()
+                except (ValueError, TypeError):
+                    modified = 0.0
+    return is_dir, size, modified
+
+
 @dataclass
 class _RateLimiter:  # pragma: no cover
     min_interval: float = _DEFAULT_RATE_LIMIT_INTERVAL
@@ -185,43 +222,18 @@ class WebDAVProvider:  # pragma: no cover
 
         base_href = self._full_path(base_path).rstrip("/")
         for response in root.iter():
-            if response.tag.endswith("}response") or response.tag == "response":
-                href = None
-                is_dir = False
-                size = 0
-                modified = 0.0
-                for child in response:
-                    tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
-                    if tag == "href":
-                        href = urllib.parse.unquote(child.text or "")
-                    elif tag == "propstat":
-                        for prop in child:
-                            prop_tag = prop.tag.split("}")[-1] if "}" in prop.tag else prop.tag
-                            if prop_tag == "prop":
-                                for p in prop:
-                                    p_tag = p.tag.split("}")[-1] if "}" in p.tag else p.tag
-                                    if p_tag == "resourcetype":
-                                        # Check for <d:collection/>
-                                        for collection in p.iter():
-                                            c_tag = (
-                                                collection.tag.split("}")[-1]
-                                                if "}" in collection.tag
-                                                else collection.tag
-                                            )
-                                            if c_tag == "collection":
-                                                is_dir = True
-                                    elif p_tag == "getcontentlength":
-                                        try:
-                                            size = int(p.text or "0")
-                                        except ValueError:
-                                            size = 0
-                                    elif p_tag == "getlastmodified":
-                                        try:
-                                            from email.utils import parsedate_to_datetime
-
-                                            modified = parsedate_to_datetime(p.text or "").timestamp()
-                                        except (ValueError, TypeError):
-                                            modified = 0.0
+            if not (response.tag.endswith("}response") or response.tag == "response"):
+                continue
+            href = None
+            is_dir = False
+            size = 0
+            modified = 0.0
+            for child in response:
+                tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                if tag == "href":
+                    href = urllib.parse.unquote(child.text or "")
+                elif tag == "propstat":
+                    is_dir, size, modified = _parse_webdav_properties(child)
 
                 if href:
                     # Strip WebDAV root prefix to get path relative to our root_path

--- a/backend/apps/core/infrastructure/health/_checkers.py
+++ b/backend/apps/core/infrastructure/health/_checkers.py
@@ -24,7 +24,7 @@ __all__ = ["check_database", "check_cache", "check_disk_space", "check_dependenc
 def _collect_db_error_diagnostics(
     exc: Exception,
     connection: Any,
-    diagnostic_info: dict[str, Any],  # type: ignore[no-untyped-def]
+    diagnostic_info: dict[str, Any],
 ) -> dict[str, Any]:
     """收集数据库错误诊断信息。"""
     try:

--- a/backend/apps/core/infrastructure/health/_checkers.py
+++ b/backend/apps/core/infrastructure/health/_checkers.py
@@ -21,6 +21,40 @@ logger = logging.getLogger(__name__)
 __all__ = ["check_database", "check_cache", "check_disk_space", "check_dependencies"]
 
 
+def _collect_db_error_diagnostics(
+    exc: Exception,
+    connection: Any,
+    diagnostic_info: dict[str, Any],  # type: ignore[no-untyped-def]
+) -> dict[str, Any]:
+    """收集数据库错误诊断信息。"""
+    try:
+        default_db = getattr(settings, "DATABASES", {}).get("default", {})
+        db_name = default_db.get("NAME", "")
+        diagnostic_info.update(
+            {
+                "database_name": db_name,
+                "error_type": type(exc).__name__,
+                "error_details": str(exc),
+                "connection_vendor": connection.vendor,
+            }
+        )
+        if connection.vendor == "sqlite":
+            db_file = Path(str(db_name)) if db_name else None
+            diagnostic_info["database_path"] = db_name
+            diagnostic_info["path_exists"] = db_file.exists() if db_file else False
+            if db_file and db_file.parent.exists():
+                db_dir = db_file.parent
+                diagnostic_info["directory_exists"] = True
+                diagnostic_info["directory_writable"] = os.access(str(db_dir), os.W_OK)
+        else:
+            diagnostic_info["database_host"] = default_db.get("HOST", "")
+            diagnostic_info["database_port"] = str(default_db.get("PORT", ""))
+    except Exception as diag_e:
+        logger.exception("操作失败")
+        diagnostic_info["diagnostic_collection_error"] = str(diag_e)
+    return diagnostic_info
+
+
 def check_database() -> ComponentHealth:
     """检查数据库连接"""
     start = time.time()
@@ -77,44 +111,7 @@ def check_database() -> ComponentHealth:
             diagnostic_info=diagnostic_info,
         )
     except Exception as e:
-        try:
-            default_db = getattr(settings, "DATABASES", {}).get("default", {})
-            db_name = default_db.get("NAME", "")
-            diagnostic_info.update(
-                {
-                    "database_name": db_name,
-                    "error_type": type(e).__name__,
-                    "error_details": str(e),
-                    "connection_vendor": connection.vendor,
-                }
-            )
-
-            if connection.vendor == "sqlite":
-                db_file = Path(str(db_name)) if db_name else None
-                diagnostic_info.update(
-                    {
-                        "database_path": db_name,
-                        "path_exists": db_file.exists() if db_file else False,
-                    }
-                )
-                if db_file:
-                    db_dir = db_file.parent
-                    diagnostic_info.update(
-                        {
-                            "directory_exists": db_dir.exists(),
-                            "directory_writable": os.access(str(db_dir), os.W_OK) if db_dir.exists() else False,
-                        }
-                    )
-            else:
-                diagnostic_info.update(
-                    {
-                        "database_host": default_db.get("HOST", ""),
-                        "database_port": str(default_db.get("PORT", "")),
-                    }
-                )
-        except Exception as diag_e:
-            logger.exception("操作失败")
-            diagnostic_info["diagnostic_collection_error"] = str(diag_e)
+        diagnostic_info = _collect_db_error_diagnostics(e, connection, diagnostic_info)
 
         return ComponentHealth(
             name="database",

--- a/backend/apps/documents/services/evidence/__init__.py
+++ b/backend/apps/documents/services/evidence/__init__.py
@@ -1,44 +1,27 @@
+import importlib
 from typing import Any
+
+# (module_name, attr_name)
+_IMPORT_MAP: dict[str, tuple[str, str]] = {
+    "EvidenceFileService": ("evidence_file_service", "EvidenceFileService"),
+    "EvidenceMutationService": ("evidence_mutation_service", "EvidenceMutationService"),
+    "EvidenceBasicQueryService": ("evidence_query_service", "EvidenceQueryService"),
+    "EvidenceService": ("evidence_service", "EvidenceService"),
+    "EvidenceAdminService": ("evidence_admin_service", "EvidenceAdminService"),
+    "EvidenceExportService": ("evidence_export_service", "EvidenceExportService"),
+    "EvidenceListPlaceholderService": ("evidence_list_placeholder_service", "EvidenceListPlaceholderService"),
+    "EvidencePageRangeCalculator": ("page_range_calculator", "EvidencePageRangeCalculator"),
+    "evidence_file_storage": ("evidence_storage", "evidence_file_storage"),
+}
 
 
 def __getattr__(name: str) -> Any:
     """延迟导入避免循环依赖"""
-    if name == "EvidenceFileService":
-        from .evidence_file_service import EvidenceFileService
-
-        return EvidenceFileService
-    elif name == "EvidenceMutationService":
-        from .evidence_mutation_service import EvidenceMutationService
-
-        return EvidenceMutationService
-    elif name == "EvidenceBasicQueryService":
-        from .evidence_query_service import EvidenceQueryService
-
-        return EvidenceQueryService
-    elif name == "EvidenceService":
-        from .evidence_service import EvidenceService
-
-        return EvidenceService
-    elif name == "EvidenceAdminService":
-        from .evidence_admin_service import EvidenceAdminService
-
-        return EvidenceAdminService
-    elif name == "EvidenceExportService":
-        from .evidence_export_service import EvidenceExportService
-
-        return EvidenceExportService
-    elif name == "EvidenceListPlaceholderService":
-        from .evidence_list_placeholder_service import EvidenceListPlaceholderService
-
-        return EvidenceListPlaceholderService
-    elif name == "EvidencePageRangeCalculator":
-        from .page_range_calculator import EvidencePageRangeCalculator
-
-        return EvidencePageRangeCalculator
-    elif name == "evidence_file_storage":
-        from .evidence_storage import evidence_file_storage
-
-        return evidence_file_storage
+    entry = _IMPORT_MAP.get(name)
+    if entry is not None:
+        module_path, attr_name = entry
+        module = importlib.import_module(f".{module_path}", __name__)
+        return getattr(module, attr_name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/backend/apps/documents/services/placeholders/litigation/enforcement_applicant_property_clue_service.py
+++ b/backend/apps/documents/services/placeholders/litigation/enforcement_applicant_property_clue_service.py
@@ -11,7 +11,7 @@ from apps.litigation_ai.placeholders.spec import LitigationPlaceholderKeys
 logger = logging.getLogger(__name__)
 
 
-def _collect_clue_lines(client_service: Any, client_id: int) -> list[str]:  # type: ignore[no-untyped-def]
+def _collect_clue_lines(client_service: Any, client_id: int) -> list[str]:
     """从客户的财产线索中提取所有非空行。"""
     lines: list[str] = []
     for clue in client_service.get_property_clues_by_client_internal(client_id):

--- a/backend/apps/documents/services/placeholders/litigation/enforcement_applicant_property_clue_service.py
+++ b/backend/apps/documents/services/placeholders/litigation/enforcement_applicant_property_clue_service.py
@@ -11,6 +11,17 @@ from apps.litigation_ai.placeholders.spec import LitigationPlaceholderKeys
 logger = logging.getLogger(__name__)
 
 
+def _collect_clue_lines(client_service: Any, client_id: int) -> list[str]:  # type: ignore[no-untyped-def]
+    """从客户的财产线索中提取所有非空行。"""
+    lines: list[str] = []
+    for clue in client_service.get_property_clues_by_client_internal(client_id):
+        for line in (clue.content or "").split("\n"):
+            stripped = line.strip()
+            if stripped:
+                lines.append(stripped)
+    return lines
+
+
 @PlaceholderRegistry.register
 class EnforcementApplicantPropertyClueService(BasePlaceholderService):
     """强制执行申请书申请人财产线索服务"""
@@ -60,14 +71,7 @@ class EnforcementApplicantPropertyClueService(BasePlaceholderService):
         lines: list[str] = []
 
         for party_dto in applicant_party_dtos:
-            client_id = party_dto.client_id
-            clue_dtos = client_service.get_property_clues_by_client_internal(client_id)
-            for clue in clue_dtos:
-                content = clue.content or ""
-                for line in content.split("\n"):
-                    stripped = line.strip()
-                    if stripped:
-                        lines.append(stripped)
+            lines.extend(_collect_clue_lines(client_service, party_dto.client_id))
 
         result = "\a".join(lines)
         logger.info("生成申请人财产线索成功: case_id=%s, 行数=%s", case_id, len(lines))

--- a/backend/apps/documents/services/placeholders/litigation/execution_request_interest.py
+++ b/backend/apps/documents/services/placeholders/litigation/execution_request_interest.py
@@ -23,79 +23,112 @@ from .execution_request_utils import (
 
 logger = logging.getLogger(__name__)
 
+_LPR_PATTERN = re.compile(
+    r"(?:LPR|贷款市场报价利率|一年期贷款市场报价利率)[^。；\n]{0,24}?([0-9]+(?:\.[0-9]+)?|[零一二两三四五六七八九十]+)\s*倍"
+)
+_LPR_MARKUP_PATTERN = re.compile(
+    r"(?:LPR|贷款市场报价利率|一年期贷款市场报价利率)[^。；\n]{0,24}?上浮\s*([0-9]+(?:\.[0-9]+)?)\s*%"
+)
+_FIXED_PATTERN = re.compile(r"(?:(?:按|起按|按照)\s*)?(年利率|年化率|年化利率)\s*([0-9]+(?:\.[0-9]+)?)\s*%")
+_UNIT_RATE_PATTERN = r"([0-9]+(?:\.[0-9]+)?|[零一二两三四五六七八九十]+)"
+_DAILY_PERMILLE_PATTERN = re.compile(rf"(?:日利率|每日)\s*千分之\s*{_UNIT_RATE_PATTERN}")
+_DAILY_PERMYRIAD_PATTERN = re.compile(rf"(?:日利率|每日)\s*万分之\s*{_UNIT_RATE_PATTERN}")
+_DAILY_PERCENT_PATTERN = re.compile(r"(?:日利率|每日)\s*([0-9]+(?:\.[0-9]+)?)\s*%")
+
+
+def _try_lpr_multiple(text: str, params: ParsedInterestParams) -> bool:
+    m = _LPR_PATTERN.search(text)
+    if not m:
+        return False
+    multiplier = parse_multiplier_value(m.group(1))
+    if multiplier is None:
+        return False
+    params.multiplier = multiplier
+    params.rate_type = "1y"
+    params.rate_description = f"全国银行间同业拆借中心公布的一年期贷款市场报价利率的{format_amount(multiplier)}倍"
+    return True
+
+
+def _try_lpr_markup(text: str, params: ParsedInterestParams) -> bool:
+    m = _LPR_MARKUP_PATTERN.search(text)
+    if not m:
+        return False
+    markup = parse_decimal(m.group(1))
+    if markup is None:
+        return False
+    params.multiplier = Decimal("1") + (markup / Decimal("100"))
+    params.rate_type = "1y"
+    params.rate_description = (
+        f"全国银行间同业拆借中心公布的一年期贷款市场报价利率的{format_amount(params.multiplier)}倍"
+    )
+    return True
+
+
+def _try_lpr_plain(text: str, params: ParsedInterestParams) -> bool:
+    if not re.search(r"(?:LPR|贷款市场报价利率|一年期贷款市场报价利率)", text):
+        return False
+    params.multiplier = Decimal("1")
+    params.rate_type = "1y"
+    params.rate_description = "全国银行间同业拆借中心公布的一年期贷款市场报价利率"
+    return True
+
+
+def _try_fixed_annual(text: str, params: ParsedInterestParams) -> bool:
+    m = _FIXED_PATTERN.search(text)
+    if not m:
+        return False
+    annual_rate = parse_decimal(m.group(2))
+    if annual_rate is None:
+        return False
+    params.custom_rate_unit = "percent"
+    params.custom_rate_value = annual_rate
+    params.rate_description = f"{m.group(1)}{format_amount(annual_rate)}%"
+    return True
+
+
+def _try_unit_rate(text: str, unit: str, label: str, params: ParsedInterestParams) -> bool:
+    pattern = _DAILY_PERMILLE_PATTERN if unit == "permille" else _DAILY_PERMYRIAD_PATTERN
+    m = pattern.search(text)
+    if not m:
+        return False
+    rate = parse_multiplier_value(m.group(1))
+    if rate is None:
+        return False
+    params.custom_rate_unit = unit
+    params.custom_rate_value = rate
+    params.rate_description = f"日利率{label}{format_amount(rate)}"
+    return True
+
+
+def _try_daily_percent(text: str, params: ParsedInterestParams) -> bool:
+    m = _DAILY_PERCENT_PATTERN.search(text)
+    if not m:
+        return False
+    rate = parse_decimal(m.group(1))
+    if rate is None:
+        return False
+    params.custom_rate_unit = "permyriad"
+    params.custom_rate_value = (rate * Decimal("100")).quantize(Decimal("0.0001"))
+    params.rate_description = f"日利率{format(rate.normalize(), 'f')}%"
+    return True
+
 
 def parse_interest_params(main_text: str) -> ParsedInterestParams:
     params = ParsedInterestParams()
     clause = extract_interest_clause(main_text)
     params.overdue_item_label = detect_overdue_item_label(main_text)
 
-    lpr_pattern = re.compile(
-        r"(?:LPR|贷款市场报价利率|一年期贷款市场报价利率)[^。；\n]{0,24}?([0-9]+(?:\.[0-9]+)?|[零一二两三四五六七八九十]+)\s*倍"
-    )
-    lpr_markup_pattern = re.compile(
-        r"(?:LPR|贷款市场报价利率|一年期贷款市场报价利率)[^。；\n]{0,24}?上浮\s*([0-9]+(?:\.[0-9]+)?)\s*%"
-    )
-    fixed_pattern = re.compile(r"(?:(?:按|起按|按照)\s*)?(年利率|年化率|年化利率)\s*([0-9]+(?:\.[0-9]+)?)\s*%")
-    unit_rate_pattern = r"([0-9]+(?:\.[0-9]+)?|[零一二两三四五六七八九十]+)"
-    daily_permille_pattern = re.compile(rf"(?:日利率|每日)\s*千分之\s*{unit_rate_pattern}")
-    daily_permyriad_pattern = re.compile(rf"(?:日利率|每日)\s*万分之\s*{unit_rate_pattern}")
-    daily_percent_pattern = re.compile(r"(?:日利率|每日)\s*([0-9]+(?:\.[0-9]+)?)\s*%")
-
     rate_text = clause or main_text
-    lpr_match = lpr_pattern.search(rate_text)
-    lpr_markup_match = lpr_markup_pattern.search(rate_text)
-    fixed_match = fixed_pattern.search(rate_text)
-    permille_match = daily_permille_pattern.search(rate_text)
-    permyriad_match = daily_permyriad_pattern.search(rate_text)
-    daily_percent_match = daily_percent_pattern.search(rate_text)
-
-    if lpr_match:
-        multiplier = parse_multiplier_value(lpr_match.group(1))
-        if multiplier is not None:
-            params.multiplier = multiplier
-            params.rate_type = "1y"
-            params.rate_description = (
-                f"全国银行间同业拆借中心公布的一年期贷款市场报价利率的{format_amount(multiplier)}倍"
-            )
-    elif lpr_markup_match:
-        markup_percent = parse_decimal(lpr_markup_match.group(1))
-        if markup_percent is not None:
-            multiplier = Decimal("1") + (markup_percent / Decimal("100"))
-            params.multiplier = multiplier
-            params.rate_type = "1y"
-            params.rate_description = (
-                f"全国银行间同业拆借中心公布的一年期贷款市场报价利率的{format_amount(multiplier)}倍"
-            )
-    elif re.search(r"(?:LPR|贷款市场报价利率|一年期贷款市场报价利率)", rate_text):
-        params.multiplier = Decimal("1")
-        params.rate_type = "1y"
-        params.rate_description = "全国银行间同业拆借中心公布的一年期贷款市场报价利率"
-    elif fixed_match:
-        annual_rate = parse_decimal(fixed_match.group(2))
-        if annual_rate is not None:
-            params.custom_rate_unit = "percent"
-            params.custom_rate_value = annual_rate
-            params.rate_description = f"{fixed_match.group(1)}{format_amount(annual_rate)}%"
-    elif permille_match:
-        unit_rate = parse_multiplier_value(permille_match.group(1))
-        if unit_rate is not None:
-            params.custom_rate_unit = "permille"
-            params.custom_rate_value = unit_rate
-            params.rate_description = f"日利率千分之{format_amount(unit_rate)}"
-    elif permyriad_match:
-        unit_rate = parse_multiplier_value(permyriad_match.group(1))
-        if unit_rate is not None:
-            params.custom_rate_unit = "permyriad"
-            params.custom_rate_value = unit_rate
-            params.rate_description = f"日利率万分之{format_amount(unit_rate)}"
-    elif daily_percent_match:
-        # 日利率 x% => 转换为万分之(x * 100)
-        percent_rate = parse_decimal(daily_percent_match.group(1))
-        if percent_rate is not None:
-            params.custom_rate_unit = "permyriad"
-            params.custom_rate_value = (percent_rate * Decimal("100")).quantize(Decimal("0.0001"))
-            percent_text = format(percent_rate.normalize(), "f")
-            params.rate_description = f"日利率{percent_text}%"
+    if (
+        _try_lpr_multiple(rate_text, params)
+        or _try_lpr_markup(rate_text, params)
+        or _try_lpr_plain(rate_text, params)
+        or _try_fixed_annual(rate_text, params)
+        or _try_unit_rate(rate_text, "permille", "千分之", params)
+        or _try_unit_rate(rate_text, "permyriad", "万分之", params)
+        or _try_daily_percent(rate_text, params)
+    ):
+        pass
 
     date_match = re.search(r"(?:自|从)\s*(\d{4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日(?:起|开始|计)?", rate_text)
     if date_match:

--- a/backend/apps/finance/services/lpr/sync_service.py
+++ b/backend/apps/finance/services/lpr/sync_service.py
@@ -120,7 +120,7 @@ class LPRSyncService:
         logger.info(f"[LPRSync] Parsed {len(unique_data)} unique LPR records")
         return unique_data
 
-    def _parse_single_row(self, row: Any) -> LPRData | None:  # type: ignore[no-untyped-def]
+    def _parse_single_row(self, row: Any) -> LPRData | None:
         """解析表格单行，返回 LPRData 或 None（跳过无效行）。"""
         cells = row.query_selector_all("td, th")
         if len(cells) < 3:

--- a/backend/apps/finance/services/lpr/sync_service.py
+++ b/backend/apps/finance/services/lpr/sync_service.py
@@ -103,37 +103,9 @@ class LPRSyncService:
 
         for row in rows:
             try:
-                cells = row.query_selector_all("td, th")
-                if len(cells) < 3:
-                    continue
-
-                date_text = cells[0].inner_text().strip()
-                rate_1y_text = cells[1].inner_text().strip()
-                rate_5y_text = cells[2].inner_text().strip()
-
-                if date_text in ["LPR报价", "日期", ""] or not date_text:
-                    continue
-
-                effective_date = self._parse_date(date_text)
-                if not effective_date:
-                    continue
-
-                rate_1y = self._parse_rate(rate_1y_text)
-                rate_5y = self._parse_rate(rate_5y_text)
-
-                if rate_1y is None:
-                    continue
-
-                if rate_5y is None:
-                    logger.warning(
-                        "[LPRSync] 5年期利率解析失败，使用1年期利率替代: date=%s, rate_1y=%s",
-                        date_text, rate_1y,
-                    )
-
-                lpr_data_list.append(
-                    LPRData(effective_date=effective_date, rate_1y=rate_1y, rate_5y=rate_5y or rate_1y)
-                )
-
+                lpr = self._parse_single_row(row)
+                if lpr:
+                    lpr_data_list.append(lpr)
             except Exception as e:
                 logger.debug(f"[LPRSync] Failed to parse row: {e}")
                 continue
@@ -147,6 +119,31 @@ class LPRSyncService:
 
         logger.info(f"[LPRSync] Parsed {len(unique_data)} unique LPR records")
         return unique_data
+
+    def _parse_single_row(self, row: Any) -> LPRData | None:  # type: ignore[no-untyped-def]
+        """解析表格单行，返回 LPRData 或 None（跳过无效行）。"""
+        cells = row.query_selector_all("td, th")
+        if len(cells) < 3:
+            return None
+        date_text = cells[0].inner_text().strip()
+        rate_1y_text = cells[1].inner_text().strip()
+        rate_5y_text = cells[2].inner_text().strip()
+        if date_text in ("LPR报价", "日期", ""):
+            return None
+        effective_date = self._parse_date(date_text)
+        if not effective_date:
+            return None
+        rate_1y = self._parse_rate(rate_1y_text)
+        if rate_1y is None:
+            return None
+        rate_5y = self._parse_rate(rate_5y_text)
+        if rate_5y is None:
+            logger.warning(
+                "[LPRSync] 5年期利率解析失败，使用1年期利率替代: date=%s, rate_1y=%s",
+                date_text,
+                rate_1y,
+            )
+        return LPRData(effective_date=effective_date, rate_1y=rate_1y, rate_5y=rate_5y or rate_1y)
 
     def _parse_date(self, date_text: str) -> date | None:
         """解析日期文本.

--- a/backend/apps/invoice_recognition/services/invoice_parser.py
+++ b/backend/apps/invoice_recognition/services/invoice_parser.py
@@ -27,12 +27,13 @@ class InvoiceParser:
     """通过正则表达式和关键词匹配从 OCR/PDF 文本中提取结构化发票字段"""
 
     _CODE_PATTERN: re.Pattern[str] = re.compile(r"(?:发票代码|No\.)[^\d]*(\d{10,12})")
-    _NUMBER_PATTERN: re.Pattern[str] = re.compile(r"(?:发票号码|No\.)[^\d]*(\d{20}|\d{8})(?!\d)")
+    _NUMBER_PATTERN: re.Pattern[str] = re.compile(r"(?:发\s*票\s*号\s*码|No\.)[^\d]*(\d{20}|\d{8})(?!\d)")
+    _NUMBER_FALLBACK_20: re.Pattern[str] = re.compile(r"(?<!\d)(\d{20})(?!\d)")
     _PROJECT_PATTERN: re.Pattern[str] = re.compile(r"\*[^*]+\*([^\s\n\r]{2,50})")
-    _DATE_CN_PATTERN: re.Pattern[str] = re.compile(r"(\d{4})年(\d{1,2})月(\d{1,2})日")
+    _DATE_CN_PATTERN: re.Pattern[str] = re.compile(r"(\d{4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日")
     _DATE_ISO_PATTERN: re.Pattern[str] = re.compile(r"(\d{4})-(\d{2})-(\d{2})")
     _AMOUNT_PATTERN: re.Pattern[str] = re.compile(r"合\s*计\s*[¥￥]([\d,]+\.\d{2})\s*[¥￥]([\d,]+\.\d{2})")
-    _TOTAL_PATTERN: re.Pattern[str] = re.compile(r"[（(]小写[）)]\s*[¥￥]([\d,]+\.\d{2})")
+    _TOTAL_PATTERN: re.Pattern[str] = re.compile(r"[（(]\s*小写\s*[）)]\s*[¥￥]\s*([\d,]+\.\d{2})")
     _BUYER_PATTERN: re.Pattern[str] = re.compile(
         r"(?:购买方名称|购方名称)[：:]\s*([^\n\r]{2,50})"
         r"|(?:购\s*名称|买\s*名称)[：:]\s*([^销\n\r]{2,50})"
@@ -124,7 +125,15 @@ class InvoiceParser:
 
     def _extract_invoice_number(self, text: str) -> str:
         m = self._NUMBER_PATTERN.search(text)
-        return m.group(1) if m else ""
+        if m:
+            return m.group(1)
+        # 数电发票：发票号码在红色印章图片中，pdfplumber 提取的文本里
+        # 号码不紧跟在「发票号码」标签后，而是散落在文本中（如「制 264420…」）
+        if re.search(r"电⼦?发票", text):
+            m = self._NUMBER_FALLBACK_20.search(text)
+            if m:
+                return m.group(1)
+        return ""
 
     def _extract_date(self, text: str) -> date | None:
         m = self._DATE_CN_PATTERN.search(text)

--- a/backend/apps/litigation_ai/services/evidence/evidence_text_extraction_service.py
+++ b/backend/apps/litigation_ai/services/evidence/evidence_text_extraction_service.py
@@ -44,7 +44,7 @@ class EvidenceTextExtractionService:
 
         return results
 
-    def _try_ocr_fallback(self, page: Any, ocr: Any) -> str:  # type: ignore[no-untyped-def]
+    def _try_ocr_fallback(self, page: Any, ocr: Any) -> str:
         """渲染页面为图片并 OCR，返回文本或空字符串。"""
         try:
             pix = page.get_pixmap(dpi=200)

--- a/backend/apps/litigation_ai/services/evidence/evidence_text_extraction_service.py
+++ b/backend/apps/litigation_ai/services/evidence/evidence_text_extraction_service.py
@@ -27,15 +27,10 @@ class EvidenceTextExtractionService:
             method = "text"
 
             if len(text) < 20:
-                try:
-                    pix = page.get_pixmap(dpi=200)
-                    png_bytes = pix.tobytes("png")
-                    ocr_text = (ocr.recognize_bytes(png_bytes) or "").strip()
-                    if ocr_text:
-                        text = ocr_text
-                        method = "ocr"
-                except Exception as e:
-                    logger.warning(f"OCR 失败: {e}", exc_info=True)
+                ocr_text = self._try_ocr_fallback(page, ocr)
+                if ocr_text:
+                    text = ocr_text
+                    method = "ocr"
 
             if text:
                 results.append(
@@ -49,6 +44,18 @@ class EvidenceTextExtractionService:
 
         return results
 
-    async def aextract_chunks(self, file_path: str, max_pages: int | None = None) -> list[dict[str, Any]]:  # pragma: no cover
+    def _try_ocr_fallback(self, page: Any, ocr: Any) -> str:  # type: ignore[no-untyped-def]
+        """渲染页面为图片并 OCR，返回文本或空字符串。"""
+        try:
+            pix = page.get_pixmap(dpi=200)
+            png_bytes = pix.tobytes("png")
+            return (ocr.recognize_bytes(png_bytes) or "").strip()
+        except Exception as e:
+            logger.warning(f"OCR 失败: {e}", exc_info=True)
+            return ""
+
+    async def aextract_chunks(
+        self, file_path: str, max_pages: int | None = None
+    ) -> list[dict[str, Any]]:  # pragma: no cover
         """异步版本 — 将 PDF 解析和 OCR 卸载到线程池."""
         return await asyncio.to_thread(self.extract_chunks, file_path, max_pages)

--- a/backend/apps/litigation_ai/services/mock_trial/mock_trial_flow_service.py
+++ b/backend/apps/litigation_ai/services/mock_trial/mock_trial_flow_service.py
@@ -618,7 +618,7 @@ class MockTrialFlowService:
         )
         if not raw:
             return ""
-        list_ids = [e.get("list_id") for e in raw if e.get("list_id")]
+        list_ids: list[int] = [int(e["list_id"]) for e in raw if e.get("list_id")]
         if not list_ids:
             return "\n".join([f"- {e.get('name', '未命名')}: {e.get('description', '')}" for e in raw])
         result = await sync_to_async(EvidenceDigestService().build_evidence_text, thread_sensitive=True)(

--- a/backend/apps/litigation_ai/services/mock_trial/mock_trial_flow_service.py
+++ b/backend/apps/litigation_ai/services/mock_trial/mock_trial_flow_service.py
@@ -613,14 +613,16 @@ class MockTrialFlowService:
         from apps.litigation_ai.services.evidence.evidence_digest_service import EvidenceDigestService
         from apps.litigation_ai.services.session.context_service import LitigationContextService
 
-        raw = await sync_to_async(LitigationContextService.get_evidence_list_for_agent, thread_sensitive=True)(case_id)
+        raw = await sync_to_async(LitigationContextService().get_evidence_list_for_agent, thread_sensitive=True)(
+            case_id
+        )
         if not raw:
             return ""
         list_ids = [e.get("list_id") for e in raw if e.get("list_id")]
         if not list_ids:
             return "\n".join([f"- {e.get('name', '未命名')}: {e.get('description', '')}" for e in raw])
         result = await sync_to_async(EvidenceDigestService().build_evidence_text, thread_sensitive=True)(
-            list_ids=list_ids, item_ids=[]
+            evidence_list_ids=list_ids, evidence_item_ids=[]
         )
         return result
 

--- a/backend/apps/litigation_ai/services/mock_trial/mock_trial_flow_service.py
+++ b/backend/apps/litigation_ai/services/mock_trial/mock_trial_flow_service.py
@@ -67,9 +67,7 @@ def format_judge_report(report: dict[str, Any]) -> str:
         lines.append("## 证据强弱对比\n")
         for c in comparisons:
             lines.append(f"**{c.get('focus', '')}**")
-            lines.append(
-                f"- 原告证据：{c.get('plaintiff_strength', '')} | 被告证据：{c.get('defendant_strength', '')}"
-            )
+            lines.append(f"- 原告证据：{c.get('plaintiff_strength', '')} | 被告证据：{c.get('defendant_strength', '')}")
             lines.append(f"- 分析：{c.get('analysis', '')}")
             lines.append("")
 
@@ -178,7 +176,9 @@ class MockTrialFlowService:
 
     # ---- MODE_SELECT ----
 
-    async def handle_mode_select(self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]) -> None:  # pragma: no cover
+    async def handle_mode_select(
+        self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]
+    ) -> None:  # pragma: no cover
         mode = self._parse_mode(user_input)
         if not mode:
             await self._send(
@@ -236,7 +236,9 @@ class MockTrialFlowService:
 
     # ---- SIMULATION dispatchers ----
 
-    async def handle_simulation(self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]) -> None:  # pragma: no cover
+    async def handle_simulation(
+        self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]
+    ) -> None:  # pragma: no cover
         metadata = await self.session_repo.get_metadata(ctx.session_id)
         mode = metadata.get("mock_trial_mode", "")
 
@@ -502,7 +504,9 @@ class MockTrialFlowService:
                 "system",
             )
 
-    async def _handle_debate_turn(self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]) -> None:  # pragma: no cover
+    async def _handle_debate_turn(
+        self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]
+    ) -> None:  # pragma: no cover
         from .debate_service import DebateService
 
         metadata = await self.session_repo.get_metadata(ctx.session_id)
@@ -636,7 +640,9 @@ class MockTrialFlowService:
 
     # ── 多 Agent 对抗 ──
 
-    async def _send_model_config_prompt(self, ctx: MockTrialContext, send_cb: Callable[..., Any]) -> None:  # pragma: no cover
+    async def _send_model_config_prompt(
+        self, ctx: MockTrialContext, send_cb: Callable[..., Any]
+    ) -> None:  # pragma: no cover
         """发送模型配置提示."""
         from apps.core.llm.config import LLMConfig
 
@@ -668,7 +674,9 @@ class MockTrialFlowService:
         )
         await self._set_step(ctx.session_id, MockTrialStep.MODEL_CONFIG)
 
-    async def handle_model_config(self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]) -> None:  # pragma: no cover
+    async def handle_model_config(
+        self, ctx: MockTrialContext, user_input: str, send_cb: Callable[..., Any]
+    ) -> None:  # pragma: no cover
         """解析用户的模型配置并启动对抗庭审."""
         from apps.core.llm.config import LLMConfig
 
@@ -755,26 +763,32 @@ class MockTrialFlowService:
         role_map = {"原告": "plaintiff", "被告": "defendant", "法官": "judge", "观看": "observer"}
         level_map = {"一审": "first", "二审": "second"}
 
+        def _apply_rule(key: str, val: str) -> bool:
+            if "原告" in key and "模型" in key:
+                config.plaintiff_model = resolve_model(val)
+            elif "被告" in key and "模型" in key:
+                config.defendant_model = resolve_model(val)
+            elif "法官" in key and "模型" in key:
+                config.judge_model = resolve_model(val)
+            elif "轮数" in key:
+                try:
+                    config.debate_rounds = max(3, int(val))
+                except ValueError:
+                    pass
+            elif "角色" in key:
+                config.user_role = role_map.get(val, "observer")
+            elif "审级" in key:
+                config.trial_level = level_map.get(val, "first")
+            else:
+                return False
+            return True
+
         for line in text.split("\n"):
             line = line.strip()
-            if ":" in line or "：" in line:
-                key, _, val = line.replace("：", ":").partition(":")
-                key, val = key.strip(), val.strip()
-                if "原告" in key and "模型" in key:
-                    config.plaintiff_model = resolve_model(val)
-                elif "被告" in key and "模型" in key:
-                    config.defendant_model = resolve_model(val)
-                elif "法官" in key and "模型" in key:
-                    config.judge_model = resolve_model(val)
-                elif "轮数" in key:
-                    try:
-                        config.debate_rounds = max(3, int(val))
-                    except ValueError:
-                        pass
-                elif "角色" in key:
-                    config.user_role = role_map.get(val, "observer")
-                elif "审级" in key:
-                    config.trial_level = level_map.get(val, "first")
+            if ":" not in line and "：" not in line:
+                continue
+            key, _, val = line.replace("：", ":").partition(":")
+            _apply_rule(key.strip(), val.strip())
 
         return config
 
@@ -835,7 +849,9 @@ class MockTrialFlowService:
         if service:
             await service.handle_user_input(ctx, text, send_cb, self._set_step)
 
-    async def _export_adversarial_report(self, ctx: MockTrialContext, send_cb: Callable[..., Any]) -> None:  # pragma: no cover
+    async def _export_adversarial_report(
+        self, ctx: MockTrialContext, send_cb: Callable[..., Any]
+    ) -> None:  # pragma: no cover
         """生成并推送对抗庭审报告."""
         service = self._adversarial_services.get(ctx.session_id)
         if not service or not service.transcript:

--- a/backend/apps/message_hub/models/inbox_message.py
+++ b/backend/apps/message_hub/models/inbox_message.py
@@ -7,6 +7,14 @@ from typing import Any, ClassVar
 from django.db import models
 
 
+def _safe_int(value: Any, default: int = -1) -> int:
+    """安全转换为 int，失败返回 default。"""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 class InboxMessage(models.Model):
     """统一收件箱消息，来自各数据源的消息聚合到此表。"""
 
@@ -53,24 +61,11 @@ class InboxMessage(models.Model):
 
             filename = str(item.get("filename") or item.get("original_filename") or "").strip()
             if not filename:
-                part_idx_raw = item.get("part_index", -1)
-                try:
-                    part_idx = int(part_idx_raw)
-                except (TypeError, ValueError):
-                    part_idx = -1
+                part_idx = _safe_int(item.get("part_index", -1))
                 filename = f"attachment_{part_idx if part_idx >= 0 else 0}"
 
-            size_raw = item.get("size", 0)
-            try:
-                size = int(size_raw)
-            except (TypeError, ValueError):
-                size = 0
-
-            part_index_raw = item.get("part_index", -1)
-            try:
-                part_index = int(part_index_raw)
-            except (TypeError, ValueError):
-                part_index = -1
+            size = _safe_int(item.get("size", 0), default=0)
+            part_index = _safe_int(item.get("part_index", -1))
 
             public_items.append(
                 {

--- a/backend/apps/organization/admin/accountcredential_admin.py
+++ b/backend/apps/organization/admin/accountcredential_admin.py
@@ -36,7 +36,7 @@ def _format_time_ago(delta):  # type: ignore[no-untyped-def]
 
 @admin.register(AccountCredential)
 class AccountCredentialAdmin(admin.ModelAdmin):  # pragma: no cover
-    list_display: ClassVar[list[str]] = [
+    list_display = [
         "id",
         "lawyer",
         "site_name",
@@ -46,11 +46,11 @@ class AccountCredentialAdmin(admin.ModelAdmin):  # pragma: no cover
 
     search_fields: ClassVar[tuple[str, ...]] = ("site_name", "url", "account", "lawyer__username", "lawyer__real_name")
 
-    list_filter: ClassVar[list[str]] = ["site_name", "lawyer", "last_login_success_at", "created_at"]
+    list_filter = ["site_name", "lawyer", "last_login_success_at", "created_at"]
 
     autocomplete_fields: ClassVar[tuple[str, ...]] = ("lawyer",)
 
-    readonly_fields: ClassVar[list[str]] = [
+    readonly_fields = [
         "id",
         "login_statistics_display",
         "success_rate_display",
@@ -68,14 +68,14 @@ class AccountCredentialAdmin(admin.ModelAdmin):  # pragma: no cover
         ("时间信息", {"fields": ("created_at", "updated_at")}),
     )
 
-    ordering: ClassVar[list[str]] = ["-last_login_success_at", "-login_success_count", "login_failure_count"]
+    ordering = ["-last_login_success_at", "-login_success_count", "login_failure_count"]
 
     date_hierarchy = "last_login_success_at"
 
     list_per_page = 50
 
     def get_form(  # pragma: no cover
-        self, request: HttpRequest, obj: AccountCredential | None = None, **kwargs: Any
+        self, request: HttpRequest, obj: AccountCredential | None = None, change: bool = False, **kwargs: Any
     ) -> type[forms.ModelForm]:
         form = super().get_form(request, obj, **kwargs)
         if "password" in form.base_fields:

--- a/backend/apps/organization/admin/accountcredential_admin.py
+++ b/backend/apps/organization/admin/accountcredential_admin.py
@@ -19,6 +19,21 @@ from django.utils.safestring import SafeString
 from apps.organization.models import AccountCredential
 
 
+def _format_time_ago(delta):  # type: ignore[no-untyped-def]
+    """将 timedelta 转为 (color, 时间文本)。"""
+    if delta.days > 30:
+        return "#dc3545", f"{delta.days}天前"
+    if delta.days > 7:
+        return "#ffc107", f"{delta.days}天前"
+    if delta.days > 0:
+        return "#007bff", f"{delta.days}天前"
+    hours = delta.seconds // 3600
+    if hours > 0:
+        return "#28a745", f"{hours}小时前"
+    minutes = delta.seconds // 60
+    return "#28a745", f"{minutes}分钟前"
+
+
 @admin.register(AccountCredential)
 class AccountCredentialAdmin(admin.ModelAdmin):  # pragma: no cover
     list_display: ClassVar[list[str]] = [
@@ -99,28 +114,8 @@ class AccountCredentialAdmin(admin.ModelAdmin):  # pragma: no cover
         if not obj.last_login_success_at:
             return format_html('<span style="color: #999;">{}</span>', "从未成功")
 
-        now = timezone.now()
-        delta = now - obj.last_login_success_at
-
-        if delta.days > 30:
-            color = "#dc3545"
-            time_str = "%(days)d天前" % {"days": delta.days}
-        elif delta.days > 7:
-            color = "#ffc107"
-            time_str = "%(days)d天前" % {"days": delta.days}
-        elif delta.days > 0:
-            color = "#007bff"
-            time_str = "%(days)d天前" % {"days": delta.days}
-        else:
-            hours = delta.seconds // 3600
-            if hours > 0:
-                color = "#28a745"
-                time_str = "%(hours)d小时前" % {"hours": hours}
-            else:
-                minutes = delta.seconds // 60
-                color = "#28a745"
-                time_str = "%(minutes)d分钟前" % {"minutes": minutes}
-
+        delta = timezone.now() - obj.last_login_success_at
+        color, time_str = _format_time_ago(delta)
         return format_html('<span style="color: {}; font-weight: bold;">{}</span>', color, time_str)
 
     @admin.display(description="操作")

--- a/backend/apps/organization/services/credential/account_credential_admin_service.py
+++ b/backend/apps/organization/services/credential/account_credential_admin_service.py
@@ -239,65 +239,29 @@ class AccountCredentialAdminService:
             duration = (end_time - start_time).total_seconds()
 
             if result:
-                self._record_login_history(
+                return self._finish_login(
                     credential=credential,
                     success=True,
                     duration=duration,
+                    trigger_reason=trigger_reason,
+                    start_time=start_time,
+                    end_time=end_time,
                     token=result,
-                    trigger_reason=trigger_reason,
-                    start_time=start_time,
-                    end_time=end_time,
-                )
-                self.credential_service.update_login_success(credential.id)
-
-                logger.info(
-                    "批量登录成功",
-                    extra={
-                        "admin_user": admin_user,
-                        "credential_id": credential.id,
-                        "account": credential.account,
-                        "duration": duration,
-                    },
                 )
 
-                return LoginResult(success=True, duration=duration, token=result)
-            else:
-                self._record_login_history(
-                    credential=credential,
-                    success=False,
-                    duration=duration,
-                    error_message="登录失败，未返回Token",
-                    trigger_reason=trigger_reason,
-                    start_time=start_time,
-                    end_time=end_time,
-                )
-                self.credential_service.update_login_failure(credential.id)
-
-                return LoginResult(
-                    success=False,
-                    duration=duration,
-                    error_message="登录失败，未返回Token",
-                )
+            return self._finish_login(
+                credential=credential,
+                success=False,
+                duration=duration,
+                trigger_reason=trigger_reason,
+                start_time=start_time,
+                end_time=end_time,
+                error_message="登录失败，未返回Token",
+            )
 
         except Exception as e:
             end_time = timezone.now()
             duration = (end_time - start_time).total_seconds()
-
-            self._record_login_history(
-                credential=credential,
-                success=False,
-                duration=duration,
-                error_message=str(e),
-                trigger_reason=trigger_reason,
-                start_time=start_time,
-                end_time=end_time,
-                error_details={
-                    "error_type": type(e).__name__,
-                    "admin_user": admin_user,
-                    "batch_operation": True,
-                },
-            )
-            self.credential_service.update_login_failure(credential.id)
 
             logger.error(
                 "批量登录失败",
@@ -311,7 +275,54 @@ class AccountCredentialAdminService:
                 exc_info=True,
             )
 
-            return LoginResult(success=False, duration=duration, error_message=str(e))
+            return self._finish_login(
+                credential=credential,
+                success=False,
+                duration=duration,
+                trigger_reason=trigger_reason,
+                start_time=start_time,
+                end_time=end_time,
+                error_message=str(e),
+                error_details={
+                    "error_type": type(e).__name__,
+                    "admin_user": admin_user,
+                    "batch_operation": True,
+                },
+            )
+
+    def _finish_login(
+        self,
+        credential: AccountCredential,
+        success: bool,
+        duration: float,
+        trigger_reason: str,
+        start_time: datetime,
+        end_time: datetime,
+        token: str | None = None,
+        error_message: str | None = None,
+        error_details: dict[str, object] | None = None,
+    ) -> LoginResult:
+        """记录登录历史 + 更新凭证状态 + 返回 LoginResult。"""
+        self._record_login_history(
+            credential=credential,
+            success=success,
+            duration=duration,
+            token=token,
+            trigger_reason=trigger_reason,
+            start_time=start_time,
+            end_time=end_time,
+            error_message=error_message,
+            error_details=error_details,
+        )
+        if success:
+            self.credential_service.update_login_success(credential.id)
+            logger.info(
+                "批量登录成功",
+                extra={"credential_id": credential.id, "account": credential.account, "duration": duration},
+            )
+        else:
+            self.credential_service.update_login_failure(credential.id)
+        return LoginResult(success=success, duration=duration, token=token, error_message=error_message)
 
     def _record_login_history(
         self,

--- a/backend/apps/organization/views.py
+++ b/backend/apps/organization/views.py
@@ -31,50 +31,26 @@ def register(request: HttpRequest) -> HttpResponse:
     is_first_user = _auth_service.is_first_user()
     show_auto_register = _auth_service.should_show_auto_register()
 
-    if request.method == "POST":
-        if request.POST.get("action") == "auto_register":
-            try:
-                result = _auth_service.auto_register_superadmin()
-            except Exception as e:
-                messages.error(request, str(e))
-                return redirect("admin_register")
+    if request.method != "POST":
+        return render(
+            request,
+            "admin/login.html",
+            {
+                "form": LawyerRegistrationForm(),
+                "reg_form": LawyerRegistrationForm(),
+                "title": "用户注册",
+                "is_first_user": is_first_user,
+                "show_auto_register": show_auto_register,
+                "show_register": True,
+            },
+        )
 
-            user = result.user
-            login(request, user)
-            messages.success(
-                request,
-                "已自动创建超级管理员账户\u201c%(name)s\u201d，并为您完成登录。"
-                % {"name": user.real_name or AUTO_REGISTER_BOOTSTRAP_USERNAME},
-            )
-            return redirect("admin:index")
+    if request.POST.get("action") == "auto_register":
+        return _handle_auto_register(request)
 
-        form = LawyerRegistrationForm(request.POST)
-        if form.is_valid():
-            username: str = form.cleaned_data["username"]
-            password: str = form.cleaned_data["password1"]
-            try:
-                result = _auth_service.register(
-                    username=username,
-                    password=password,
-                    real_name=username,
-                )
-            except Exception as e:
-                messages.error(request, str(e))
-            else:
-                user = result.user
-                if user.is_admin:
-                    login(request, user)
-                    messages.success(
-                        request,
-                        "注册成功！您是第一个用户，已自动获得管理员权限。系统正在初始化中... %(name)s"
-                        % {"name": user.real_name or user.username},
-                    )
-                    return redirect("admin:index")
-                else:
-                    messages.info(request, "注册成功！请等待管理员开通权限后再登录。")
-                    return redirect("admin:login")
-    else:
-        form = LawyerRegistrationForm()
+    form = LawyerRegistrationForm(request.POST)
+    if form.is_valid():
+        return _handle_form_register(request, form)
 
     return render(
         request,
@@ -88,3 +64,43 @@ def register(request: HttpRequest) -> HttpResponse:
             "show_register": True,
         },
     )
+
+
+def _handle_auto_register(request: HttpRequest) -> HttpResponse:
+    try:
+        result = _auth_service.auto_register_superadmin()
+    except Exception as e:
+        messages.error(request, str(e))
+        return redirect("admin_register")
+
+    user = result.user
+    login(request, user)
+    messages.success(
+        request,
+        "已自动创建超级管理员账户“%(name)s”，并为您完成登录。"
+        % {"name": user.real_name or AUTO_REGISTER_BOOTSTRAP_USERNAME},
+    )
+    return redirect("admin:index")
+
+
+def _handle_form_register(request: HttpRequest, form: LawyerRegistrationForm) -> HttpResponse:
+    username: str = form.cleaned_data["username"]
+    password: str = form.cleaned_data["password1"]
+    try:
+        result = _auth_service.register(username=username, password=password, real_name=username)
+    except Exception as e:
+        messages.error(request, str(e))
+        return redirect("admin_register")
+
+    user = result.user
+    if user.is_admin:
+        login(request, user)
+        messages.success(
+            request,
+            "注册成功！您是第一个用户，已自动获得管理员权限。系统正在初始化中... %(name)s"
+            % {"name": user.real_name or user.username},
+        )
+        return redirect("admin:index")
+
+    messages.info(request, "注册成功！请等待管理员开通权限后再登录。")
+    return redirect("admin:login")

--- a/backend/apps/workbench/services/batch_service.py
+++ b/backend/apps/workbench/services/batch_service.py
@@ -72,26 +72,14 @@ def _split_excel_rows(uploaded_file: Any) -> list[tuple[str, str]]:
     base_name = Path(uploaded_file.name).stem
     results: list[tuple[str, str]] = []
 
-    for row_idx, row in df.iterrows():
-        # 跳过全空行
-        non_null = row.dropna()
-        if non_null.empty or all(str(v).strip() in ("", "nan", "None") for v in row.values):
+    def _row_to_text(row: Any) -> str | None:
+        cleaned = {k: str(v).strip() for k, v in row.items() if str(v).strip() not in ("", "nan", "None")}
+        return "\n".join(f"{k}: {v}" for k, v in cleaned.items()) if cleaned else None
+
+    for row_idx, text_content in enumerate(df.apply(_row_to_text, axis=1), start=1):
+        if text_content is None or not text_content:
             continue
-
-        # 格式化为 "列名: 值" 文本
-        lines: list[str] = []
-        for col_name, value in row.items():
-            val_str = str(value).strip()
-            if val_str in ("", "nan", "None"):
-                continue
-            lines.append(f"{col_name}: {val_str}")
-
-        if not lines:
-            continue
-
-        text_content = "\n".join(lines)
-        file_name = f"{base_name}_第{row_idx + 1}行.txt"
-        results.append((file_name, text_content))
+        results.append((f"{base_name}_第{row_idx}行.txt", text_content))
 
     logger.info("Excel 拆分完成: %s → %d 行", uploaded_file.name, len(results))
     return results

--- a/changelog/v26.54/v26.54.11.md
+++ b/changelog/v26.54/v26.54.11.md
@@ -1,5 +1,15 @@
 # v26.54.11
 
+## 修复
+
+### InvoiceParser 正则兼容 pdfplumber 空格
+
+`invoice_recognition/services/invoice_parser.py`：
+
+- 发票号码/开票日期/价税合计正则加入 `\s*` 容忍 pdfplumber 插入的空格
+- 新增 `_NUMBER_FALLBACK_20`：数电发票标签后无号码时从全文宽松匹配 20 位数字
+- `_extract_invoice_number` 添加兜底逻辑，解决印章图片号码无法识别问题
+
 ## 改进
 
 ### 后端嵌套控制流全面重构
@@ -42,3 +52,9 @@
 - 禁止 3 层以上 for 循环嵌套
 - 禁止 for>for 中内层做线性搜索（O(n²)）
 - 强制扁平化手法：dict dispatch / guard clause / 反向索引 / 批量预取 / helper 函数
+
+### Plugins 子模块 CI 自动同步
+
+FachuanPlugins 仓库新增 GitHub Actions workflow（`.github/workflows/sync-main-repo-pointer.yml`）：
+- 当 plugins PR 合并到 main 时，自动在主仓库创建子模块指针更新 PR
+- 使用 `peter-evans/create-pull-request` action + PAT token 实现跨仓库操作

--- a/changelog/v26.54/v26.54.11.md
+++ b/changelog/v26.54/v26.54.11.md
@@ -1,0 +1,44 @@
+# v26.54.11
+
+## 改进
+
+### 后端嵌套控制流全面重构
+
+三轮 opus agent 并行深度扫描 backend 全部模块（apps/ + plugins/），发现 80+ 处嵌套问题，已完成 20 项重构。
+
+#### 已完成的重构（20 项，涉及 22 个文件）
+
+| 文件 | 改动 | 嵌套层数变化 |
+|------|------|-------------|
+| `documents/services/evidence/__init__.py` | 9 层 elif → dict dispatch + importlib | 9→1 |
+| `organization/admin/accountcredential_admin.py` | 提取 `_format_time_ago()` helper | 3→1 |
+| `litigation_ai/mock_trial_flow_service.py` | 提取 `_apply_rule()` + guard clause | 3→2 |
+| `documents/.../execution_request_interest.py` | 7 分支 elif → 7 个 early-return handler | 3→1 |
+| `contracts/.../archive_classifier.py` + `material_mapping.py` | for>for>if → `_search_keyword_mapping()` | 嵌套→helper |
+| `core/cloud_storage/webdav_provider.py` | 4 层 for+4 层 if → `_parse_webdav_properties()` | 8→3 |
+| `organization/views.py` register() | 4 层 → early-return + handler 拆分 | 4→1 |
+| `organization/.../account_credential_admin_service.py` | 3 段重复 if/else → `_finish_login()` | 3→1 |
+| `contracts/.../folder_builder.py` | 3 处重复 temp-file 清理 → `_cleanup_temp_files()` | 5→2 |
+| `contracts/.../pdf_utils.py` | is_a4 重复计算 → `_is_a4()` helper | 4→2 |
+| `contracts/.../archive_query_service.py` | N+1 查询 → `filter(pk__in=...)` 批量预取 | 消除 N+1 |
+| `contracts/admin/contract_admin.py` | 4 层 for → `_client_file_path()` | 4→1 |
+| `workbench/services/batch_service.py` | iterrows+for → `df.apply()` + `_row_to_text()` | 3→1 |
+| `message_hub/models/inbox_message.py` | 3 处 try/except int → `_safe_int()` | 消除重复 |
+| `finance/.../sync_service.py` | for>try>if → `_parse_single_row()` | 4→1 |
+| `client/.../extraction_service.py` | try>for>try>if → `_ocr_single_page()` | 4→1 |
+| `litigation_ai/.../evidence_text_extraction_service.py` | try>if → `_try_ocr_fallback()` | 4→1 |
+| `core/infrastructure/health/_checkers.py` | except>try>if>if → `_collect_db_error_diagnostics()` | 4→1 |
+| `contracts/.../contract_details_assembler.py` | for>for×2 → `_serialize_parties()` + `_serialize_authorities()` | 2→1 |
+| `documents/.../enforcement_applicant_property_clue_service.py` | for>for>for>if → `_collect_clue_lines()` | 4→1 |
+
+#### 审计报告（持续跟踪）
+
+新增 `backend/NESTING_AUDIT.md`，三轮扫描覆盖全部模块，记录剩余 37 项待处理问题（30 中等 + 7 高难度）。
+
+#### 新增 CLAUDE.md 规范
+
+`backend/CLAUDE.md` 新增「严禁多层 if / for 嵌套」章节：
+- 禁止 4 层以上 if 嵌套
+- 禁止 3 层以上 for 循环嵌套
+- 禁止 for>for 中内层做线性搜索（O(n²)）
+- 强制扁平化手法：dict dispatch / guard clause / 反向索引 / 批量预取 / helper 函数


### PR DESCRIPTION
## Summary

三轮 opus agent 并行深度扫描 backend 全部模块，发现 80+ 处嵌套问题，完成 20 项重构，涉及 22 个文件。

### 重构内容（20 项）

| 文件 | 改动 | 嵌套层变化 |
|------|------|-----------|
| `evidence/__init__.py` | 9 层 elif → dict dispatch | 9→1 |
| `accountcredential_admin.py` | 提取 `_format_time_ago()` | 3→1 |
| `mock_trial_flow_service.py` | 提取 `_apply_rule()` | 3→2 |
| `execution_request_interest.py` | 7 分支 → early-return handler | 3→1 |
| `archive_classifier.py` + `material_mapping.py` | for>for>if → helper | 嵌套→helper |
| `webdav_provider.py` | 4层for+4层if → `_parse_webdav_properties()` | 8→3 |
| `views.py` register() | 4 层 → handler 拆分 | 4→1 |
| `account_credential_admin_service.py` | 3段重复 → `_finish_login()` | 3→1 |
| `folder_builder.py` | 3处重复清理 → `_cleanup_temp_files()` | 5→2 |
| `pdf_utils.py` | is_a4 重复 → `_is_a4()` | 4→2 |
| `archive_query_service.py` | N+1 查询 → 批量预取 | 消除 N+1 |
| `contract_admin.py` | 4层for → `_client_file_path()` | 4→1 |
| `batch_service.py` | iterrows+for → `df.apply()` | 3→1 |
| `inbox_message.py` | 3处try/except → `_safe_int()` | 消除重复 |
| `sync_service.py` | for>try>if → `_parse_single_row()` | 4→1 |
| `extraction_service.py` | try>for>try>if → `_ocr_single_page()` | 4→1 |
| `evidence_text_extraction_service.py` | try>if → `_try_ocr_fallback()` | 4→1 |
| `_checkers.py` | except>try>if>if → `_collect_db_error_diagnostics()` | 4→1 |
| `contract_details_assembler.py` | for>for×2 → list comprehension | 2→1 |
| `enforcement_applicant_property_clue_service.py` | for>for>for>if → `_collect_clue_lines()` | 4→1 |

### 其他改动

- **Bug fix**: `invoice_parser.py` 正则兼容 pdfplumber 空格，数电发票兜底提取
- **审计报告**: 新增 `backend/NESTING_AUDIT.md`（三轮扫描覆盖全部模块）
- **CLAUDE.md**: 新增「严禁多层 if / for 嵌套」规范

## Test plan

- [x] 所有修改文件通过 ruff check + format
- [x] 所有修改文件通过 compileall
- [x] mypy-changed 仅报 pre-existing 错误（accountcredential_admin.py ClassVar 类型、mock_trial_flow_service.py API 签名），非本轮引入

🤖 Generated with [Claude Code](https://claude.com/claude-code)