### PR TITLE
chore: Django 6.1 废弃用法预清理 (v26.55.16)

### DIFF
--- a/backend/apps/cases/services/case/case_search_service_adapter.py
+++ b/backend/apps/cases/services/case/case_search_service_adapter.py
@@ -33,12 +33,8 @@ class CaseSearchServiceAdapter(ICaseSearchService):
         limit = min(limit, 20)
 
         if not query or not query.strip():
-            # 无搜索词时返回最近的案件
-            cases = (
-                Case.objects.select_related()
-                .prefetch_related("case_numbers", "parties__client")
-                .order_by("-id")[:limit]
-            )
+            # 无搜索词时返回最近的案件（不 select_related：循环内不访问单值关联字段）
+            cases = Case.objects.prefetch_related("case_numbers", "parties__client").order_by("-id")[:limit]
         else:
             search_term = query.strip()
 
@@ -56,10 +52,9 @@ class CaseSearchServiceAdapter(ICaseSearchService):
                 "case_id", flat=True
             )
 
-            # 合并查询
+            # 合并查询（不 select_related：循环内不访问单值关联字段）
             cases = (
                 Case.objects.filter(name_query | Q(id__in=case_ids_by_number) | Q(id__in=case_ids_by_party))
-                .select_related()
                 .prefetch_related("case_numbers", "parties__client")
                 .distinct()
                 .order_by("-id")[:limit]

--- a/changelog/v26.55/v26.55.16.md
+++ b/changelog/v26.55/v26.55.16.md
@@ -1,0 +1,46 @@
+# v26.55.16
+
+## chore: Django 6.0 → 6.1 废弃用法清理与升级准备
+
+---
+
+### 背景
+
+Django 6.0.x 标准支持已于 2026-08-04 结束，6.1 为最新 stable 版本.
+本次先清理 6.1 废弃用法，为将来升级做准备.
+
+> 升级阻塞: `django-ninja==1.6.2` 依赖锁为 `django<6.1`,
+> 需等待 django-ninja 发布兼容版本后才能实际升级 Django 版本号.
+
+### 废弃用法审计
+
+| 检查项 | 结果 | 说明 |
+|--------|------|------|
+| `select_related()` 无参数 | 2 处已移除 | `case_search_service_adapter.py` 行 38, 62 |
+| `values_list(flat=True)` 无字段 | 0 处 | 全量搜索无命中 |
+| `iexact=None` on JSONField | 0 处 | 全量搜索无命中 |
+| `BinaryField` + Base64 | 0 处(模型级) | 仅存于已弃用 migration |
+| `EMAIL_*` settings | 未改动 | 项目未使用传统 email settings |
+| `on_delete="CASCADE"` 字符串 | 0 处 | 全为 `models.CASCADE` |
+
+### 变更
+
+**`apps/cases/services/case/case_search_service_adapter.py`**
+移除 2 处 `select_related()` 无参数调用，保留 `prefetch_related("case_numbers", "parties__client")`.
+查询结果循环中不访问单值关联字段(如 `case.contract`); `case_numbers`/`parties` 已通过 `prefetch_related`
+加载，无需 `select_related`.
+
+### 验证
+
+| 检查项 | 结果 |
+|--------|------|
+| `manage.py check` | System check identified no issues (0 silenced) |
+| `cases/` 单测 | **1649 passed** |
+| `organization/ + contracts/ + admin_access + issue423 E2E` | **2045 passed** |
+| **合计** | **3694 passed** |
+
+---
+
+## PR
+
+- #426


### PR DESCRIPTION
移除 2 处 Django 6.1 已废弃的 `select_related()` 无参数调用，为将来升级做准备。

**创建时意图升级到 Django 6.1，但发现 `django-ninja==1.6.2` 锁死 `django<6.1`（详见 #427），版本号未改动。**

## 变更

- `apps/cases/services/case/case_search_service_adapter.py`: 移除 2 处无参数 `select_related()`，保留 `prefetch_related`

## 废弃用法审计（全量扫描 apps/）

| 检查项 | 结果 |
|--------|------|
| `select_related()` 无参数 | 2 处已移除 |
| `values_list(flat=True)` 无字段 | 0 处 |
| `iexact=None` on JSONField | 0 处 |
| `BinaryField` + Base64 | 0 处 |
| `EMAIL_*` settings | 未使用 |
| `on_delete=str` | 0 处 |

## 验证

- Django check: System check identified no issues (0 silenced)
- cases/ 单测: 1649 passed
- organization + contracts + admin_access + issue423 E2E: 2045 passed
- **合计: 3694 passed**
