### PR TITLE
feat: v26.55.13 开发快捷命令 + 文档解析优化 + 其他工具侧边栏

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,19 @@ ci-frontend: ## 仅前端 CI（tsc + eslint + build）
 ci-backend-full: ## 仅后端 CI（完整模式，需要 PostgreSQL）
 	@bash scripts/ci-local.sh --full --backend
 
+# ============================================================
+# 开发服务器（前台运行，可直接 Ctrl+C 退出）
+# ============================================================
+
+frontend: ## 启动前端开发服务器（Vite，热重载，端口 5173）
+	cd frontend && pnpm dev
+
+backend: ## 启动后端开发服务器（Uvicorn，热重载，默认端口 8002，可用 PORT=8003 覆盖）
+	cd backend && $(MAKE) run-dev
+
+q: ## 启动 Django-Q 任务队列（文件变化自动重启）
+	cd backend && $(MAKE) qcluster-dev
+
 install-hooks: ## 安装 git pre-push hook（推送前自动运行本地 CI）
 	@ln -sf ../../scripts/pre-push .git/hooks/pre-push
 	@chmod +x scripts/pre-push
@@ -42,5 +55,6 @@ help: ## 显示帮助信息
 	@echo "推送前建议:  make ci-full"
 	@echo "日常开发:    make ci"
 	@echo "安装 hook:   make install-hooks"
+	@echo "启动服务:    make frontend / make backend / make q"
 
-.PHONY: help ci ci-full ci-backend ci-frontend ci-backend-full install-hooks
+.PHONY: help ci ci-full ci-backend ci-frontend ci-backend-full install-hooks frontend backend q

--- a/backend/apiSystem/apiSystem/admin_customization.py
+++ b/backend/apiSystem/apiSystem/admin_customization.py
@@ -166,12 +166,13 @@ def _build_other_tools_list() -> list[dict[str, Any]]:
     return tools
 
 
-# 新用户默认收藏的子工具 URL（首次访问「其他工具」页时自动创建）
+# 新用户默认收藏的子工具 URL（首次打开「其他工具」页时自动创建）
 _DEFAULT_FAV_URLS = [
     "/admin/finance/calculator/",
     "/admin/express_query/expressquerytool/",
     "/admin/automation/courtsms/",
     "/admin/doc_convert/docconverttool/",
+    "/admin/document_parsing/documentparsingtool/",
 ]
 
 # "办案"聚合页应用列表
@@ -246,22 +247,14 @@ def _sorted_get_app_list(self: admin.AdminSite, request: HttpRequest, app_label:
             }
         )
 
-    # 注入虚拟「其他工具」顶级菜单（服务端过滤：只注入用户收藏的工具，避免客户端 JS 操作 DOM 导致闪烁）
+    # 注入虚拟「其他工具」顶级菜单（服务端过滤：直接从数据库取收藏，5 条记录以内不需要缓存）
     if app_label is None and not any(a.get("app_label") == "other_tools" for a in app_list):
-        # 获取用户收藏的 URL 集合（服务端过滤，HTML 里只渲染需要的行）
+        # 获取用户收藏的 URL 集合（直接走数据库，收藏/取消后即时反应，无需缓存过期等待）
         fav_urls: set[str] = set()
         if request is not None and hasattr(request, "user") and request.user.is_authenticated:
-            from django.core.cache import cache as _django_cache
+            from apps.core.models import ToolFavorite
 
-            _fav_cache_key = f"admin:fav_urls:{request.user.id}"
-            _cached_favs = _django_cache.get(_fav_cache_key)
-            if _cached_favs is not None:
-                fav_urls = set(_cached_favs)
-            else:
-                from apps.core.models import ToolFavorite
-
-                fav_urls = set(ToolFavorite.objects.filter(user=request.user).values_list("tool_url", flat=True))
-                _django_cache.set(_fav_cache_key, list(fav_urls), timeout=300)
+            fav_urls = set(ToolFavorite.objects.filter(user=request.user).values_list("tool_url", flat=True))
         if not fav_urls:
             fav_urls = set(_DEFAULT_FAV_URLS)
 
@@ -442,26 +435,17 @@ def other_tools_hub_view(request: HttpRequest) -> TemplateResponse:
             }
         )
 
-    # 获取当前用户的收藏 URL 集合；首次访问时创建默认收藏
-    from django.core.cache import cache as _django_cache
-
-    _fav_cache_key = f"admin:fav_urls:{request.user.id}"
-    _cached_favs = _django_cache.get(_fav_cache_key)
-    if _cached_favs is not None:
-        fav_urls = set(_cached_favs)
-    else:
+    # 获取当前用户的收藏 URL 集合；直接查询数据库（5 条以内没必要缓存）
+    existing_favs = ToolFavorite.objects.filter(user=request.user)
+    if not existing_favs.exists():
+        for url in _DEFAULT_FAV_URLS:
+            ToolFavorite.objects.get_or_create(
+                user=request.user,
+                tool_url=url,
+                defaults={"tool_name": url.strip("/").split("/")[-1].replace("_", " ").title()},
+            )
         existing_favs = ToolFavorite.objects.filter(user=request.user)
