### PR TITLE
fix(ci): 数据库层超时保护,根治 backend-unit-coverage hang

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -306,7 +306,7 @@ jobs:
 
   backend-unit-coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: backend

--- a/backend/apiSystem/apiSystem/settings.py
+++ b/backend/apiSystem/apiSystem/settings.py
@@ -251,6 +251,13 @@ elif DB_ENGINE in ("", "postgres", "postgresql", "django.db.backends.postgresql"
     # 生产环境：保持 600 秒复用连接提升性能
     _conn_max_age = 0 if DEBUG else 600
 
+    # 测试/开发环境下添加数据库超时，防止 flaky test 在 psycopg socket wait 中 hang 住
+    # 导致 CI 60 分钟超时。statement_timeout 让长时间 SQL 自动失败，
+    # idle_in_transaction_session_timeout 让持有事务不释放的连接自动取消。
+    _pg_options: dict[str, object] = {"connect_timeout": 10}
+    if DEBUG:
+        _pg_options["options"] = "-c statement_timeout=30000 -c idle_in_transaction_session_timeout=60000"
+
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
@@ -261,9 +268,7 @@ elif DB_ENGINE in ("", "postgres", "postgresql", "django.db.backends.postgresql"
             "PORT": int(os.environ.get("DB_PORT", "5432") or "5432"),
             "CONN_MAX_AGE": _conn_max_age,
             "CONN_HEALTH_CHECKS": True,
-            "OPTIONS": {
-                "connect_timeout": 10,
-            },
+            "OPTIONS": _pg_options,
         }
     }
 elif DB_ENGINE in ("mysql", "django.db.backends.mysql"):

--- a/changelog/v26.55/v26.55.8.md
+++ b/changelog/v26.55/v26.55.8.md
@@ -1,0 +1,83 @@
+# v26.55.8
+
+## 修复 backend-unit-coverage flaky test 导致 CI 60 分钟 hang
+
+---
+
+### 背景
+
+PR #414 修复了 `--timeout=60` 丢失的问题后，合并到 main 的 push 事件中，`backend-unit-coverage` 仍然卡满 60 分钟被取消。
+
+### 根本原因
+
+通过 GitHub Actions 日志的 stack trace 分析发现：
+
+1. **`--timeout=60` 确实生效了**：日志在 `07:23:57` 显示 `+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++`
+2. **但 thread method 无法杀掉 hang 的线程**：hang 发生在 `ThreadPoolExecutor` 的 worker 线程中，阻塞在 `psycopg/connection.py:484` 的 `wait` 方法（等待 PostgreSQL socket 事件）
+3. **pytest-timeout 的 thread method 局限**：thread method 只能检测超时并打印消息，无法强制中断 C 扩展层的 socket 阻塞
+4. **数据库层无超时保护**：PostgreSQL OPTIONS 只有 `connect_timeout: 10`（连接建立阶段），没有 `statement_timeout` 和 `idle_in_transaction_session_timeout`，导致 SQL 执行和事务持有可以无限阻塞
+
+时间线：
+- `07:20:10` pytest 启动
+- `07:23:57` 第一次 Timeout（worker 线程在 `work_queue.get` 等待任务）
+- `07:24:57` 第二次 Timeout（同一个线程转移到 `psycopg/connection.py:484` 的 socket wait）
+- `07:24:57` → `08:19:52` pytest 继续卡住 55 分钟，直到 job 级 60m timeout 强制取消
+
+PostgreSQL autovacuum 反复报 `skipping vacuum of "xxx" --- lock not available`，确认有事务持锁不释放。
+
+### 修复方案
+
+**1. 数据库层超时保护（核心修复）**
+
+在 `settings.py` 的 PostgreSQL OPTIONS 中，DEBUG 模式下添加：
+
+```python
+_pg_options: dict[str, object] = {"connect_timeout": 10}
+if DEBUG:
+    _pg_options["options"] = (
+        "-c statement_timeout=30000"
+        " -c idle_in_transaction_session_timeout=60000"
+    )
+```
+
+- `statement_timeout=30000`：SQL 执行超过 30 秒自动失败，让 psycopg 收到异常而非无限阻塞
+- `idle_in_transaction_session_timeout=60000`：事务空闲超过 60 秒自动取消，**直接解决 autovacuum lock not available 问题**（测试持有事务不释放时，PostgreSQL 主动断开连接释放锁）
+
+只在 DEBUG 模式下生效，不影响生产环境。
+
+**2. 减少 job timeout 兜底**
+
+`backend-ci.yml` 的 `backend-unit-coverage` job：`timeout-minutes: 60` → `timeout-minutes: 15`
+
+即使数据库超时未生效，也只浪费 15 分钟而非 60 分钟。
+
+---
+
+### CI/CD
+
+#### 修复：数据库层超时保护
+
+- `apiSystem/apiSystem/settings.py`：DEBUG 模式下 PostgreSQL OPTIONS 添加 `statement_timeout=30000` 和 `idle_in_transaction_session_timeout=60000`
+
+#### 优化：job timeout 兜底
+
+- `.github/workflows/backend-ci.yml`：`backend-unit-coverage` 的 `timeout-minutes` 从 60 减少到 15
+
+---
+
+### 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `backend/apiSystem/apiSystem/settings.py` | DEBUG 模式下 PostgreSQL OPTIONS 添加数据库超时 |
+| `.github/workflows/backend-ci.yml` | backend-unit-coverage timeout-minutes 60→15 |
+
+---
+
+### 验证
+
+- 本地确认数据库超时生效：`statement_timeout: 30s`，`idle_in_transaction_session_timeout: 1min`
+- 数据库超时覆盖了之前 hang 的所有场景：
+  - SQL 执行 hang → `statement_timeout` 30 秒后自动失败
+  - 事务持锁不释放 → `idle_in_transaction_session_timeout` 60 秒后自动取消
+  - 即使两者都未生效 → job 级 15 分钟兜底（vs 之前 60 分钟）


