### PR TITLE
refactor: 嵌套扁平化 + 死代码清理（v26.54.13）

### DIFF
--- a/backend/apps/contracts/services/archive/checklist/case_material_sync.py
+++ b/backend/apps/contracts/services/archive/checklist/case_material_sync.py
@@ -181,6 +181,34 @@ def get_case_material_match_map(
     }
 
 
+def _collect_matching_materials(
+    cases: Any, keyword_map: dict[str, list[str]], case_source_items: dict[str, Any]
+) -> tuple[dict[str, list[Any]], dict[str, int]]:
+    """收集所有案件中匹配的材料，返回 (code_to_materials, case_id_for_code)。"""
+    from apps.cases.models import CaseMaterial
+
+    code_to_case_materials: dict[str, list[Any]] = {}
+    case_id_for_code: dict[str, int] = {}
+
+    for case in cases:
+        case_materials = list(
+            CaseMaterial.objects.filter(case=case)
+            .select_related("source_attachment")
+            .only("id", "type_name", "category", "source_attachment_id", "source_attachment__file", "case_id")
+        )
+        for cm in case_materials:
+            matched_code = match_type_name_to_code(cm.type_name, keyword_map)
+            if not matched_code or matched_code not in case_source_items:
+                continue
+            if matched_code not in code_to_case_materials:
+                code_to_case_materials[matched_code] = []
+                case_id_for_code[matched_code] = case.id
+            if case_id_for_code[matched_code] == case.id:
+                code_to_case_materials[matched_code].append(cm)
+
+    return code_to_case_materials, case_id_for_code
+
+
 def sync_case_materials_to_archive(
     contract: Contract,
     archive_item_codes: list[str] | None = None,
@@ -213,27 +241,7 @@ def sync_case_materials_to_archive(
 
     from apps.cases.models import CaseMaterial
 
-    for case in cases:
-        case_materials = list(
-            CaseMaterial.objects.filter(case=case)
-            .select_related("source_attachment")
-            .only(
-                "id",
-                "type_name",
-                "category",
-                "source_attachment_id",
-                "source_attachment__file",
-                "case_id",
-            )
-        )
-        for cm in case_materials:
-            matched_code = match_type_name_to_code(cm.type_name, keyword_map)
-            if matched_code and matched_code in case_source_items:
-                if matched_code not in code_to_case_materials:
-                    code_to_case_materials[matched_code] = []
-                    case_id_for_code[matched_code] = case.id
-                if case_id_for_code[matched_code] == case.id:
-                    code_to_case_materials[matched_code].append(cm)
+    code_to_case_materials, case_id_for_code = _collect_matching_materials(cases, keyword_map, case_source_items)
 
     synced: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []

--- a/backend/apps/contracts/services/archive/learning_service.py
+++ b/backend/apps/contracts/services/archive/learning_service.py
@@ -20,6 +20,32 @@ logger = logging.getLogger(__name__)
 _LEARNED_RULES_PATH = Path(__file__).parent.parent / "contract" / "integrations" / "_learned_rules.py"
 
 
+def _learn_keywords_for_material(
+    archive_category: str,
+    material: Any,
+    keywords: list[str],
+    ambiguous_keys: set[tuple[str, str]],
+) -> tuple[int, int, int]:
+    """学习单个材料的关键词规则，返回 (learned, updated, ambiguous)。"""
+    learned = updated = ambiguous = 0
+    for kw in keywords:
+        if (archive_category, kw) in ambiguous_keys:
+            ambiguous += 1
+            continue
+        rule, created = ArchiveClassificationRule.objects.get_or_create(
+            archive_category=archive_category,
+            filename_keyword=kw,
+            defaults={"archive_item_code": material.archive_item_code, "source": "learned", "hit_count": 1},
+        )
+        if created:
+            learned += 1
+        elif rule.archive_item_code == material.archive_item_code:
+            rule.hit_count += 1
+            rule.save(update_fields=["hit_count", "updated_at"])
+            updated += 1
+    return learned, updated, ambiguous
+
+
 class ArchiveLearningService:
     """归档分类学习服务。
 
@@ -108,38 +134,11 @@ class ArchiveLearningService:
                 continue
 
             has_ambiguous = False
-            for kw in keywords:
-                if (archive_category, kw) in ambiguous_keys:
-                    ambiguous += 1
-                    has_ambiguous = True
-                    continue
-
-                rule, created = ArchiveClassificationRule.objects.get_or_create(
-                    archive_category=archive_category,
-                    filename_keyword=kw,
-                    defaults={
-                        "archive_item_code": material.archive_item_code,
-                        "source": "learned",
-                        "hit_count": 1,
-                    },
-                )
-
-                if created:
-                    learned += 1
-                    logger.info(
-                        "archive_rule_learned",
-                        extra={
-                            "archive_category": archive_category,
-                            "keyword": kw,
-                            "archive_item_code": material.archive_item_code,
-                        },
-                    )
-                else:
-                    # 已有规则，如果目标一致则累加命中次数，否则不覆盖
-                    if rule.archive_item_code == material.archive_item_code:
-                        rule.hit_count += 1
-                        rule.save(update_fields=["hit_count", "updated_at"])
-                        updated += 1
+            l, u, a = _learn_keywords_for_material(archive_category, material, keywords, ambiguous_keys)
+            learned += l
+            updated += u
+            ambiguous += a
+            has_ambiguous = a > 0
 
             if has_ambiguous and not any((archive_category, kw) not in ambiguous_keys for kw in keywords):
                 skipped += 1

--- a/backend/apps/contracts/services/archive/supervision_card_extractor.py
+++ b/backend/apps/contracts/services/archive/supervision_card_extractor.py
@@ -57,42 +57,44 @@ class SupervisionCardExtractor:
 
         # 2. 逐个检查PDF文件的最后2页
         for material in pdf_materials:
-            file_path = material.file_path
-            if not file_path:
-                continue
-
-            # 构建完整路径
-            full_path = self._resolve_file_path(file_path)
-            if not full_path or not full_path.exists():
-                continue
-
-            if not str(full_path).lower().endswith(".pdf"):
-                continue
-
-            try:
-                result = self._check_pdf_for_supervision_card(full_path)
-                if result["found"]:
-                    # 3. 提取监督卡页面
-                    extracted_pdf = self._extract_page(full_path, result["page_number"])
-                    if extracted_pdf:
-                        # 4. 保存为新的 FinalizedMaterial
-                        extracted_material = self._save_extracted_card(
-                            contract=contract,
-                            pdf_content=extracted_pdf,
-                            original_material=material,
-                            page_number=result["page_number"],
-                        )
-                        return {
-                            "found": True,
-                            "page_number": result["page_number"],
-                            "material_id": extracted_material.id if extracted_material else None,
-                            "error": None,
-                        }
-            except Exception as e:
-                logger.warning("检测监督卡失败: %s", e, extra={"file_path": str(full_path)})
-                continue
+            result = self._try_extract_from_material(material, contract)
+            if result is not None:
+                return result
 
         return {"found": False, "page_number": None, "material_id": None, "error": "未在合同PDF末尾检测到监督卡"}
+
+    def _try_extract_from_material(
+        self, material: Any, contract: Any
+    ) -> dict[str, Any] | None:  # pragma: no cover  # type: ignore[no-untyped-def]
+        """尝试从单个材料中检测并提取监督卡，成功返回结果 dict，失败返回 None。"""
+        file_path = material.file_path
+        if not file_path:
+            return None
+        full_path = self._resolve_file_path(file_path)
+        if not full_path or not full_path.exists() or not str(full_path).lower().endswith(".pdf"):
+            return None
+        try:
+            result = self._check_pdf_for_supervision_card(full_path)
+            if not result["found"]:
+                return None
+            extracted_pdf = self._extract_page(full_path, result["page_number"])
+            if not extracted_pdf:
+                return None
+            extracted_material = self._save_extracted_card(
+                contract=contract,
+                pdf_content=extracted_pdf,
+                original_material=material,
+                page_number=result["page_number"],
+            )
+            return {
+                "found": True,
+                "page_number": result["page_number"],
+                "material_id": extracted_material.id if extracted_material else None,
+                "error": None,
+            }
+        except Exception as e:
+            logger.warning("检测监督卡失败: %s", e, extra={"file_path": str(full_path)})
+            return None
 
     def _check_pdf_for_supervision_card(self, pdf_path: Path) -> dict[str, Any]:  # pragma: no cover
         """

--- a/backend/apps/core/services/bound_folder_scan_service.py
+++ b/backend/apps/core/services/bound_folder_scan_service.py
@@ -375,18 +375,7 @@ class BoundFolderScanService:
                 self._notify(progress_callback, "extracting", progress, current_file)
                 try:
                     file_bytes = scanner.read_file_bytes(scanned)
-                    import os
-                    import tempfile
-
-                    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
-                        tmp.write(file_bytes)
-                        tmp_path = tmp.name
-                    try:
-                        extraction = self._text_extraction_service.extract_text(tmp_path)
-                        extraction_method = extraction.extraction_method if extraction.success else "none"
-                        text_excerpt = (extraction.text or "")[: self._MAX_TEXT_EXCERPT]
-                    finally:
-                        os.unlink(tmp_path)
+                    extraction_method, text_excerpt = self._extract_text_from_bytes(file_bytes)
                 except Exception:
                     logger.exception("scan_extract_failed_cloud", extra={"path": scanned.as_posix})
 
@@ -445,6 +434,22 @@ class BoundFolderScanService:
         return deduped
 
     @staticmethod
+    def _extract_text_from_bytes(self, file_bytes: bytes) -> tuple[str, str]:
+        """从 PDF 字节流中提取文本，返回 (extraction_method, text_excerpt)。"""
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(file_bytes)
+            tmp_path = tmp.name
+        try:
+            extraction = self._text_extraction_service.extract_text(tmp_path)
+            method = extraction.extraction_method if extraction.success else "none"
+            text = (extraction.text or "")[: self._MAX_TEXT_EXCERPT]
+            return method, text
+        finally:
+            os.unlink(tmp_path)
+
     def _extract_parent_folder_hint_cloud(scanned: Any, scan_root: str) -> str:
         """Extract parent folder hint from cloud file path."""
         from pathlib import PurePosixPath

--- a/backend/apps/core/services/bound_folder_scan_service.py
+++ b/backend/apps/core/services/bound_folder_scan_service.py
@@ -433,7 +433,6 @@ class BoundFolderScanService:
         deduped.sort(key=lambda x: x["scanned"].as_posix)
         return deduped
 
-    @staticmethod
     def _extract_text_from_bytes(self, file_bytes: bytes) -> tuple[str, str]:
         """从 PDF 字节流中提取文本，返回 (extraction_method, text_excerpt)。"""
         import os
@@ -450,6 +449,7 @@ class BoundFolderScanService:
         finally:
             os.unlink(tmp_path)
 
+    @staticmethod
     def _extract_parent_folder_hint_cloud(scanned: Any, scan_root: str) -> str:
         """Extract parent folder hint from cloud file path."""
         from pathlib import PurePosixPath

--- a/backend/apps/documents/services/external_template/filling_service.py
+++ b/backend/apps/documents/services/external_template/filling_service.py
@@ -37,6 +37,17 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+def _set_paragraph_runs(paragraph: Any, value: str) -> None:  # type: ignore[no-untyped-def]
+    """保留首 run 格式写入文本，清空后续 run。"""
+    runs = paragraph.runs
+    if not runs:
+        paragraph.add_run(value)
+        return
+    runs[0].text = value
+    for run in runs[1:]:
+        run.text = ""
+
+
 @dataclass(frozen=True)
 class FillPreviewItem:
     """填充预览项"""
@@ -206,9 +217,7 @@ class FillingService:
         filled_by: Any = None,
     ) -> Any:  # pragma: no cover
         """异步版本：文件 I/O + docx 操作在线程池中执行。"""
-        return await asyncio.to_thread(
-            self.fill_template, template_id, case_id, party_id, custom_values, filled_by
-        )
+        return await asyncio.to_thread(self.fill_template, template_id, case_id, party_id, custom_values, filled_by)
 
     def fill_template(
         self,
@@ -374,41 +383,19 @@ class FillingService:
             if locator_type == "paragraph":
                 para_index: int = locator.get("paragraph_index", 0)
                 if para_index >= len(doc.paragraphs):
-                    logger.warning(
-                        "段落索引越界: index=%d, total=%d",
-                        para_index,
-                        len(doc.paragraphs),
-                    )
+                    logger.warning("段落索引越界: index=%d, total=%d", para_index, len(doc.paragraphs))
                     return False
-
                 paragraph = doc.paragraphs[para_index]
-                runs = paragraph.runs
-                if not runs:
-                    # 无 run 时直接添加
-                    paragraph.add_run(value)
-                    return True
-
-                # 保留第一个 run 的格式，替换文本
-                first_run = runs[0]
-                first_run.text = value
-                # 清除后续 run 的文本
-                for run in runs[1:]:
-                    run.text = ""
+                _set_paragraph_runs(paragraph, value)
                 return True
 
             elif locator_type == "table_cell":
                 table_index: int = locator.get("table_index", 0)
                 row: int = locator.get("row", 0)
                 col: int = locator.get("col", 0)
-
                 if table_index >= len(doc.tables):
-                    logger.warning(
-                        "表格索引越界: index=%d, total=%d",
-                        table_index,
-                        len(doc.tables),
-                    )
+                    logger.warning("表格索引越界: index=%d, total=%d", table_index, len(doc.tables))
                     return False
-
                 table = doc.tables[table_index]
                 if row >= len(table.rows) or col >= len(table.columns):
                     logger.warning(
@@ -419,18 +406,9 @@ class FillingService:
                         len(table.columns),
                     )
                     return False
-
                 cell = table.cell(row, col)
-                # 写入单元格第一个段落
                 if cell.paragraphs:
-                    paragraph = cell.paragraphs[0]
-                    runs = paragraph.runs
-                    if not runs:
-                        paragraph.add_run(value)
-                    else:
-                        runs[0].text = value
-                        for run in runs[1:]:
-                            run.text = ""
+                    _set_paragraph_runs(cell.paragraphs[0], value)
                 else:
                     cell.text = value
                 return True
@@ -596,9 +574,7 @@ class FillingService:
         filled_by: Any = None,
     ) -> Any:  # pragma: no cover
         """异步版本：批量文件 I/O 在线程池中执行。"""
-        return await asyncio.to_thread(
-            self.batch_fill, case_id, template_ids, party_ids, custom_values, filled_by
-        )
+        return await asyncio.to_thread(self.batch_fill, case_id, template_ids, party_ids, custom_values, filled_by)
 
     def batch_fill(
         self,

--- a/backend/apps/documents/services/external_template/filling_service.py
+++ b/backend/apps/documents/services/external_template/filling_service.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def _set_paragraph_runs(paragraph: Any, value: str) -> None:  # type: ignore[no-untyped-def]
+def _set_paragraph_runs(paragraph: Any, value: str) -> None:
     """保留首 run 格式写入文本，清空后续 run。"""
     runs = paragraph.runs
     if not runs:

--- a/backend/apps/documents/services/generation/folder_generation_service.py
+++ b/backend/apps/documents/services/generation/folder_generation_service.py
@@ -36,6 +36,40 @@ class DocumentPlacement:
     supplementary_agreement: Any | None = None  # 补充协议实例(仅补充协议模板时有值)
 
 
+def _collect_single_file(
+    target_path: str,
+    file_field: Any,
+    path_resolver: Any,
+    documents: list[Any],
+    name_prefix: str | None,
+    logger: Any,
+    label: str,
+    fallback_name: str = "",
+) -> None:
+    """读取单个文件字段并追加到 documents 列表。"""
+    if not file_field:
+        return
+    try:
+        raw = str(getattr(file_field, "path", file_field) or "")
+        if not raw:
+            return
+        abs_path = path_resolver(raw) if callable(path_resolver) else Path(raw)
+        if not abs_path.exists():
+            return
+        content = abs_path.read_bytes()
+        if name_prefix:
+            suffix = abs_path.suffix or ".pdf"
+            filename = f"{name_prefix}{suffix}"
+        else:
+            filename = abs_path.name
+            if not filename.lower().endswith(".pdf"):
+                filename = f"{filename}.pdf"
+        documents.append((target_path, content, filename))
+        logger.info("案件文件夹 - %s已添加: %s → %s", label, filename, target_path)
+    except (OSError, ValueError) as e:
+        logger.warning("读取%s失败: %s - %s", label, fallback_name or file_field, e)
+
+
 class FolderGenerationService:
     """
     文件夹生成服务
@@ -695,71 +729,48 @@ class FolderGenerationService:
         for identity_path in identity_paths:
             for party in case.parties.select_related("client"):
                 for identity_doc in party.client.identity_docs.all():
-                    if not identity_doc.file_path:
-                        continue
-                    try:
-                        abs_path = to_media_abs(identity_doc.file_path)
-                        if abs_path.exists():
-                            content = abs_path.read_bytes()
-                            suffix = abs_path.suffix
-                            # 证件类型显示名称：去掉 "/" 避免路径问题，统一改为 "法定代表人身份证"
-                            doc_type_display = (
-                                identity_doc.get_doc_type_display()
-                                .replace("/", "身份证")
-                                .replace("负责人身份证", "法定代表人身份证")
-                            )
-                            filename = f"{party.client.name}_{doc_type_display}{suffix}"
-                            documents.append((identity_path, content, filename))
-                            logger.info(
-                                "案件文件夹 - 证件材料已添加: %s → %s",
-                                filename,
-                                identity_path,
-                            )
-                    except (OSError, ValueError) as e:
-                        logger.warning("读取证件文件失败: %s - %s", identity_doc.file_path, e)
+                    doc_type_display = (
+                        identity_doc.get_doc_type_display()
+                        .replace("/", "身份证")
+                        .replace("负责人身份证", "法定代表人身份证")
+                    )
+                    _collect_single_file(
+                        identity_path,
+                        identity_doc.file_path,
+                        to_media_abs,
+                        documents,
+                        f"{party.client.name}_{doc_type_display}",
+                        logger,
+                        "证件材料",
+                    )
 
         # 6. 放入律师执业证 → "委托材料"文件夹
         for attorney_path in attorney_paths:
             for assignment in case.assignments.select_related("lawyer"):
                 lawyer = assignment.lawyer
-                if not lawyer.license_pdf:
-                    continue
-                try:
-                    # license_pdf 是 FileField，.path 就是完整的文件系统路径
-                    abs_path = Path(lawyer.license_pdf.path)
-                    if abs_path.exists():
-                        content = abs_path.read_bytes()
-                        filename = f"{lawyer.real_name or lawyer.username}_执业证.pdf"
-                        documents.append((attorney_path, content, filename))
-                        logger.info(
-                            "案件文件夹 - 律师执业证已添加: %s → %s",
-                            filename,
-                            attorney_path,
-                        )
-                except (OSError, ValueError) as e:
-                    logger.warning("读取律师执业证失败: %s - %s", lawyer.username, e)
+                _collect_single_file(
+                    attorney_path,
+                    getattr(lawyer, "license_pdf", None),
+                    lambda p: Path(p),
+                    documents,
+                    f"{lawyer.real_name or lawyer.username}_执业证",
+                    logger,
+                    "律师执业证",
+                )
 
         # 7. 放入已生效案号裁判文书 → "执行依据及生效证明"文件夹
         for exec_path in execution_paths:
             for case_number in case.case_numbers.filter(is_active=True).exclude(document_file=""):
-                if not case_number.document_file:
-                    continue
-                try:
-                    # document_file 是 FileField，使用 .path 获取实际文件路径
-                    abs_path = Path(case_number.document_file.path)
-                    if abs_path.exists():
-                        content = abs_path.read_bytes()
-                        filename = abs_path.name
-                        if not filename.lower().endswith(".pdf"):
-                            filename = f"{filename}.pdf"
-                        documents.append((exec_path, content, filename))
-                        logger.info(
-                            "案件文件夹 - 执行依据已添加: %s → %s",
-                            filename,
-                            exec_path,
-                        )
-                except (OSError, ValueError) as e:
-                    logger.warning("读取案号裁判文书失败: %s - %s", case_number.number, e)
+                _collect_single_file(
+                    exec_path,
+                    getattr(case_number, "document_file", None),
+                    lambda p: Path(p),
+                    documents,
+                    None,
+                    logger,
+                    "案号裁判文书",
+                    fallback_name=case_number.number,
+                )
 
         # 8. 若有包裹文件夹，需要将所有文档路径加上包裹前缀
         if wrap_folder_name:

--- a/backend/apps/documents/services/generation/pipeline/preview.py
+++ b/backend/apps/documents/services/generation/pipeline/preview.py
@@ -9,6 +9,22 @@ from typing import Any
 from apps.core.utils.path import Path
 
 
+def _format_value(val: Any) -> str:
+    """格式化变量值为可读文本。"""
+    plain = getattr(val, "plain_text", None)
+    if plain is not None:
+        return str(plain)
+    if isinstance(val, list):
+        lines = []
+        for item in val:
+            if isinstance(item, dict):
+                lines.append(" | ".join(f"{k}: {v}" for k, v in item.items()))
+            else:
+                lines.append(str(item))
+        return "\n".join(lines)
+    return str(val).replace("\a", "\n")
+
+
 class DocxPreviewService:
     """从 docx 模板提取占位符，与上下文匹配后返回键值对预览"""
 
@@ -28,24 +44,11 @@ class DocxPreviewService:
         rows: list[dict[str, str]] = []
         for var in ordered_vars:
             val = context.get(var)
-            if val:
-                # 优先使用 plain_text 属性（如 _ArchiveMaterialsRichText），否则用 str()
-                display_val = getattr(val, "plain_text", None)
-                if display_val is None:
-                    if isinstance(val, list):
-                        # 列表类型：格式化每项的字典为可读文本
-                        lines: list[str] = []
-                        for item in val:
-                            if isinstance(item, dict):
-                                lines.append(" | ".join(f"{k}: {v}" for k, v in item.items()))
-                            else:
-                                lines.append(str(item))
-                        display_val = "\n".join(lines)
-                    else:
-                        display_val = str(val).replace("\a", "\n")
-                rows.append({"key": var, "value": display_val, "status": "ok"})
-            else:
+            if not val:
                 rows.append({"key": var, "value": "", "status": "empty"})
+                continue
+            display_val = _format_value(val)
+            rows.append({"key": var, "value": display_val, "status": "ok"})
         return rows
 
     def _extract_ordered_vars(self, path: str) -> list[str]:  # pragma: no cover

--- a/backend/apps/documents/services/placeholders/litigation/preservation_property_clue_service.py
+++ b/backend/apps/documents/services/placeholders/litigation/preservation_property_clue_service.py
@@ -111,8 +111,17 @@ class PreservationPropertyClueService(BasePlaceholderService):
         if not content:
             return []
 
-        # 按行分割内容
         lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
+
+        result: list[Any] = []
+        for line in lines:
+            if ":" in line:
+                result.append(line)
+            elif ":" in line:
+                result.append(line.replace(":", ":"))
+            else:
+                result.append(line)
+        return result
 
     def _format_clue_items(self, clue_list: list[Any], start_index: int) -> tuple[list[str], int]:
         """格式化线索项列表，返回 (formatted_lines, next_index)。"""
@@ -123,19 +132,6 @@ class PreservationPropertyClueService(BasePlaceholderService):
                 idx += 1
                 lines.append(f"({idx}){content_line}")
         return lines, idx
-
-        result: list[Any] = []
-        for line in lines:
-            if ":" in line:
-                # 保留原始格式
-                result.append(line)
-            elif ":" in line:
-                # 英文冒号转中文冒号
-                result.append(line.replace(":", ":"))
-            else:
-                result.append(line)
-
-        return result
 
     def generate_property_clue_info(self, case_id: int) -> str:
         """

--- a/backend/apps/documents/services/placeholders/litigation/preservation_property_clue_service.py
+++ b/backend/apps/documents/services/placeholders/litigation/preservation_property_clue_service.py
@@ -114,6 +114,16 @@ class PreservationPropertyClueService(BasePlaceholderService):
         # 按行分割内容
         lines = [line.strip() for line in content.strip().split("\n") if line.strip()]
 
+    def _format_clue_items(self, clue_list: list[Any], start_index: int) -> tuple[list[str], int]:
+        """格式化线索项列表，返回 (formatted_lines, next_index)。"""
+        lines: list[str] = []
+        idx = start_index
+        for clue in clue_list:
+            for content_line in self._parse_clue_content(clue.clue_type, clue.content):
+                idx += 1
+                lines.append(f"({idx}){content_line}")
+        return lines, idx
+
         result: list[Any] = []
         for line in lines:
             if ":" in line:
@@ -187,22 +197,12 @@ class PreservationPropertyClueService(BasePlaceholderService):
             # 构建该被申请人的财产线索内容
             clue_parts = [header]
 
+            item_index = 0
             for clue_type_index, (clue_type, clue_list) in enumerate(clues_by_type.items(), 1):
                 type_display = self.CLUE_TYPE_DISPLAY.get(clue_type, clue_type)
-
-                # 二级:阿拉伯数字 + 线索类型
-                type_header = f"{clue_type_index}。{type_display}："
-                clue_parts.append(type_header)
-
-                # 三级:带括号数字 + 具体内容
-                item_index = 0
-                for clue in clue_list:
-                    content_lines = self._parse_clue_content(clue.clue_type, clue.content)
-
-                    if content_lines:
-                        for line in content_lines:
-                            item_index += 1
-                            clue_parts.append(f"({item_index}){line}")
+                clue_parts.append(f"{clue_type_index}。{type_display}：")
+                formatted, item_index = self._format_clue_items(clue_list, item_index)
+                clue_parts.extend(formatted)
 
             # 使用 \a 换行符连接
             result_parts.append("\a".join(clue_parts))

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/case_import/detail_extractor.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/case_import/detail_extractor.py
@@ -24,7 +24,7 @@ _FIELD_RULES: list[tuple[tuple[str, ...], str]] = [
 ]
 
 
-def _apply_customer_field(customer: Any, label: str, value: str) -> None:  # type: ignore[no-untyped-def]
+def _apply_customer_field(customer: Any, label: str, value: str) -> None:
     """根据标签文本设置客户字段。"""
     for keywords, attr in _FIELD_RULES:
         if any(kw in label for kw in keywords):

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/case_import/detail_extractor.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/case_import/detail_extractor.py
@@ -14,6 +14,23 @@ from .models import CaseSearchItem, OACaseCustomerData, OACaseData, OACaseInfoDa
 
 logger = logging.getLogger("apps.oa_filing.jtn_case_import")
 
+# 标签到客户字段的映射规则（顺序优先级）
+_FIELD_RULES: list[tuple[tuple[str, ...], str]] = [
+    (("地址",), "address"),
+    (("电话", "号码"), "phone"),
+    (("身份证",), "id_number"),
+    (("行业",), "industry"),
+    (("法定代表", "负责人", "姓名"), "legal_representative"),
+]
+
+
+def _apply_customer_field(customer: Any, label: str, value: str) -> None:  # type: ignore[no-untyped-def]
+    """根据标签文本设置客户字段。"""
+    for keywords, attr in _FIELD_RULES:
+        if any(kw in label for kw in keywords):
+            setattr(customer, attr, value)
+            return
+
 
 class JtnDetailExtractorMixin:  # pragma: no cover
     """详情页 Tab 数据提取。"""
@@ -102,17 +119,7 @@ class JtnDetailExtractorMixin:  # pragma: no cover
                             for i in range(0, cell_count - 1, 2):
                                 label_cell = (await cells[i].inner_text()).strip()
                                 value_cell = (await cells[i + 1].inner_text()).strip() if i + 1 < cell_count else ""
-
-                                if "地址" in label_cell:
-                                    current_customer.address = value_cell
-                                elif any(x in label_cell for x in ("电话", "号码")):
-                                    current_customer.phone = value_cell
-                                elif "身份证" in label_cell:
-                                    current_customer.id_number = value_cell
-                                elif "行业" in label_cell:
-                                    current_customer.industry = value_cell
-                                elif any(x in label_cell for x in ("法定代表", "负责人", "姓名")):
-                                    current_customer.legal_representative = value_cell
+                                _apply_customer_field(current_customer, label_cell, value_cell)
 
                     except Exception as exc:
                         logger.debug("解析客户行异常: %s", exc)

--- a/backend/apps/workbench/services/chat_service.py
+++ b/backend/apps/workbench/services/chat_service.py
@@ -266,7 +266,7 @@ async def _handle_stream_event(event: Any, event_queue: Any, agent_name: str) ->
             )
     elif isinstance(event, FunctionToolResultEvent):
         result_content = event.content
-        if hasattr(result_content, "content"):
+        if result_content is not None and hasattr(result_content, "content"):
             result_content = result_content.content
         result_str = str(result_content) if result_content else ""
         await event_queue.put(

--- a/backend/apps/workbench/services/chat_service.py
+++ b/backend/apps/workbench/services/chat_service.py
@@ -238,7 +238,7 @@ async def _maybe_create_summary(
 # ─── 主服务 ───────────────────────────────────────────────────────────────────
 
 
-async def _handle_stream_event(event: Any, event_queue: Any, agent_name: str) -> None:  # type: ignore[no-untyped-def]
+async def _handle_stream_event(event: Any, event_queue: Any, agent_name: str) -> None:
     """处理 Agent 流式事件：工具调用/结果/handoff。"""
     if isinstance(event, FunctionToolCallEvent):
         args = event.part.args

--- a/backend/apps/workbench/services/chat_service.py
+++ b/backend/apps/workbench/services/chat_service.py
@@ -238,6 +238,47 @@ async def _maybe_create_summary(
 # ─── 主服务 ───────────────────────────────────────────────────────────────────
 
 
+async def _handle_stream_event(event: Any, event_queue: Any, agent_name: str) -> None:  # type: ignore[no-untyped-def]
+    """处理 Agent 流式事件：工具调用/结果/handoff。"""
+    if isinstance(event, FunctionToolCallEvent):
+        args = event.part.args
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        tool_name = event.part.tool_name
+        await event_queue.put(
+            {
+                "type": "tool_call",
+                "tool_call_id": event.part.tool_call_id or "",
+                "name": tool_name,
+                "arguments": args,
+            }
+        )
+        if "handoff" in tool_name:
+            await event_queue.put(
+                {
+                    "type": "handoff",
+                    "from_agent": agent_name,
+                    "to_agent": tool_name.replace("_handoff_to_", ""),
+                }
+            )
+    elif isinstance(event, FunctionToolResultEvent):
+        result_content = event.content
+        if hasattr(result_content, "content"):
+            result_content = result_content.content
+        result_str = str(result_content) if result_content else ""
+        await event_queue.put(
+            {
+                "type": "tool_result",
+                "tool_call_id": event.result.tool_call_id,
+                "name": event.result.tool_name,
+                "result": result_str[:2000],
+            }
+        )
+
+
 class WorkbenchChatService:
     """工作台对话编排服务"""
 
@@ -471,47 +512,7 @@ class WorkbenchChatService:
                             stream: AgentStream[WorkbenchDeps, str]
                             async with node.stream(run.ctx) as stream:
                                 async for event in stream:
-                                    if isinstance(event, FunctionToolCallEvent):
-                                        # 工具调用（执行前）
-                                        args = event.part.args
-                                        if isinstance(args, str):
-                                            try:
-                                                args = json.loads(args)
-                                            except (json.JSONDecodeError, TypeError):
-                                                pass
-                                        tool_name = event.part.tool_name
-                                        await event_queue.put(
-                                            {
-                                                "type": "tool_call",
-                                                "tool_call_id": event.part.tool_call_id or "",
-                                                "name": tool_name,
-                                                "arguments": args,
-                                            }
-                                        )
-                                        # 检测 handoff 工具调用
-                                        if "handoff" in tool_name:
-                                            target = tool_name.replace("_handoff_to_", "")
-                                            await event_queue.put(
-                                                {
-                                                    "type": "handoff",
-                                                    "from_agent": agent_name,
-                                                    "to_agent": target,
-                                                }
-                                            )
-                                    elif isinstance(event, FunctionToolResultEvent):
-                                        # 工具结果
-                                        result_content = event.content
-                                        if hasattr(result_content, "content"):
-                                            result_content = result_content.content
-                                        result_str = str(result_content) if result_content else ""
-                                        await event_queue.put(
-                                            {
-                                                "type": "tool_result",
-                                                "tool_call_id": event.result.tool_call_id,
-                                                "name": event.result.tool_name,
-                                                "result": result_str[:2000],
-                                            }
-                                        )
+                                    await _handle_stream_event(event, event_queue, agent_name)
 
                         elif Agent.is_call_tools_node(node):
                             # 工具执行节点：等待完成

--- a/changelog/v26.54/v26.54.13.md
+++ b/changelog/v26.54/v26.54.13.md
@@ -1,0 +1,42 @@
+# v26.54.13
+
+## 改进
+
+### 后端嵌套控制流修复（真实问题 + 轻微问题 + 死代码清理）
+
+对 v26.54.11 中标记的 30 个中等问题进行严格验证（3 个 opus agent 并行审查），筛除 16 个误报后，对剩余 14 个真实/轻微问题逐一修复。
+
+#### 真实问题修复（6 处）
+
+| 文件 | 改动 | 嵌套层变化 |
+|------|------|-----------|
+| `workbench/services/chat_service.py` | 提取 `_handle_stream_event()` | 7→3 |
+| `documents/generation/pipeline/preview.py` | 提取 `_format_value()` + early-continue | 6→2 |
+| `documents/generation/folder_generation_service.py` | 提取 `_collect_single_file()` 消除三段重复 | 5→3 |
+| `contracts/archive/checklist/case_material_sync.py` | 提取 `_collect_matching_materials()` | 4→2 |
+| `contracts/archive/learning_service.py` | 提取 `_learn_keywords_for_material()` | 5→2 |
+| `core/services/bound_folder_scan_service.py` | 提取 `_extract_text_from_bytes()` | 5→2 |
+
+#### 轻微问题修复（4 处）
+
+| 文件 | 改动 |
+|------|------|
+| `preservation_property_clue_service.py` | 提取 `_format_clue_items()` |
+| `contracts/archive/supervision_card_extractor.py` | 提取 `_try_extract_from_material()` |
+| `oa_filing/jtn/case_import/detail_extractor.py` | 提取 `_apply_customer_field()` + `_FIELD_RULES` dict |
+| `documents/external_template/filling_service.py` | 提取 `_set_paragraph_runs()` |
+
+#### Plugins 子模块修复（4 处）
+
+| 文件 | 改动 |
+|------|------|
+| `court_filing_http/party_mixin.py` | 提取 `_find_matching_auto()` |
+| `playwright_filing/party_info_handler.py` | 提取 `_process_single_party()` |
+| `playwright_filing/filing_steps.py` | 提取 `_upload_single_file()` |
+| `message_hub/services/imap/imap_fetcher.py` | 提取 `_process_single_uid()` |
+
+#### 死代码清理
+
+- `captcha_recognizer.py`：删除 `ManualCaptchaRecognizer.arecognize()` 和 `FileBasedCaptchaRecognizer.arecognize()`（合计 -123 行）
+  - 全局搜索 0 处调用，不在抽象接口中，无测试引用，DdddocrRecognizer 也未实现
+  - 同时移除无用的 `import asyncio`


### PR DESCRIPTION
## Summary

对 v26.54.11 嵌套审计中 30 个中等问题进行严格验证（3 个 opus agent 并行），筛除 16 个误报后修复剩余 14 个。

### 真实问题修复（6 处）

| 文件 | 改动 | 层变化 |
|------|------|--------|
| `chat_service.py` | 提取 `_handle_stream_event()` | 7→3 |
| `preview.py` | 提取 `_format_value()` | 6→2 |
| `folder_generation_service.py` | 提取 `_collect_single_file()` 消除三段重复 | 5→3 |
| `case_material_sync.py` | 提取 `_collect_matching_materials()` | 4→2 |
| `learning_service.py` | 提取 `_learn_keywords_for_material()` | 5→2 |
| `bound_folder_scan_service.py` | 提取 `_extract_text_from_bytes()` | 5→2 |

### 轻微问题修复（4 处）

| 文件 | 改动 |
|------|------|
| `preservation_property_clue_service.py` | 提取 `_format_clue_items()` |
| `supervision_card_extractor.py` | 提取 `_try_extract_from_material()` |
| `detail_extractor.py` | 提取 `_apply_customer_field()` + `_FIELD_RULES` dict |
| `filling_service.py` | 提取 `_set_paragraph_runs()` |

### Plugins 子模块

- 4 处轻微嵌套扁平化（party_mixin、party_info_handler、filing_steps、imap_fetcher）
- 删除 `captcha_recognizer.py` 中 `arecognize` 死代码（-123 行）

## 关联 PR

- Plugins 子模块: https://github.com/Lawyer-ray/FachuanPlugins/pull/15（需先合并）

🤖 Generated with [Claude Code](https://claude.com/claude-code)