-        if not existing_favs.exists():
-            for url in _DEFAULT_FAV_URLS:
-                ToolFavorite.objects.get_or_create(
-                    user=request.user,
-                    tool_url=url,
-                    defaults={"tool_name": url.strip("/").split("/")[-1].replace("_", " ").title()},
-                )
-            existing_favs = ToolFavorite.objects.filter(user=request.user)
-
-        fav_urls = set(existing_favs.values_list("tool_url", flat=True))
-        _django_cache.set(_fav_cache_key, list(fav_urls), timeout=300)
+    fav_urls = set(existing_favs.values_list("tool_url", flat=True))
 
     context: dict[str, Any] = {
         **admin.site.each_context(request),
@@ -501,11 +485,6 @@ def tool_favorite_toggle_view(request: HttpRequest) -> HttpResponse:
     else:
         ToolFavorite.objects.create(user=request.user, tool_url=tool_url, tool_name=tool_name)
         is_fav = True
-
-    # 清除侧边栏和 hub 的收藏缓存
-    from django.core.cache import cache as _django_cache
-
-    _django_cache.delete(f"admin:fav_urls:{request.user.id}")
 
     return HttpResponse(
         json.dumps({"is_fav": is_fav, "url": tool_url}),

--- a/backend/apps/document_parsing/admin/document_parsing_admin.py
+++ b/backend/apps/document_parsing/admin/document_parsing_admin.py
@@ -9,7 +9,7 @@ from typing import Any
 from django.conf import settings
 from django.contrib import admin, messages
 from django.core.files.storage import default_storage
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -165,9 +165,6 @@ class DocumentParsingTaskAdmin(admin.ModelAdmin):  # pragma: no cover
         "file_size",
         "status",
         "backend_used",
-        "text",
-        "markdown",
-        "metadata",
         "error_message",
         "created_at",
         "completed_at",
@@ -181,15 +178,9 @@ class DocumentParsingTaskAdmin(admin.ModelAdmin):  # pragma: no cover
             },
         ),
         (
-            "解析结果",
+            "错误信息",
             {
-                "fields": ("text", "markdown"),
-            },
-        ),
-        (
-            "元数据",
-            {
-                "fields": ("metadata", "error_message"),
+                "fields": ("error_message",),
                 "classes": ("collapse",),
             },
         ),
@@ -203,6 +194,47 @@ class DocumentParsingTaskAdmin(admin.ModelAdmin):  # pragma: no cover
     )
 
     change_form_template = "admin/document_parsing/documentparsingtask/change_form.html"
+
+    def get_urls(self) -> list:
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "<path:object_id>/download-markdown/",
+                self.admin_site.admin_view(self.download_markdown),
+                name="document_parsing_documentparsingtask_download_markdown",
+            ),
+        ]
+        return custom_urls + urls
+
+    def change_view(
+        self,
+        request: HttpRequest,
+        object_id: str,
+        form_url: str = "",
+        extra_context: dict[str, Any] | None = None,
+    ) -> TemplateResponse:
+        """注入下载文件名到模板上下文"""
+        extra = extra_context or {}
+        obj = self.get_object(request, object_id)
+        if obj and obj.file_name:
+            extra["download_filename"] = Path(obj.file_name).stem + ".md"
+        return super().change_view(request, object_id, form_url, extra)  # type: ignore[return-value]
+
+    def download_markdown(self, request: HttpRequest, object_id: str) -> HttpResponse:
+        """下载解析结果的 Markdown 文件"""
+        from apps.document_parsing.models import DocumentParsingTask
+
+        task = DocumentParsingTask.objects.filter(pk=object_id).first()
+        if not task or not task.markdown:
+            raise Http404("解析任务或 Markdown 内容不存在")
+
+        response = HttpResponse(
+            task.markdown,
+            content_type="text/markdown; charset=utf-8",
+        )
+        safe_name = Path(task.file_name).stem or f"task_{task.id}"
+        response["Content-Disposition"] = f'attachment; filename="{safe_name}.md"'
+        return response
 
     @admin.display(description="状态")
     def status_display(self, obj: DocumentParsingTask) -> str:

--- a/backend/apps/document_parsing/templates/admin/document_parsing/documentparsingtask/change_form.html
+++ b/backend/apps/document_parsing/templates/admin/document_parsing/documentparsingtask/change_form.html
@@ -38,6 +38,11 @@
 </div>
 
 <div class="result-panel" id="markdown-panel">
+    <div style="display: flex; justify-content: flex-end; margin-bottom: 12px;">
+        <a href="{% url 'admin:document_parsing_documentparsingtask_download_markdown' original.id %}"
+           class="button" style="padding: 8px 16px; text-decoration: none;"
+           download="{{ download_filename }}">⬇️ 下载 Markdown</a>
+    </div>
     <div class="md-content">
         <pre>{{ original.markdown }}</pre>
     </div>

