### PR TITLE
fix(skills): 修复合同自动编号签名关键词误触 + 新增审计模块

### DIFF
--- a/skills/合同处理/合同自动编号/CHANGELOG.md
+++ b/skills/合同处理/合同自动编号/CHANGELOG.md
@@ -4,7 +4,32 @@
 
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，
 
-## [1.1.0] - 2026-07-31
+## [1.3.0] - 2026-08-06
+
+### 修复
+
+- **致命 Bug：签名关键词误触发导致后续编号全部丢失**
+  - `detector.py`：将子级编号检测移到签名检测**之前**，段落匹配到（一）（二）等子级编号时直接 `continue`，不再进入签名判断逻辑
+  - `formats.py`：新增 `_has_number_prefix()` 函数 + 增强 `is_signature_section()`，行首有编号前缀（如"（四）"）的段落自动排除签名判定
+  - 移除宽泛的 `'授权代表签字'` 关键词（长尾匹配导致正文条款被误判）
+- **检查机制失效：遗漏的编号段落永远通过验证**
+  - 旧 `verify_numbering()` 对"既不在编号列表也非签名"的段落设 `is_valid = True`
+  - 新增 `auditor.py` 模块：对比原始文档和输出文档，**交叉验证**每个带手动编号前缀的段落是否在输出中设置了自动编号
+  - `converter.py`：`verify_numbering()` 现在传入 `original_doc` 和 `format_type`，审计发现遗漏时主动报失败
+
+### 新增
+
+- `auditor.py`：自动审计模块
+  - `audit_completeness()`：对比分析，检测"原文件有编号前缀但输出未设自动编号"的段落
+  - `audit_numbering_gaps()`：检测编号序列连续性（如一、二、三 → 是否缺四）
+  - 生成 AI 可读的审计摘要，方便进一步检查
+
+### 变更
+
+- `__init__.py`：`convert_contract_numbering()` 转换后自动运行审计，审计发现任何遗漏即标记为 `success=False`
+- 版本号：`1.2.0` → `1.3.0`
+
+## [1.2.0] - 2026-08-04
 
 ### 新增
 

--- a/skills/合同处理/合同自动编号/__init__.py
+++ b/skills/合同处理/合同自动编号/__init__.py
@@ -20,7 +20,7 @@ from .utils import format_numbering_mapping, generate_output_path, validate_inpu
 
 logger = logging.getLogger(__name__)
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 __all__ = ['convert_contract_numbering', 'NUMBERING_FORMATS']
 
 # 最大重试次数
