### PR TITLE
fix(skills/合同自动编号): 修复（一）子标题后内容层级平铺 bug + 新增层级结构验证

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "psycopg[binary]==3.3.4",
     # --- HTTP 客户端 ---
     "httpx[http2]==0.28.1",
+    "h2>=4.4.1",
     # --- 异步 I/O ---
     "aiofiles>=24.1.0",
     # --- LLM / AI ---

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1427,6 +1427,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "gunicorn" },
+    { name = "h2" },
     { name = "httpx", extra = ["http2"] },
     { name = "huggingface-hub" },
     { name = "icalendar" },
@@ -1523,6 +1524,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.150.0" },
     { name = "google-auth", specifier = ">=2.35.0" },
     { name = "gunicorn", specifier = "==26.0.0" },
+    { name = "h2", specifier = ">=4.4.1" },
     { name = "httpx", extras = ["http2"], specifier = "==0.28.1" },
     { name = "huggingface-hub", specifier = ">=1.0.0" },
     { name = "icalendar", specifier = ">=7.1.0" },
@@ -2135,15 +2137,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
@@ -2180,11 +2182,11 @@ wheels = [
 
 [[package]]
 name = "hpack"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]

--- a/skills/合同处理/合同自动编号/CHANGELOG.md
+++ b/skills/合同处理/合同自动编号/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 所有对此 skill 的更改都将记录在此文件中。
 
-格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，
+格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0)，
+
+## [1.4.0] - 2026-08-07
+
+### 修复
+
+- **层级检测 Bug：（一）子标题后的内容段落全部被平铺到同一层级**
+  - `detector.py`：`detect_chinese_sublevel()` 分离 `（一）`（中文数字带括号 → level 1）和 `（1）`（阿拉伯数字带括号 → level 2）的检测，原先共用一条正则导致 `（1）` 被误判为 level 1
+  - `detector.py`：`detect_numbering_structure()` 中，`（一）` 型子标题检测为 level 1 后，`prev_level` 设为 `level + 1`（即 level 2），使后续无编号段落正确降为下一级，而非继承子标题的同级
+  - `detector.py`：`has_level1_heading` 标志仅由 `（一）` 型子标题设置，不再被 `1.` 型内容段落误设（原先 `1.` 也会触发 `has_level1_heading = True`，导致后续 `1.` 段落错误降级）
+
+### 新增
+
+- `auditor.py`：新增 `validate_hierarchy()` 层级结构验证函数
+  - 检测 `（一）` 子标题后的无编号内容段落是否错误地停留在同级（L1），应在下一级（L2）
+  - `AuditReport` 新增 `hierarchy_issues` 字段
+  - `audit_completeness()` 支持传入 `numbered_paras` 参数，执行层级结构验证
+
+### 变更
+
+- `converter.py`：`verify_numbering()` 将 `numbered_paras` 传给 `audit_completeness()`，审计发现的层级问题会覆盖 `all_valid` 为 False
+- 版本号：`1.3.0` → `1.4.0`
 
 ## [1.3.0] - 2026-08-06
 

--- a/skills/合同处理/合同自动编号/__init__.py
+++ b/skills/合同处理/合同自动编号/__init__.py
@@ -20,7 +20,7 @@ from .utils import format_numbering_mapping, generate_output_path, validate_inpu
 
 logger = logging.getLogger(__name__)
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 __all__ = ['convert_contract_numbering', 'NUMBERING_FORMATS']
 
 # 最大重试次数

--- a/skills/合同处理/合同自动编号/auditor.py
+++ b/skills/合同处理/合同自动编号/auditor.py
@@ -44,6 +44,7 @@ class AuditReport(NamedTuple):
     missed_paras: list[ParagraphAudit]  # 遗漏的段落
     mismatch_paras: list[ParagraphAudit]  # 编号不匹配段落
     sequence_gaps: list[dict]  # 编号序列缺口
+    hierarchy_issues: list[dict]  # 层级结构问题
     all_clear: bool  # 是否全部通过
     summary: str  # AI 友好的摘要文本
 
@@ -149,18 +150,73 @@ def _detect_sequence_gaps(original_doc: Document) -> list[dict]:
     return gaps
 
 