--- a/changelog/v26.55/v26.55.13.md
+++ b/changelog/v26.55/v26.55.13.md
@@ -1,0 +1,98 @@
+# v26.55.13
+
+## feat: 开发快捷命令 + 文档解析结果优化 + 其他工具侧边栏收藏优化
+
+---
+
+### 1. feat(make): 根目录新增 frontend/backend/q 快捷启动命令
+
+#### 背景
+日常开发需要在根目录和 `backend/` 子目录之间反复 `cd`，启动前端/后端/Django-Q 都要先切目录再执行命令，比较繁琐。
+
+#### 新功能
+在根目录 `Makefile` 添加三个快捷命令：
+
+| 命令 | 说明 |
+|------|------|
+| `make frontend` | 启动前端 Vite 开发服务器（热重载，端口 5173） |
+| `make backend` | 启动后端 Uvicorn（复用 `backend/Makefile` 的 `run-dev`，默认端口 8002，可用 `PORT=8003` 覆盖） |
+| `make q` | 启动 Django-Q 任务队列（复用 `backend/Makefile` 的 `qcluster-dev`，文件变化自动重启） |
+
+均保持原有热重载行为不变，只是在根目录提供一层包装。
+
+#### 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `Makefile` | 新增 `frontend` / `backend` / `q` 目标 + `.PHONY` + help 输出 |
+
+---
+
+### 2. feat(document_parsing): 去重解析结果展示 + Markdown 下载按钮
+
+#### 背景
+文档解析任务 Admin 详情页的 `text` / `markdown` / `metadata` 字段直接列在编辑表单中，解析结果过长时：
+- 字段表单被撑得非常高，影响其他字段操作
+- Markdown 结果只能复制无法直接下载
+
+#### 改动
+
+**后端** (`document_parsing_admin.py`)：
+- `list_display` 移除 `text` / `markdown` / `metadata`，保持列表页简洁
+- `fieldsets` 替换为仅展开 `error_message`，解析结果不再出现在表单中
+- 新增 `download_markdown` Admin 视图：`GET /download-markdown/` 返回 `text/markdown` 附件下载
+- `change_view` 注入 `download_filename`（基于原文件名）到模板上下文
+
+**前端** (`change_form.html`)：
+- Markdown 面板顶部新增「⬇️ 下载 Markdown」按钮，指向 `download_markdown` 端点
+
+#### 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `backend/apps/document_parsing/admin/document_parsing_admin.py` | 去重字段 + 新增下载视图 |
+| `backend/apps/document_parsing/templates/admin/document_parsing/documentparsingtask/change_form.html` | 新增下载按钮 |
+
+---
+
+### 3. feat(admin): 其他工具侧边栏收藏优化
+
+#### 背景
+用户反馈「其他工具」侧边栏加载不稳定，收藏/取消收藏后侧边栏有时不即时更新。调查发现原因是 `ToolFavorite` 收藏列表在多处使用了 Django Cache（5 分钟 TTL），收藏/取消后需要等缓存过期或手动清缓存才能更新。
+
+#### 改动
+
+**去掉缓存，直查数据库**：
+- `_sorted_get_app_list`（侧边栏注入）：移除 `django_cache.get/set` 缓存逻辑，每次请求直接 `ToolFavorite.objects.filter(user=request.user)`
+- `other_tools_hub_view`（聚合页渲染）：移除相同的缓存逻辑，直查数据库
+- `tool_favorite_toggle_view`（切换收藏 API）：移除 `_django_cache.delete` 缓存清理逻辑
+
+> 单个用户的收藏数量有限（通常 ≤10 条），直查数据库成本极低，缓存收益不足以抵消不一致性。
+
+**文档解析工具加入默认收藏**：
+新用户首次打开「其他工具」页时，自动在侧边栏收藏 `document_parsing`：
+
+```python
+_DEFAULT_FAV_URLS = [
+    "/admin/finance/calculator/",
+    "/admin/express_query/expressquerytool/",
+    "/admin/automation/courtsms/",
+    "/admin/doc_convert/docconverttool/",
+    "/admin/document_parsing/documentparsingtool/",  # ← 新增
+]
+```
+
+#### 涉及文件
+
+| 文件 | 变更 |
+|------|------|
+| `backend/apiSystem/apiSystem/admin_customization.py` | 去掉三处缓存逻辑 + 加入默认收藏 |
+
+---
+
+## 验证
+
+- ruff 通过
+- 开发命令在根目录实测可用：`make frontend` / `make backend` / `make q`
+- 文档解析结果下载功能正常，文件名基于原文件
+- 收藏/取消收藏后侧边栏即时更新，无 5 分钟延迟


### PR DESCRIPTION
- **feat(make)**: 根目录新增 `make frontend` / `make backend` / `make q` 快捷启动命令
- **feat(document_parsing)**: 去重解析结果展示 + Markdown 下载按钮
- **feat(admin)**: 其他工具侧边栏去掉 Django Cache 缓存，收藏/取消即时反应；文档解析工具加入默认收藏

CI: ruff ✅ | mypy ✅ | pre-commit ✅