### PR TITLE
fix: 同步 plugins 行为变更后过期的单元测试断言

### DIFF
--- a/backend/tests/ci/unit/automation/guarantee/test_court_guarantee_helpers.py
+++ b/backend/tests/ci/unit/automation/guarantee/test_court_guarantee_helpers.py
@@ -283,11 +283,11 @@ class TestResolveInsuranceCompanyDefaults:
 
     def test_no_context_returns_global_default(self):
         from plugins.court_automation.guarantee.helpers import (
-            _DEFAULT_INSURANCE_COMPANY,
+            _SUNSHINE_INSURANCE_COMPANY,
             _resolve_insurance_company_defaults,
         )
         default, options = _resolve_insurance_company_defaults(quote_context=None)
-        assert default == _DEFAULT_INSURANCE_COMPANY
+        assert default == _SUNSHINE_INSURANCE_COMPANY
 
 
 # ── _normalize_selected_party_ids ────────────────────────────────────────────

--- a/backend/tests/ci/unit/automation/test_court_guarantee_api.py
+++ b/backend/tests/ci/unit/automation/test_court_guarantee_api.py
@@ -67,7 +67,8 @@ def test_build_selected_respondent_property_clues_returns_all_clues(monkeypatch)
     assert result[0]["property_info"] == "银行账户：户名: 测试户名A；银行账号: 6222"
     assert result[1]["property_info"] == "微信账户：微信号: test_wechat_123"
     assert result[2]["property_info"] == "其他：测试设备线索一批"
-    assert [item["property_value"] for item in result] == ["206135.64", "206135.64", "206135.64"]
+    # 财产线索价值平均分配保全金额（commit b580df3），206135.64 // 3 = 68711（向下取整）
+    assert [item["property_value"] for item in result] == ["68711", "68711", "68711"]
 
 
 def test_build_selected_respondent_property_clues_falls_back_when_no_clues(monkeypatch) -> None:

--- a/backend/tests/ci/unit/automation/test_court_guarantee_helpers.py
+++ b/backend/tests/ci/unit/automation/test_court_guarantee_helpers.py
@@ -505,7 +505,7 @@ class TestExtractQuoteCompanyOptions:
 class TestResolveInsuranceCompanyDefaults:
     def test_no_quote_context(self):
         company, options = _resolve_insurance_company_defaults(quote_context=None)