-def audit_completeness(original_doc: Document, output_doc: Document, format_type: str) -> AuditReport:
+def validate_hierarchy(numbered_paras: list[tuple[int, int, str, str]]) -> list[dict]:
+    """验证编号层级结构的合理性
+
+    检查规则：
+    - （一）型子标题（level 1，matched 以（开头）后的无编号段落应在 level 2
+    - 如果子标题后的段落仍在 level 1，标记为层级错误
+
+    Args:
+        numbered_paras: 编号段落列表 (para_idx, level, matched, text)
+
+    Returns:
+        层级问题列表，每项含 para_idx, heading_idx, issue, text
+    """
+    issues = []
+
+    for i, (para_idx, level, matched, text) in enumerate(numbered_paras):
+        # 检测（一）型子标题（level 1，matched 以（或(开头）
+        is_subheading = level == 1 and matched and matched[0] in '（('
+
+        if not is_subheading:
+            continue
+
+        # 检查后续段落，直到遇到下一个同级或更高级标题
+        for j in range(i + 1, len(numbered_paras)):
+            next_idx, next_level, next_matched, next_text = numbered_paras[j]
+
+            # 遇到更高级别标题（level 更小），停止检查
+            if next_level < level:
+                break
+
+            # 遇到同级子标题（有编号前缀），停止检查
+            if next_level == level and next_matched:
+                break
+
+            # 同级无编号内容段落 → 层级错误（应在 level+1）
+            if next_level == level and not next_matched:
+                issues.append({
+                    'para_idx': next_idx,
+                    'heading_idx': para_idx,
+                    'heading_text': text[:50],
+                    'issue': f'段落在子标题"{text[:30]}"之后，'
+                             f'但层级相同（L{level}），应为 L{level + 1}',
+                    'text': next_text[:50],
+                })
+
+    return issues
+
+
+def audit_completeness(
+    original_doc: Document,
+    output_doc: Document,
+    format_type: str,
+    numbered_paras: list[tuple[int, int, str, str]] | None = None,
+) -> AuditReport:
     """审计输出文档的编号完整性
 
     核心检查项：
     1. 原文件中所有带编号前缀的段落，输出文件中是否都有自动编号
     2. 输出中有自动编号的段落，文本是否与原始文档一致（编号前缀被替换为自动编号）
     3. 编号序列是否连续
+    4. 层级结构是否合理（子标题后的内容应在更深层级）
 
     Args:
         original_doc: 原始文档
         output_doc: 输出文档
         format_type: 编号格式类型
+        numbered_paras: 编号段落列表（可选，用于层级结构验证）
 
     Returns:
         审计报告
@@ -248,9 +304,20 @@ def audit_completeness(original_doc: Document, output_doc: Document, format_type
     sequence_gaps = _detect_sequence_gaps(original_doc)
 
     # ------------------------------------------------------------------
+    # 检查4: 层级结构合理性
+    # ------------------------------------------------------------------
+    hierarchy_issues: list[dict] = []
+    if numbered_paras is not None:
+        hierarchy_issues = validate_hierarchy(numbered_paras)
+
+    # ------------------------------------------------------------------
     # 生成摘要
     # ------------------------------------------------------------------
-    all_clear = len(missed) == 0 and len(mismatched) == 0
+    all_clear = (
+        len(missed) == 0
+        and len(mismatched) == 0
+        and len(hierarchy_issues) == 0
+    )
 
     lines = []
     lines.append(f'审计完成：{len(original_numbered)} 个原文件编号段落，'
@@ -269,6 +336,11 @@ def audit_completeness(original_doc: Document, output_doc: Document, format_type
             for m in mismatched:
                 lines.append(f'   [{m.para_idx}] {m.output_text[:50]}')
 
+        if hierarchy_issues:
+            lines.append(f'⚠ 层级结构 {len(hierarchy_issues)} 处问题（子标题后内容层级错误）：')
+            for h in hierarchy_issues:
+                lines.append(f'   [{h["para_idx"]}] {h["issue"]}: {h["text"]}')
+
     if sequence_gaps:
         lines.append(f'ℹ 编号序列 {len(sequence_gaps)} 处可能不连续：')
         for g in sequence_gaps:
@@ -282,6 +354,7 @@ def audit_completeness(original_doc: Document, output_doc: Document, format_type
         missed_paras=missed,
         mismatch_paras=mismatched,
         sequence_gaps=sequence_gaps,
+        hierarchy_issues=hierarchy_issues,
         all_clear=all_clear,
         summary=summary,
     )

--- a/skills/合同处理/合同自动编号/converter.py
+++ b/skills/合同处理/合同自动编号/converter.py
@@ -361,12 +361,12 @@ def verify_numbering(doc: Document, numbered_paras: list[tuple[int, int, str, st
     # 运行增强审计（优先使用，更强的可靠性）
     audit_report = None
     if original_doc is not None:
-        audit_report = audit_completeness(original_doc, doc, format_type)
-        # 审计报告优先：即使 basic verifictin 说 "all_valid"，
-        # 只要审计发现遗漏，就覆盖为 not valid
+        audit_report = audit_completeness(original_doc, doc, format_type, numbered_paras=numbered_paras)
+        # 审计报告优先：即使 basic verification 说 "all_valid"，
+        # 只要审计发现遗漏或层级问题，就覆盖为 not valid
         if not audit_report.all_clear:
             all_valid = False
-            logger.warning("审计发现遗漏，recommend review:\n%s", audit_report.summary)
+            logger.warning("审计发现问题，recommend review:\n%s", audit_report.summary)
 
     return {
         'all_valid': all_valid,

--- a/skills/合同处理/合同自动编号/detector.py
+++ b/skills/合同处理/合同自动编号/detector.py
@@ -69,6 +69,11 @@ def detect_decimal_level0(text: str) -> tuple[str, str] | tuple[None, None]:
 def detect_chinese_sublevel(text: str, has_level1_heading: bool) -> tuple[int, str] | tuple[None, None]:
     """检测中文格式的子级编号
 
