### PR TITLE
feat: 顾问合同保存时校验标题日期与开始/结束日期一致性

### DIFF
--- a/backend/apps/contracts/admin/contract_admin.py
+++ b/backend/apps/contracts/admin/contract_admin.py
@@ -112,6 +112,24 @@ class ContractAdmin(
 
         def clean(self) -> dict[str, Any]:  # pragma: no cover
             cleaned = super().clean() or {}
+
+            # 顾问合同标题-日期一致性校验
+            try:
+                from apps.contracts.domain.validators import validate_advisor_contract_title_dates
+
+                validate_advisor_contract_title_dates(
+                    case_type=cleaned.get("case_type"),
+                    title=cleaned.get("name"),
+                    start_date=cleaned.get("start_date"),
+                    end_date=cleaned.get("end_date"),
+                )
+            except Exception as exc:
+                from apps.core.exceptions import ValidationException
+
+                if isinstance(exc, ValidationException):
+                    raise forms.ValidationError(str(exc)) from exc
+                logger.exception("顾问合同标题日期校验异常")
+
             try:
                 from apps.contracts.validators import normalize_representation_stages
 

--- a/backend/apps/contracts/domain/validators.py
+++ b/backend/apps/contracts/domain/validators.py
@@ -2,12 +2,161 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
+from datetime import date
 
 from apps.core.exceptions import ValidationException
 from apps.core.models.enums import CaseStage, CaseType
 
 APPLICABLE_TYPES = {CaseType.CIVIL, CaseType.CRIMINAL, CaseType.ADMINISTRATIVE, CaseType.LABOR, CaseType.INTL}
+
+
+# ---------------------------------------------------------------------------
+# 顾问合同标题-日期一致性校验
+# ---------------------------------------------------------------------------
+
+# 完整中文日期: 2026年08月12日 / 2026年8月12日 / 2026年08月 / 2026年8月
+_DATE_FULL_RE = re.compile(r"(\d{4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日")
+
+# "YYYY-YYYY" 或 "YYYY～YYYY" 年度范围（中间可选"年""至"等文字）
+_YEAR_RANGE_RE = re.compile(r"(?<!\d)(\d{4})\s*[-–—~～]\s*(\d{4})(?!\d)")
+
+# 独立四位年份（不在已被 _YEAR_RANGE_RE 匹配的范围内）
+_YEAR_RE = re.compile(r"(?<!\d)(\d{4})(?!\d)")
+
+# 两位年份缩写: 26-27 / 26~27
+_SHORT_YEAR_RANGE_RE = re.compile(r"(?<!\d)(\d{2})\s*[-–—~～]\s*(\d{2})(?!\d)")
+
+
+def _normalize_2digit_year(y: int) -> int:
+    """把两位年份映射到 2000+Y（假设在 2000-2099 范围内）。"""
+    return y + 2000 if y < 100 else y
+
+
+def validate_advisor_contract_title_dates(
+    case_type: str | None,
+    title: str | None,
+    start_date: date | None,
+    end_date: date | None,
+) -> None:
+    """
+    校验常法顾问合同标题中的日期/年度信息是否与开始/结束日期一致。
+
+    只在 case_type == ADVISOR 且标题含可识别日期模式时才校验。
+    不含任何日期信息的标题不做校验。
+
+    Raises:
+        ValidationException: 标题日期与实际日期不匹配时抛出。
+    """
+    if case_type != CaseType.ADVISOR:
+        return
+
+    if not title or not start_date or not end_date:
+        return
+
+    title = title.strip()
+
+    # ---- 1. 提取完整中文日期 ----
+    raw_dates = _DATE_FULL_RE.findall(title)
+    specific_dates: list[tuple[int, int]] = []
+    for m_y, m_m, m_d in raw_dates:
+        try:
+            dt = date(int(m_y), int(m_m), int(m_d))
+        except ValueError:
+            continue
+        specific_dates.append((dt.year * 10000 + dt.month * 100 + dt.day,))
+
+    # ---- 2. 提取年份范围 (优先匹配短横线连接的) ----
+    years: list[int] = []
+
+    short_range = _SHORT_YEAR_RANGE_RE.search(title)
+    if short_range:
+        y1 = _normalize_2digit_year(int(short_range.group(1)))
+        y2 = _normalize_2digit_year(int(short_range.group(2)))
+        years.extend([y1, y2])
+    else:
+        full_range = _YEAR_RANGE_RE.search(title)
+        if full_range:
+            years.extend([int(full_range.group(1)), int(full_range.group(2))])
+
+    # 独立年份（排除已被范围匹配的年份）
+    if not years:
+        seen_spans: list[tuple[int, int]] = []
+        for m in _YEAR_RANGE_RE.finditer(title):
+            seen_spans.append((m.start(), m.end()))
+        for m in _YEAR_RE.finditer(title):
+            if any(s <= m.start() < e for s, e in seen_spans):
+                continue
+            years.append(int(m.group(1)))
+
+    # ---- 3. 没有可校验信息则跳过 ----
+    if not years and not specific_dates:
+        return
+
+    # ---- 4. 如果有完整日期，要求精确匹配 ----
+    if specific_dates:
+        actual_start_int = start_date.year * 10000 + start_date.month * 100 + start_date.day
+        actual_end_int = end_date.year * 10000 + end_date.month * 100 + end_date.day
+
+        found_start: int | None = None
+        found_end: int | None = None
+        for di in sorted(specific_dates):
+            if di[0] <= actual_start_int:
+                found_start = di[0]
+            if found_end is None and di[0] >= actual_start_int:
+                found_end = di[0]
+
+        # 取第一个和最后一个日期
+        all_ints = [d[0] for d in specific_dates]
+        first_int = all_ints[0]
+        last_int = all_ints[-1]
+
+        def _fmt_date_int(v: int) -> str:
+            y, rem = divmod(v, 10000)
+            m, d = divmod(rem, 100)
+            return "%d年%d月%d日" % (y, m, d)
+
+        if first_int != actual_start_int:
+            raise ValidationException(
+                "顾问合同标题中的开始日期（%(title_date)s）与实际开始日期（%(actual_date)s）不一致"
+                % {"title_date": _fmt_date_int(first_int), "actual_date": start_date.strftime("%Y年%m月%d日")},
+                code="ADVISOR_TITLE_DATE_MISMATCH",
+            )
+        if last_int != actual_end_int:
+            raise ValidationException(
+                "顾问合同标题中的结束日期（%(title_date)s）与实际结束日期（%(actual_date)s）不一致"
+                % {"title_date": _fmt_date_int(last_int), "actual_date": end_date.strftime("%Y年%m月%d日")},
+                code="ADVISOR_TITLE_DATE_MISMATCH",
+            )
+        return
+
+    # ---- 5. 只有年份范围时，校验年份是否覆盖实际日期 ----
+    if len(years) >= 2:
+        title_start_year, title_end_year = years[0], years[1]
+        if title_start_year > title_end_year:
+            title_start_year, title_end_year = title_end_year, title_start_year
+
+        if not (start_date.year <= title_start_year and end_date.year >= title_end_year):
+            raise ValidationException(
+                "顾问合同标题年度范围（%(ty_start)s-%(ty_end)s）与实际日期（%(as)s ~ %(ae)s）不匹配"
+                % {
+                    "ty_start": title_start_year,
+                    "ty_end": title_end_year,
+                    "as": start_date.strftime("%Y-%m-%d"),
+                    "ae": end_date.strftime("%Y-%m-%d"),
+                },
+                code="ADVISOR_TITLE_YEAR_MISMATCH",
+            )
+    elif len(years) == 1:
+        # 只有一个年份，检查是否在合同期间内
+        y = years[0]
+        if not (start_date.year <= y <= end_date.year):
+            raise ValidationException(
+                "顾问合同标题中的年份（%(ty)s）不在合同期（%(as)s ~ %(ae)s）范围内"
+                % {"ty": y, "as": start_date.strftime("%Y-%m-%d"), "ae": end_date.strftime("%Y-%m-%d")},
+                code="ADVISOR_TITLE_YEAR_MISMATCH",
+            )
 
 
 def normalize_representation_stages(

--- a/backend/apps/contracts/domain/validators.py
+++ b/backend/apps/contracts/domain/validators.py
@@ -59,13 +59,13 @@ def validate_advisor_contract_title_dates(
 
     # ---- 1. 提取完整中文日期 ----
     raw_dates = _DATE_FULL_RE.findall(title)
-    specific_dates: list[tuple[int, int]] = []
+    specific_dates: list[int] = []
     for m_y, m_m, m_d in raw_dates:
         try:
             dt = date(int(m_y), int(m_m), int(m_d))
         except ValueError:
             continue
-        specific_dates.append((dt.year * 10000 + dt.month * 100 + dt.day,))
+        specific_dates.append(dt.year * 10000 + dt.month * 100 + dt.day)
 
     # ---- 2. 提取年份范围 (优先匹配短横线连接的) ----
     years: list[int] = []
@@ -99,18 +99,8 @@ def validate_advisor_contract_title_dates(
         actual_start_int = start_date.year * 10000 + start_date.month * 100 + start_date.day
         actual_end_int = end_date.year * 10000 + end_date.month * 100 + end_date.day
 
-        found_start: int | None = None
-        found_end: int | None = None
-        for di in sorted(specific_dates):
-            if di[0] <= actual_start_int:
-                found_start = di[0]
-            if found_end is None and di[0] >= actual_start_int:
-                found_end = di[0]
-
-        # 取第一个和最后一个日期
-        all_ints = [d[0] for d in specific_dates]
-        first_int = all_ints[0]
-        last_int = all_ints[-1]
+        first_int = specific_dates[0]
+        last_int = specific_dates[-1]
 
         def _fmt_date_int(v: int) -> str:
             y, rem = divmod(v, 10000)

--- a/backend/apps/contracts/validators.py
+++ b/backend/apps/contracts/validators.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from .domain.validators import normalize_representation_stages
+from .domain.validators import normalize_representation_stages, validate_advisor_contract_title_dates
 
-__all__: list[str] = ["normalize_representation_stages"]
+__all__: list[str] = ["normalize_representation_stages", "validate_advisor_contract_title_dates"]

--- a/backend/tests/ci/unit/test_advisor_title_date_validation.py
+++ b/backend/tests/ci/unit/test_advisor_title_date_validation.py
@@ -1,0 +1,231 @@
+"""Unit tests for validate_advisor_contract_title_dates."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from apps.contracts.domain.validators import validate_advisor_contract_title_dates
+from apps.core.exceptions import ValidationException
+
+# ---------------------------------------------------------------------------
+# 非顾问合同 → 跳过校验
+# ---------------------------------------------------------------------------
+
+
+def test_non_advisor_skipped() -> None:
+    """非顾问合同不做标题日期校验，即使标题/日期明显不匹配也不报错。"""
+    validate_advisor_contract_title_dates(
+        case_type="civil",
+        title="2024-2025年度 某某合同",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 缺少字段 → 跳过校验
+# ---------------------------------------------------------------------------
+
+
+def test_missing_title_skipped() -> None:
+    """没有标题时跳过校验。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title=None,
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+def test_missing_dates_skipped() -> None:
+    """没有日期时跳过校验。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司常法顾问-2026年8月12日至2027年8月11日",
+        start_date=None,
+        end_date=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 标题无日期信息 → 跳过校验
+# ---------------------------------------------------------------------------
+
+
+def test_no_date_in_title_skipped() -> None:
+    """标题中不含任何日期信息时跳过校验。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司常法顾问合同",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 完整中文日期格式
+# ---------------------------------------------------------------------------
+
+
+def test_full_chinese_date_correct() -> None:
+    """标题中的完整中文日期与实际日期完全一致 → 通过。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司常法顾问-2026年8月12日至2027年8月11日",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+def test_full_chinese_date_correct_padded() -> None:
+    """带零填充的日期也能正确解析。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司常法顾问-2026年08月12日至2027年08月11日",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+def test_full_chinese_date_wrong_start() -> None:
+    """标题开始日期比实际早一年 → 报错。"""
+    with pytest.raises(ValidationException, match="开始日期"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="某某公司常法顾问-2025年8月12日至2026年8月11日",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )
+
+
+def test_full_chinese_date_wrong_end() -> None:
+    """标题结束日期与实际不一致 → 报错。"""
+    with pytest.raises(ValidationException, match="结束日期"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="某某公司常法顾问-2026年8月12日至2026年8月11日",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )
+
+
+def test_full_chinese_date_wrong_day() -> None:
+    """年月正确但日期差一天 → 报错。"""
+    with pytest.raises(ValidationException, match="结束日期"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="某某公司常法顾问-2026年8月12日至2027年8月12日",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 年度范围格式
+# ---------------------------------------------------------------------------
+
+
+def test_year_range_dash_correct() -> None:
+    """2026-2027 年度，实际日期跨越 2026~2027 → 通过。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司2026-2027年度常法顾问合同",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+def test_year_range_tilde_correct() -> None:
+    """波浪线分隔的年份范围也能识别。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司2026～2027年度常法顾问合同",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+def test_year_range_wrong_past() -> None:
+    """年份范围是过去年度（2024-2025），但实际日期是 2026~2027 → 报错。"""
+    with pytest.raises(ValidationException, match="年度范围"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="某某公司2024-2025年度常法顾问合同",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )
+
+
+def test_year_range_wrong_offset() -> None:
+    """年份范围偏移一年（2025-2026），但实际是 2026~2027 → 报错。"""
+    with pytest.raises(ValidationException, match="年度范围"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="某某公司2025-2026年度常法顾问合同",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )
+
+
+def test_year_range_cross_year_contract() -> None:
+    """跨年合同（从 2025 年底到 2027 年初），标题 2025-2027 → 通过。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司2025-2027年度常法顾问合同",
+        start_date=date(2025, 12, 1),
+        end_date=date(2027, 1, 31),
+    )
+
+
+def test_year_range_swapped_order() -> None:
+    """标题年份范围倒序（2027-2026），但实际日期 2026~2027 → 自动交换，通过。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司2027-2026年度常法顾问合同",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 短横线年份缩写 (26-27)
+# ---------------------------------------------------------------------------
+
+
+def test_short_year_range_correct() -> None:
+    """两位年份缩写 26-27 正确解析为 2026-2027。"""
+    validate_advisor_contract_title_dates(
+        case_type="advisor",
+        title="某某公司26-27年度常法顾问合同",
+        start_date=date(2026, 8, 12),
+        end_date=date(2027, 8, 11),
+    )
+
+
+def test_short_year_range_wrong() -> None:
+    """两位年份缩写 24-25 与实际 2026~2027 不匹配 → 报错。"""
+    with pytest.raises(ValidationException, match="年度范围"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="某某公司24-25年度常法顾问合同",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 完整日期优先于年份范围
+# ---------------------------------------------------------------------------
+
+
+def test_both_full_date_and_year_range_full_date_wrong() -> None:
+    """标题同时含完整日期和年份范围时，以完整日期为准（完整日期错 → 报错）。"""
+    with pytest.raises(ValidationException, match="开始日期"):
+        validate_advisor_contract_title_dates(
+            case_type="advisor",
+            title="2026-2027年度常法顾问-2025年8月12日至2026年8月11日",
+            start_date=date(2026, 8, 12),
+            end_date=date(2027, 8, 11),
+        )

--- a/changelog/v26.54/v26.54.14.md
+++ b/changelog/v26.54/v26.54.14.md
@@ -1,0 +1,41 @@
+# v26.54.14
+
+## feat: 顾问合同保存时校验标题日期与开始/结束日期一致性
+
+### 背景
+
+顾问合同（常法顾问）的标题通常包含合同期的日期信息，如"XX公司常法顾问-2026年8月12日至2027年8月11日"或"XX公司2026-2027年度常法顾问合同"。此前保存时没有任何校验，容易出现标题年度与实际日期不一致的错误。
+
+### 改动内容
+
+**新增验证函数** `validate_advisor_contract_title_dates()`
+- 位于 `backend/apps/contracts/domain/validators.py`
+- 仅在 `case_type == "advisor"` 时触发，其他合同类型不受影响
+
+**Admin 表单集成**
+- 在 `ContractAdminForm.clean()` 中调用验证（`backend/apps/contracts/admin/contract_admin.py`）
+- 保存时实时拦截，标题日期与实际日期不匹配时阻止保存并提示错误
+
+**支持的标题日期格式**
+
+| 格式 | 示例 |
+|---|---|
+| 完整中文日期 | `2026年8月12日至2027年8月11日` |
+| 带零填充 | `2026年08月12日至2027年08月11日` |
+| 年度范围（横线） | `2026-2027` / `2026～2027` |
+| 年份缩写 | `26-27` |
+
+**校验规则**
+
+- **完整中文日期**：要求标题中的起止日期与 `start_date` / `end_date` 精确匹配
+- **年度范围**：要求标题年份覆盖实际合同期间（如 `2026-2027` 则 `start_date.year ≤ 2026` 且 `end_date.year ≥ 2027`）
+- **无日期信息**：跳过校验（不影响标题不含日期的合同）
+
+### 涉及文件
+
+| 文件 | 变更 |
+|---|---|
+| `backend/apps/contracts/domain/validators.py` | 新增验证函数（+149 行） |
+| `backend/apps/contracts/admin/contract_admin.py` | clean() 中调用验证（+18 行） |
+| `backend/apps/contracts/validators.py` | 更新 re-export（+2 行） |
+| `backend/tests/ci/unit/test_advisor_title_date_validation.py` | 新增 18 个单元测试（+231 行） |


### PR DESCRIPTION
## 背景

顾问合同（常法顾问）的标题通常包含合同期日期信息，如 `XX公司常法顾问-2026年8月12日至2027年8月11日` 或 `XX公司2026-2027年度常法顾问合同`。此前保存时没有校验，容易出现标题与实际日期不一致的错误。

## 改动

新增 `validate_advisor_contract_title_dates()`，在 `ContractAdminForm.clean()` 中调用，保存时实时拦截。

**触发条件：** `case_type == "advisor"` 且标题含可识别日期信息

**支持的格式：**

| 格式 | 示例 |
|---|---|
| 完整中文日期 | `2026年8月12日至2027年8月11日` |
| 带零填充 | `2026年08月12日至2027年08月11日` |
| 年度范围（横线） | `2026-2027` / `2026～2027` |
| 年份缩写 | `26-27` |

**校验规则：**
- 完整中文日期 → 要求精确匹配 start_date / end_date
- 年度范围 → 要求年份覆盖实际合同期间
- 标题无日期信息 → 跳过校验
- 非顾问合同 → 跳过校验

## 涉及文件

| 文件 | 变更 |
|---|---|
| `backend/apps/contracts/domain/validators.py` | 新增验证函数 |
| `backend/apps/contracts/admin/contract_admin.py` | clean() 中调用验证 |
| `backend/apps/contracts/validators.py` | 更新 re-export |
| `backend/tests/ci/unit/test_advisor_title_date_validation.py` | 新增 18 个单元测试 |

## 测试

- ✅ ruff check 通过
- ✅ mypy 通过（changed files）
- ✅ 18 个单元测试全部通过