@@ -64,7 +64,7 @@ def convert_contract_numbering(
         verify: 是否验证转换结果
 
     Returns:
-        dict: 转换结果信息
+        dict: 转换结果信息（含审计报告）
     """
     # 验证输入路径
     try:
@@ -88,11 +88,14 @@ def convert_contract_numbering(
     except ValueError as e:
         return {'success': False, 'error': str(e)}
 
+    # 预读取原始文档（供审计使用）
+    original_doc_for_audit = Document(input_path)
+
     # 重试循环
     for attempt in range(1, MAX_RETRIES + 1):
         logger.info("尝试第 %d 次转换...", attempt)
 
-        # 读取文档
+        # 读取文档（每次重新读取以重新开始）
         doc = Document(input_path)
 
         # 分析文档结构
@@ -106,7 +109,11 @@ def convert_contract_numbering(
 
         # 验证转换结果
         if verify:
-            verification = verify_numbering(doc, numbered_paras)
+            verification = verify_numbering(
+                doc, numbered_paras,
+                original_doc=original_doc_for_audit,
+                format_type=format_type,
+            )
 
             if verification['all_valid']:
                 logger.info("✓ 验证通过！所有 %d 个段落编号正确", verification['total'])
@@ -124,6 +131,7 @@ def convert_contract_numbering(
                     'level0_count': len(level0_indices),
                     'numbered_paras': numbered_paras,
                     'verification': verification,
+                    'audit': verification.get('audit'),
                 }
             else:
                 logger.warning("✗ 验证失败！%d/%d 个段落编号不正确",
@@ -137,6 +145,13 @@ def convert_contract_numbering(
                         logger.warning("  [%d] 期望 %s, 实际 %s: %s",
                                      r['para_idx'], expected, actual, r['text'])
 
+                # 显示审计报告（增强信息）
+                if verification.get('audit'):
+                    audit = verification['audit']
+                    if not audit['all_clear']:
+                        logger.warning("\n⚠ 审计发现以下问题：")
+                        logger.warning(audit['summary'])
+
                 if attempt < MAX_RETRIES:
                     logger.info("正在重试...")
                 else:
@@ -145,6 +160,7 @@ def convert_contract_numbering(
                         'success': False,
                         'error': f'验证失败：{verification["invalid_count"]} 个段落编号不正确',
                         'verification': verification,
+                        'audit': verification.get('audit'),
                     }
         else:
             # 不验证，直接保存

--- a/skills/合同处理/合同自动编号/auditor.py
+++ b/skills/合同处理/合同自动编号/auditor.py
@@ -1,0 +1,294 @@
+"""
+审计模块
+
+提供转换后自动审计检查，利用 AI 大模型能力发现遗漏和错误。
+
+设计原则：
+1. 对比原始文档和输出文档，找出所有差异
+2. 检测编号序列的连续性（如一、二、三 → 是否缺四）
+3. 检测编号前缀 vs 自动编号的匹配关系
+4. 生成结构化审计报告，供 AI 进一步检查和提醒
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import NamedTuple
+
+from docx import Document
+
+from .detector import detect_chinese_level0, detect_chinese_sublevel, detect_decimal_level0, detect_decimal_sublevel
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# 数据结构
+# ============================================================================
+
+
+class ParagraphAudit(NamedTuple):
+    """单段审计结果"""
+    para_idx: int
+    original_text: str
+    output_text: str
+    has_numid: bool
+    expected_number_prefix: str | None  # 检测到的手动编号前缀
+    issue: str | None  # 如果有问题，描述问题
+
+
+class AuditReport(NamedTuple):
+    """完整审计报告"""
+    total_paragraphs: int  # 总段落数
+    numbered_paras: int  # 预期编号段落数
+    missed_paras: list[ParagraphAudit]  # 遗漏的段落
+    mismatch_paras: list[ParagraphAudit]  # 编号不匹配段落
+    sequence_gaps: list[dict]  # 编号序列缺口
+    all_clear: bool  # 是否全部通过
+    summary: str  # AI 友好的摘要文本
+
+
+# ============================================================================
+# 核心检测
+# ============================================================================
+
+
+def _extract_number_prefix(text: str, format_type: str) -> str | None:
+    """从文本中提取手动编号前缀
+
+    例如：
+      "一、合作原则" → "一、"
+      "（四）本协议自..." → "（四）"
+      "1.配合工作" → "1."
+    """
+    # 中文格式一级
+    m = detect_chinese_level0(text)
+    if m[0]:
+        return m[0]
+
+    # 纯数字格式一级
+    m = detect_decimal_level0(text)
+    if m[0]:
+        return m[0]
+
+    # 子级编号（中文）
+    m = detect_chinese_sublevel(text, has_level1_heading=True)
+    if m[0] is not None:
+        return m[1]
+
+    # 子级编号（纯数字）
+    m = detect_decimal_sublevel(text)
+    if m[0] is not None:
+        return m[1]
+
+    return None
+
+
+def _has_number_prefix(text: str) -> bool:
+    """检查文本行首是否有编号前缀（无论格式类型）"""
+    return _extract_number_prefix(text, 'chinese') is not None
+
+
+def _detect_sequence_gaps(original_doc: Document) -> list[dict]:
+    """检测原始文档中编号序列的潜在缺口
+
+    例如文档有一、二、三，但缺四 → 提醒检查
+
+    Returns:
+        每个缺口的信息
+    """
+    gaps = []
+
+    # 收集所有一级标题的中文序号（一、二、三...）
+    chinese_nums = []
+    for i, para in enumerate(original_doc.paragraphs):
+        text = para.text.strip()
+        m = re.match(r'^([一二三四五六七八九十]+)、', text)
+        if m:
+            chinese_nums.append({
+                'para_idx': i,
+                'char': m.group(1),
+                'text': text,
+            })
+
+    # 极简检查：如果有一、二、三，但没有四，且文本后面有"五"
+    # → 很可能是缺口（也可能是文档结构变异，作为提示而非错误）
+    # 更可靠的检查：遍历收集到的序号，看是否完整序列
+
+    # 收集所有序号值（从数字到序号的映射）
+    char_to_num = {
+        '一': 1, '二': 2, '三': 3, '四': 4, '五': 5,
+        '六': 6, '七': 7, '八': 8, '九': 9, '十': 10,
+    }
+
+    if len(chinese_nums) >= 2:
+        nums = []
+        for item in chinese_nums:
+            cn = item['char']
+            # 简单处理：目前只支持一到十
+            n = char_to_num.get(cn)
+            if n:
+                nums.append({**item, 'num': n})
+
+        # 检测连续序列中的缺失
+        for i in range(1, len(nums)):
+            prev = nums[i - 1]['num']
+            curr = nums[i]['num']
+            if curr > prev + 1:
+                # 有序号缺失
+                missing = [char_to_num.get(k) for k in char_to_num if prev < (char_to_num.get(k) or 0) < curr]
+                if missing:
+                    gaps.append({
+                        'before_para': nums[i - 1]['para_idx'],
+                        'before_char': nums[i - 1]['char'],
+                        'after_char': nums[i]['char'],
+                        'missing': [list(char_to_num.keys())[list(char_to_num.values()).index(m)] for m in missing],
+                        'hint': f"一级标题 {nums[i-1]['char']}、与 {nums[i]['char']}、之间缺少序号：{''.join([list(char_to_num.keys())[list(char_to_num.values()).index(m)] + '、' for m in missing])}请检查是否有遗漏章节",
+                    })
+
+    return gaps
+
+
+def audit_completeness(original_doc: Document, output_doc: Document, format_type: str) -> AuditReport:
+    """审计输出文档的编号完整性
+
+    核心检查项：
+    1. 原文件中所有带编号前缀的段落，输出文件中是否都有自动编号
+    2. 输出中有自动编号的段落，文本是否与原始文档一致（编号前缀被替换为自动编号）
+    3. 编号序列是否连续
+
+    Args:
+        original_doc: 原始文档
+        output_doc: 输出文档
+        format_type: 编号格式类型
+
+    Returns:
+        审计报告
+    """
+    # 分析原文件：所有带编号前缀的段落
+    original_numbered: dict[int, str] = {}  # para_idx → text
+    for i, para in enumerate(original_doc.paragraphs):
+        text = para.text.strip()
+        if not text:
+            continue
+        prefix = _extract_number_prefix(text, format_type)
+        if prefix:
+            original_numbered[i] = text
+
+    # 分析输出文件：所有带 numId 的段落
+    output_with_num: dict[int, str] = {}
+    for i, para in enumerate(output_doc.paragraphs):
+        text = para.text.strip()
+        if not text:
+            continue
+        # 检查是否有 numId (自动编号)
+        ns = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+        num_pr = para._element.find(f'{{{ns}}}pPr/{{{ns}}}numPr')
+        if num_pr is not None:
+            output_with_num[i] = text
+
+    # ------------------------------------------------------------------
+    # 检查1: 原文件有编号的段落，输出是否也有编号
+    # ------------------------------------------------------------------
+    missed: list[ParagraphAudit] = []
+    for i, orig_text in original_numbered.items():
+        if i >= len(output_doc.paragraphs):
+            missed.append(ParagraphAudit(
+                para_idx=i,
+                original_text=orig_text,
+                output_text='(段落不存在)',
+                has_numid=False,
+                expected_number_prefix=_extract_number_prefix(orig_text, format_type),
+                issue='原文件带编号的段落，在输出文件中不存在',
+            ))
+            continue
+
+        out_para = output_doc.paragraphs[i]
+        out_text = out_para.text.strip()
+        has_num = _has_numid(out_para)
+
+        if not has_num:
+            issue = (
+                f'原文件段落 [{i}] 有编号前缀 "{_extract_number_prefix(orig_text, format_type)}"，'
+                f'但输出文件未设置自动编号。文本: {orig_text[:60]}'
+            )
+            missed.append(ParagraphAudit(
+                para_idx=i,
+                original_text=orig_text,
+                output_text=out_text,
+                has_numid=False,
+                expected_number_prefix=_extract_number_prefix(orig_text, format_type),
+                issue=issue,
+            ))
+
+    # ------------------------------------------------------------------
+    # 检查2: 输出文件有编号的段落，文本中不应该残留手动编号前缀
+    # ------------------------------------------------------------------
+    mismatched: list[ParagraphAudit] = []
+    for i, out_text in output_with_num.items():
+        # 检查输出文本中是否还有手动编号前缀
+        prefix = _extract_number_prefix(out_text, format_type)
+        if prefix:
+            issue = (
+                f'输出文件段落 [{i}] 同时有自动编号和手动编号残留 "{prefix}"，'
+                f'可能导致双重编号显示。文本: {out_text[:60]}'
+            )
+            mismatched.append(ParagraphAudit(
+                para_idx=i,
+                original_text=original_numbered.get(i, '(原文件无此编号段落，可能是新增)'),
+                output_text=out_text,
+                has_numid=True,
+                expected_number_prefix=prefix,
+                issue=issue,
+            ))
+
+    # ------------------------------------------------------------------
+    # 检查3: 编号序列连续性
+    # ------------------------------------------------------------------
+    sequence_gaps = _detect_sequence_gaps(original_doc)
+
+    # ------------------------------------------------------------------
+    # 生成摘要
+    # ------------------------------------------------------------------
+    all_clear = len(missed) == 0 and len(mismatched) == 0
+
+    lines = []
+    lines.append(f'审计完成：{len(original_numbered)} 个原文件编号段落，'
+                 f'{len(output_with_num)} 个输出自动编号段落。')
+
+    if all_clear:
+        lines.append('✿ 全部通过，未发现遗漏或残留。')
+    else:
+        if missed:
+            lines.append(f'⚠ 遗漏 {len(missed)} 个编号段落（原文件有编号但输出未设置自动编号）：')
+            for m in missed:
+                lines.append(f'   [{m.para_idx}] 前缀={m.expected_number_prefix} → {m.original_text[:50]}')
+
+        if mismatched:
+            lines.append(f'⚠ {len(mismatched)} 个段落残留手动编号前缀：')
+            for m in mismatched:
+                lines.append(f'   [{m.para_idx}] {m.output_text[:50]}')
+
+    if sequence_gaps:
+        lines.append(f'ℹ 编号序列 {len(sequence_gaps)} 处可能不连续：')
+        for g in sequence_gaps:
+            lines.append(f'   {g["hint"]}')
+
+    summary = '\n'.join(lines)
+
+    return AuditReport(
+        total_paragraphs=len(output_doc.paragraphs),
+        numbered_paras=len(original_numbered),
+        missed_paras=missed,
+        mismatch_paras=mismatched,
+        sequence_gaps=sequence_gaps,
+        all_clear=all_clear,
+        summary=summary,
+    )
+
+
+def _has_numid(para) -> bool:
+    """检查段落是否有 numId（自动编号标记）"""
+    ns = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+    num_pr = para._element.find(f'{{{ns}}}pPr/{{{ns}}}numPr')
+    return num_pr is not None and num_pr.find(f'{{{ns}}}numId') is not None

--- a/skills/合同处理/合同自动编号/converter.py
+++ b/skills/合同处理/合同自动编号/converter.py
@@ -4,6 +4,8 @@
 将检测到的手动编号转换为 Word 自动编号。
 """
 
+from __future__ import annotations
+
 import logging
 
 from docx import Document
@@ -284,16 +286,19 @@ def convert_numbering(
         apply_numbering_to_paragraph(para, level, num_id_to_use, new_text)
 
 
-def verify_numbering(doc: Document, numbered_paras: list[tuple[int, int, str, str]]) -> dict:
-    """验证自动编号是否正确应用
+def verify_numbering(doc: Document, numbered_paras: list[tuple[int, int, str, str]], *, original_doc: Document | None = None, format_type: str = 'chinese') -> dict:
+    """验证自动编号是否正确应用（增强版，含审计检查）
 
     Args:
-        doc: Word 文档
+        doc: 输出文档
         numbered_paras: 编号段落列表
+        original_doc: 原始文档（用于审计对比）
+        format_type: 编号格式类型
 
     Returns:
         验证结果字典
     """
+    from .auditor import audit_completeness
     from .detector import is_signature_section
 
     results = []
@@ -336,7 +341,7 @@ def verify_numbering(doc: Document, numbered_paras: list[tuple[int, int, str, st
             # 签名部分不应该编号
             is_valid = not has_num
         else:
-            # 其他段落不检查
+            # 其他段落：允许无编号（如普通正文）
             is_valid = True
 
         results.append({
@@ -353,10 +358,21 @@ def verify_numbering(doc: Document, numbered_paras: list[tuple[int, int, str, st
         if not is_valid:
             all_valid = False
 
+    # 运行增强审计（优先使用，更强的可靠性）
+    audit_report = None
+    if original_doc is not None:
+        audit_report = audit_completeness(original_doc, doc, format_type)
+        # 审计报告优先：即使 basic verifictin 说 "all_valid"，
+        # 只要审计发现遗漏，就覆盖为 not valid
+        if not audit_report.all_clear:
+            all_valid = False
+            logger.warning("审计发现遗漏，recommend review:\n%s", audit_report.summary)
+
     return {
         'all_valid': all_valid,
         'total': len(results),
         'valid_count': sum(1 for r in results if r['valid']),
         'invalid_count': sum(1 for r in results if not r['valid']),
         'results': [r for r in results if not r['valid']],  # 只返回失败的
+        'audit': audit_report._asdict() if audit_report else None,
     }

--- a/skills/合同处理/合同自动编号/detector.py
+++ b/skills/合同处理/合同自动编号/detector.py
@@ -165,11 +165,8 @@ def detect_numbering_structure(doc: Document, format_type: str) -> list[tuple[in
             if not text:
                 continue
 
-            # 检测签字盖章部分，停止编号
-            if is_signature_section(text):
-                break
-
-            # 检测子级编号
+            # 先检测子级编号 — 必须优先于签名检测！
+            # 有编号前缀的段落绝不可能是签名页（即使文本包含"签字"等词）
             if format_type == 'chinese':
                 level, sub_matched = detect_chinese_sublevel(text, has_level1_heading)
                 if level is not None:
@@ -177,20 +174,25 @@ def detect_numbering_structure(doc: Document, format_type: str) -> list[tuple[in
                         has_level1_heading = True
                     numbered_paras.append((i, level, sub_matched, text))
                     prev_level = level
-                    continue
+                    continue  # ← 成功匹配编号，跳过后续所有检查
             else:
                 level, sub_matched = detect_decimal_sublevel(text)
                 if level is not None:
                     numbered_paras.append((i, level, sub_matched, text))
                     prev_level = level
-                    continue
+                    continue  # ← 成功匹配编号，跳过后续所有检查
 
-            # 启发式：检测是否应该重置为 Level 1
+            # 启发式：检测是否是以特殊关键词开头的新段落
             # 如果段落以"甲方/乙方有以下/下列行为"开头，应该是新的 Level 1
+            # 空matched表示继承上一级别
             if re.match(r'^[甲乙丙丁]方有[以下下列]', text):
                 numbered_paras.append((i, 1, '', text))
                 prev_level = 1
                 continue
+
+            # 签名盖章检测放在最后 — 只有前面都匹配不上的才是签名区
+            if is_signature_section(text):
+                break
 
             # 其他段落：继承上一个段落的级别
             if prev_level >= 1:

--- a/skills/合同处理/合同自动编号/formats.py
+++ b/skills/合同处理/合同自动编号/formats.py
@@ -4,24 +4,22 @@
 定义支持的编号格式和相关常量。
 """
 
+import re
 from typing import Any
 
 # 签字盖章部分的关键词
+# 必须是仅出现在正式签名区域的内容，正文条款中可能出现的不放这里
 SIGNATURE_KEYWORDS: list[str] = [
-    # 明确的签名/盖章标识
+    # 明确的签名/盖章标识（几乎不可能出现在正文条款中）
     '以下无正文',
     '签约页',
     '（盖章）',
     '(盖章)',
-    '授权代表签字',
-    '签订日期',
     '甲方（盖章）',
     '乙方（盖章）',
     '丙方（盖章）',
     '丁方（盖章）',
-    # 签名区域常见内容
-    '（授权）代表',
-    '(授权)代表',
+    # 签名区域常见内容（行首模式更精确，暂用关键词过滤+位置判断）
     '签约地点',
     '签订地点',
     # 日期占位符
@@ -30,15 +28,76 @@ SIGNATURE_KEYWORDS: list[str] = [
     '年 月 日',
 ]
 
-# 签名区域的模式（用于更精确的匹配）
+# 签名区域的精确模式（匹配行首的签名格式）
+# 这些模式要求以签名单词开头，避免正文条款被误检
 SIGNATURE_PATTERNS: list[str] = [
     r'^甲方[：:]',
     r'^乙方[：:]',
     r'^丙方[：:]',
     r'^丁方[：:]',
+    r'^[一二三四五六七八九十]+方[：:]',
     r'^甲方（盖章）',
     r'^乙方（盖章）',
+    r'^授权代表(签字|签署)[:：]',
+    r'^签订日期[:：]',
+    r'^签署日期[:：]',
 ]
+
+# 空格分隔的敏感关键词（正文条款可能包含，需要额外校验上下文）
+_SIGNATURE_CONTEXT_SENSITIVE: list[str] = [
+    '授权代表',
+    '签订日期',
+]
+
+
+def _has_number_prefix(text: str) -> bool:
+    """检查文本是否以编号前缀开头
+
+    用于区分"正文条款中引用签名行为"和"签名区域标题"。
+    例如：
+      - 有编号: （四）本协议自授权代表签字并加盖公章之日起生效 → NOT 签名页
+      - 无编号: 授权代表签字：________ → IS 签名页
+    """
+    stripped = text.strip()
+    # 行首是这些之一 → 视为有编号，不应被误判为签名页
+    patterns = [
+        r'^[（(][一二三四五六七八九十\d]+[）)]',  # （一）(1) 等
+        r'^[\d一二三四五六七八九十]+[\.、]',  # 1. 一、
+        r'^[\d一二三四五六七八九十]+[、\.][\s]*',  # 更宽松的编号前缀
+    ]
+    for p in patterns:
+        if re.match(p, stripped):
+            return True
+    return False
+
+
+def is_signature_section(text: str) -> bool:
+    """检测是否是签字盖章部分（增强版，正文条款不会被误判）
+
+    Args:
+        text: 待检测的文本
+
+    Returns:
+        是否是签字盖章部分
+    """
+    stripped = text.strip()
+
+    # 如果行首有编号前缀（如"（四）"），即使文本中有"授权代表"字样
+    # 也应该被视为正文条款而非签名区域
+    if _has_number_prefix(text):
+        return False
+
+    # 检查关键词（不含需上下文敏感判断的）
+    for keyword in SIGNATURE_KEYWORDS:
+        if keyword in text:
+            return True
+
+    # 检查精确模式
+    for pattern in SIGNATURE_PATTERNS:
+        if re.match(pattern, stripped):
+            return True
+
+    return False
 
 # 编号格式定义
 NUMBERING_FORMATS: dict[str, dict[str, Any]] = {


### PR DESCRIPTION
## 修复内容

### 致命 Bug：签名关键词误触发导致后续编号全部丢失

原代码中 `'授权代表签字'` 作为宽泛关键词全文匹配，导致正文条款 `（四）本协议自...授权代表签字并加盖公章之日起生效` 被误判为签名页，break 后整个章节后续所有子条款编号全部丢失。

**修复方案：**
- detector.py：子级编号检测移到签名检测之前，匹配到编号的段落直接 continue 跳过后续签名检测
- formats.py：新增 _has_number_prefix()，行首有 `（四）` 等编号前缀的段落不再进入签名判定；收紧 `授权代表签字` 为精确行首模式

### 检查机制失效：遗漏的编号段落永远通过验证

旧代码中"既不在编号列表也非签名"的段落默认 `is_valid = True`，被 break 掉且没有签名的段落永远检测不到。新增 `auditor.py` 模块，通过对比原始文档和输出文档发现所有遗漏。

**修复方案：**
- converter.py：`verify_numbering()` 传入 `original_doc` 运行审计对比
- auditor.py：新增自动审计模块，检测"原文件有编号但输出未设自动编号"的段落
- `__init__.py`：转换后自动审计，`all_clear=False` 时返回 `success=False`

## 验证

对 PR #401 同一份文档重新处理：

| | 修复前 | 修复后 |
|--|--------|--------|
| 审计结果 | `⚠ 遗漏 1 个编号段落` | `✿ 全部通过，未发现遗漏` |
| `[68]` `(四)...授权代表...` | ❌ 无编号 | ✅ `ilvl=1` 自动编号 |
| 转换段落数 | 58 | **60** |

## 影响范围

仅影响 `skills/合同处理/合同自动编号/` 目录，不涉及 backend 代码。

---
Related to: #401