-        assert company == _DEFAULT_INSURANCE_COMPANY
+        assert company == _SUNSHINE_INSURANCE_COMPANY
 
     def test_with_recommended(self):
         ctx = {

--- a/backend/tests/ci/unit/automation/test_court_guarantee_helpers_full.py
+++ b/backend/tests/ci/unit/automation/test_court_guarantee_helpers_full.py
@@ -510,7 +510,7 @@ class TestExtractQuoteCompanyOptions:
 class TestResolveInsuranceCompanyDefaults:
     def test_none_context(self):
         default, options = helpers._resolve_insurance_company_defaults(quote_context=None)
-        assert default == helpers._DEFAULT_INSURANCE_COMPANY
+        assert default == helpers._SUNSHINE_INSURANCE_COMPANY
 
     def test_with_recommended(self):
         context = {

--- a/backend/tests/ci/unit/automation/test_court_guarantee_helpers_full_coverage.py
+++ b/backend/tests/ci/unit/automation/test_court_guarantee_helpers_full_coverage.py
@@ -635,11 +635,11 @@ class TestResolveInsuranceCompanyDefaults:
     def test_no_options(self, mock_extract):
         mock_extract.return_value = []
         from plugins.court_automation.guarantee.schemas import (
-            _DEFAULT_INSURANCE_COMPANY,
             _GUARANTEE_INSURANCE_COMPANY_OPTIONS,
+            _SUNSHINE_INSURANCE_COMPANY,
         )
         company, options = self._fn()(quote_context=None)
-        assert company == _DEFAULT_INSURANCE_COMPANY
+        assert company == _SUNSHINE_INSURANCE_COMPANY
         assert options == _GUARANTEE_INSURANCE_COMPANY_OPTIONS
 
 

--- a/backend/tests/ci/unit/automation/test_court_guarantee_helpers_round2.py
+++ b/backend/tests/ci/unit/automation/test_court_guarantee_helpers_round2.py
@@ -527,7 +527,7 @@ class TestResolveInsuranceCompanyDefaults:
 
     def test_no_quote_returns_defaults(self):
         company, options = self._fn_import()(quote_context=None)
-        assert company == "中国平安财产保险股份有限公司"
+        assert company == "阳光财产保险股份有限公司"
 
     def test_recommended_in_options(self):
         ctx = {

--- a/backend/tests/ci/unit/automation/test_court_guarantee_helpers_round3.py
+++ b/backend/tests/ci/unit/automation/test_court_guarantee_helpers_round3.py
@@ -300,7 +300,7 @@ class TestResolveInsuranceCompanyDefaults:
     def test_no_quote_options(self):
         from plugins.court_automation.guarantee.helpers import _resolve_insurance_company_defaults
         default, options = _resolve_insurance_company_defaults(quote_context=None)
-        assert default == "中国平安财产保险股份有限公司"
+        assert default == "阳光财产保险股份有限公司"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/ci/unit/automation/test_court_zxfw.py
+++ b/backend/tests/ci/unit/automation/test_court_zxfw.py
@@ -2,7 +2,7 @@
 
 import json
 import socket
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -93,8 +93,9 @@ class TestIsNetworkError:
     def test_network_string_in_message(self):
         assert self.service._is_network_error(Exception("ERR_NAME_NOT_RESOLVED")) is True
 
-    def test_timeout_in_message(self):
-        assert self.service._is_network_error(Exception("request timeout occurred")) is True
+    def test_timeout_string_not_network_error(self):
+        # commit e2c813b 有意将 "timeout" 从 network_tokens 移除，普通异常不应误判为网络错误
+        assert self.service._is_network_error(Exception("request timeout occurred")) is False
 
     def test_not_network_error(self):
         assert self.service._is_network_error(ValueError("some value error")) is False

--- a/backend/tests/ci/unit/automation/test_schemas_coverage_round2.py
+++ b/backend/tests/ci/unit/automation/test_schemas_coverage_round2.py
@@ -92,7 +92,7 @@ class TestCourtGuaranteeSchemas:
             has_case_number=True,
         )
         assert obj.case_id == 1
-        assert obj.insurance_company_name == "中国平安财产保险股份有限公司"
+        assert obj.insurance_company_name == "阳光财产保险股份有限公司"
 
     def test_case_quote_operation_in(self):
         from plugins.court_automation.guarantee.schemas import CaseQuoteOperationIn


### PR DESCRIPTION
## 背景

plugins 子模块的三次行为变更未同步更新主仓库测试，导致 `make ci-backend-full` 中 unit-tests / unit-coverage / apps-coverage 三步失败（10 failed）。

## 根因

| plugins commit | 变更 | 影响测试 |
|---|---|---|
| `5c1f2fa` | 默认选中阳光财产保险 | 8 个 `_resolve_insurance_company_defaults` 测试仍断言 `_DEFAULT_INSURANCE_COMPANY`（中国平安） |
| `b580df3` | 财产线索价值平均分配保全金额 | `test_build_selected_respondent_property_clues` 仍断言全额 `206135.64` |
| `e2c813b` | "timeout" 从 network_tokens 移除（网络误判修复） | `test_timeout_in_message` 仍断言 `True` |

## 改动

9 个测试文件，15 insertions / 13 deletions，仅同步过期断言：

- `guarantee/test_court_guarantee_helpers.py` — `_DEFAULT_INSURANCE_COMPANY` → `_SUNSHINE_INSURANCE_COMPANY`
- `test_court_guarantee_helpers.py` — 同上
- `test_court_guarantee_helpers_full.py` — 同上
- `test_court_guarantee_helpers_full_coverage.py` — 同上
- `test_court_guarantee_helpers_round2.py` — `"中国平安..."` → `"阳光财产保险股份有限公司"`
- `test_court_guarantee_helpers_round3.py` — 同上
- `test_schemas_coverage_round2.py` — `insurance_company_name` 默认值
- `test_court_guarantee_api.py` — `property_value` 由 `206135.64` → `68711`（平均分配向下取整）
- `test_court_zxfw.py` — `test_timeout_in_message` → `test_timeout_string_not_network_error`，断言 `True` → `False`

## 验证

- 本地 `make ci-backend-full`：28231 passed，10 个断言失败全部修复（unit-tests 从 ✗ 变 ✓）
- 剩余 unit-coverage / apps-coverage 的 11 errors 均为 `Database couldn't be flushed` teardown 偶发错误（本地 PostgreSQL 锁问题，与改动无关），GitHub CI 独立 PostgreSQL 环境不会出现
- pre-commit 全部通过