### PR DESCRIPTION
## 背景

PR #414 修复了 `--timeout=60` 丢失问题后，合并到 main 的 push 事件中，`backend-unit-coverage` 仍然卡满 60 分钟被取消。

## 根本原因

通过 GitHub Actions 日志的 stack trace 分析发现：

1. **`--timeout=60` 确实生效了**：日志在 `07:23:57` 显示 `+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++`
2. **但 thread method 无法杀掉 hang 的线程**：hang 发生在 `ThreadPoolExecutor` 的 worker 线程中，阻塞在 `psycopg/connection.py:484` 的 `wait` 方法（等待 PostgreSQL socket 事件）
3. **pytest-timeout 的 thread method 局限**：thread method 只能检测超时并打印消息，**无法强制中断 C 扩展层的 socket 阻塞**
4. **数据库层无超时保护**：PostgreSQL OPTIONS 只有 `connect_timeout: 10`（连接建立阶段），没有 `statement_timeout` 和 `idle_in_transaction_session_timeout`，导致 SQL 执行和事务持有可以无限阻塞

时间线：
- `07:20:10` pytest 启动
- `07:23:57` 第一次 Timeout（worker 线程在 `work_queue.get` 等待任务）
- `07:24:57` 第二次 Timeout（同一个线程转移到 `psycopg/connection.py:484` 的 socket wait）
- `07:24:57` → `08:19:52` pytest 继续卡住 55 分钟，直到 job 级 60m timeout 强制取消

PostgreSQL autovacuum 反复报 `skipping vacuum of "xxx" --- lock not available`，确认有事务持锁不释放。

## 修复方案

**1. 数据库层超时保护（核心修复）**

在 `settings.py` 的 PostgreSQL OPTIONS 中，DEBUG 模式下添加：

```python
_pg_options: dict[str, object] = {"connect_timeout": 10}
if DEBUG:
    _pg_options["options"] = "-c statement_timeout=30000 -c idle_in_transaction_session_timeout=60000"
```

- `statement_timeout=30000`：SQL 执行超过 30 秒自动失败，让 psycopg 收到异常而非无限阻塞
- `idle_in_transaction_session_timeout=60000`：事务空闲超过 60 秒自动取消，**直接解决 autovacuum lock not available 问题**（测试持有事务不释放时，PostgreSQL 主动断开连接释放锁）

只在 DEBUG 模式下生效，不影响生产环境。

**2. 减少 job timeout 兜底**

`backend-ci.yml` 的 `backend-unit-coverage` job：`timeout-minutes: 60` → `timeout-minutes: 15`

即使数据库超时未生效，也只浪费 15 分钟而非 60 分钟。

## 涉及文件

| 文件 | 变更 |
|------|------|
| `backend/apiSystem/apiSystem/settings.py` | DEBUG 模式下 PostgreSQL OPTIONS 添加数据库超时 |
| `.github/workflows/backend-ci.yml` | backend-unit-coverage timeout-minutes 60→15 |
| `changelog/v26.55/v26.55.8.md` | CHANGELOG |

## 验证

- pre-push hook CI 通过（ruff/mypy/pip-audit/bandit 等）
- 本地确认 DEBUG 模式数据库超时生效：`statement_timeout: 30s`，`idle_in_transaction_session_timeout: 1min`
- 数据库超时覆盖了之前 hang 的所有场景：
  - SQL 执行 hang → `statement_timeout` 30 秒后自动失败
  - 事务持锁不释放 → `idle_in_transaction_session_timeout` 60 秒后自动取消
  - 即使两者都未生效 → job 级 15 分钟兜底（vs 之前 60 分钟）

## CHANGELOG
- `changelog/v26.55/v26.55.8.md`