+    层级映射（中文格式 一、1.（1）①）：
+      Level 1 → 1.    （来源：（一）（二）... 中文数字带括号）
+      Level 2 → （1）  （来源：（1）（2）... 阿拉伯数字带括号，或 1. 2. 当存在（一）子标题时）
+      Level 3 → ①     （来源：1）2）... 无左括号）
+
     Args:
         text: 待检测的文本
         has_level1_heading: 是否已经出现过 （一）子标题
@@ -76,15 +81,20 @@ def detect_chinese_sublevel(text: str, has_level1_heading: bool) -> tuple[int, s
     Returns:
         (level, matched_text) 或 (None, None)
     """
-    # Level 1: （一）（二）... 或 （1）（2）...
-    m = re.match(r'^[（(]([一二三四五六七八九十\d]+)[）)]\s*', text)
+    # Level 1: （一）（二）... （中文数字带括号 → 映射为 "1."）
+    m = re.match(r'^[（(]([一二三四五六七八九十]+)[）)]\s*', text)
     if m:
         return 1, m.group(0)
 
-    # Level 2: 1）2）... 或 (1)(2)...（无左括号）
-    m = re.match(r'^(\d+)[）)]\s*', text)
+    # Level 2: （1）（2）... （阿拉伯数字带括号 → 映射为 "（1）"）
+    m = re.match(r'^[（(](\d+)[）)]\s*', text)
     if m:
         return 2, m.group(0)
+
+    # Level 3: 1）2）... （无左括号）
+    m = re.match(r'^(\d+)[）)]\s*', text)
+    if m:
+        return 3, m.group(0)
 
     # 数字编号：1. 2. 3... 或 1.1 1.2...
     m = re.match(r'^(\d+\.\d+|\d+[.、])\s*', text)
@@ -170,10 +180,16 @@ def detect_numbering_structure(doc: Document, format_type: str) -> list[tuple[in
             if format_type == 'chinese':
                 level, sub_matched = detect_chinese_sublevel(text, has_level1_heading)
                 if level is not None:
-                    if level == 1:
+                    # 只有（一）型子标题才设置 has_level1_heading
+                    is_subheading = level == 1 and sub_matched and sub_matched[0] in '（('
+                    if is_subheading:
                         has_level1_heading = True
                     numbered_paras.append((i, level, sub_matched, text))
-                    prev_level = level
+                    # （一）型子标题后的无编号段落应为下一级（level + 1）
+                    if is_subheading:
+                        prev_level = level + 1
+                    else:
+                        prev_level = level
                     continue  # ← 成功匹配编号，跳过后续所有检查
             else:
                 level, sub_matched = detect_decimal_sublevel(text)


### PR DESCRIPTION
## 改动说明

### 问题描述

合同自动编号 skill 在处理含有 `（一）` 子标题的合同时，子标题后的内容段落全部被平铺到与子标题同一层级（L1），而非降为下一级（L2）。

例如 `（一）甲方权责` 后的 `提供合作场地：...` 应为 L2，但被错误设为 L1。

### 根因

`detector.py` 存在三个缺陷：

1. `（一）`（中文数字带括号）和 `（1）`（阿拉伯数字带括号）共用一条正则，都返回 level 1
2. `（一）` 子标题检测为 level 1 后，`prev_level` 设为 1，导致后续无编号段落继承 level 1
3. `has_level1_heading` 被所有 level 1 段落设置（包括 `1.` 内容段落），不应如此

### 修复内容

- **detector.py**：分离 `（一）`（→ level 1）和 `（1）`（→ level 2）的正则；`（一）` 子标题后 `prev_level` 设为 `level + 1`；`has_level1_heading` 仅由 `（一）` 型子标题设置
- **auditor.py**：新增 `validate_hierarchy()` 层级结构验证函数，检测子标题后内容段落层级错误；`AuditReport` 新增 `hierarchy_issues` 字段
- **converter.py**：`verify_numbering()` 将 `numbered_paras` 传给审计做层级检查

### 附加修复

- 升级 `h2 4.3.0 → 4.4.1` 修复 CVE-2026-71554

### 验证

用真实合同文档验证，`（一）` 子标题后的内容段落正确降为 L2，无 `（一）` 子标题的章节内容仍在 L1。层级检查能捕获旧 bug 输出。

### CHANGELOG

已更新 `skills/合同处理/合同自动编号/CHANGELOG.md`，版本号 1.3.0 → 1.4.0