### PR TITLE
fix(jtn)+refactor(skill): v26.55.17 — 消除双重SSO弹窗 + 合同编号去除切片

### DIFF
--- a/backend/apps/oa_filing/services/oa_scripts/jtn/archive/playwright_archive.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/archive/playwright_archive.py
@@ -68,7 +68,7 @@ class PlaywrightArchiveMixin:  # pragma: no cover
             logger.info("归档材料提交完成")
 
     async def _login(self: Any, page: Page, context: Any) -> None:  # pragma: no cover
-        """登录 OA：优先缓存 cookies，否则 SSO 扫码。"""
+        """登录 OA：优先缓存 cookies，否则在当前页面 SSO 扫码。"""
         cached = JtnAuthService.load_cookies()
         if cached:
             logger.info("使用缓存 cookies 登录归档页面")
@@ -80,7 +80,8 @@ class PlaywrightArchiveMixin:  # pragma: no cover
                 return
             logger.warning("缓存 cookies 已失效，执行 SSO 扫码登录")
 
-        cookies = await self._auth.sso_login()
+        # 在当前页面执行 SSO 扫码登录（复用现有浏览器窗口）
+        cookies = await self._auth.perform_sso_login(page, context)
         await JtnAuthService.inject_to_context(context, cookies)
 
     async def _navigate(self: Any, page: Page) -> None:  # pragma: no cover

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/auth/service.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/auth/service.py
@@ -76,50 +76,58 @@ class JtnAuthService:  # pragma: no cover
     # SSO 扫码登录（Playwright 有头模式）
     # ------------------------------------------------------------------
 
-    async def sso_login(self) -> list[dict[str, Any]]:
-        """完整的 SSO 扫码 + 凭证登录流程。
+    async def perform_sso_login(self, page: Any, context: Any) -> list[dict[str, Any]]:
+        """在已有浏览器页面中执行 SSO 扫码 + 凭证登录。
 
-        打开有头浏览器 → 点击扫码图标 → 等待用户扫码 →
-        填写账号密码 → 捕获 cookies → 保存到磁盘。
+        复用传入的 page/context，不在内部创建新浏览器窗口。
+        调用方应确保 page 已打开到 OA 登录页（或会被重定向到登录页）。
+        """
+        # 1. 确保在当前页面操作
+        logger.info("SSO 登录: 打开 %s", _LOGIN_URL)
+        await page.goto(_LOGIN_URL, wait_until="domcontentloaded", timeout=60_000)
+        await asyncio.sleep(3)
+
+        # 2. 尝试点击扫码图标（失败不阻塞，用户可手动点击）
+        try:
+            await self._click_qr_icon(page)
+            await asyncio.sleep(2)
+        except RuntimeError:
+            logger.warning("未自动找到扫码图标，请在浏览器中手动点击扫码")
+        logger.info("SSO 登录: 请用企业微信扫码（等待 180 秒）")
+
+        # 3. 等待扫码完成，跳转回 OA 登录页
+        await page.wait_for_url("**/ims.jtn.com/**", timeout=180_000)
+        await asyncio.sleep(3)
+        logger.info("SSO 登录: 扫码完成，回到 OA 登录页")
+
+        # 4. 填写账号密码并登录
+        await page.fill('input[name="userid"]', self._account)
+        await page.fill('input[name="password"]', self._password)
+        await asyncio.sleep(0.5)
+        await page.click("button.input_btn")
+        await asyncio.sleep(5)
+
+        # 5. 验证登录结果
+        if "login" in page.url.lower():
+            raise RuntimeError("OA 登录失败，请检查账号密码")
+
+        logger.info("SSO 登录成功，当前页面: %s", page.url)
+
+        # 6. 捕获 cookies 并保存
+        cookies = await self._capture_cookies(context)
+        self.save_cookies(cookies)
+        return cookies
+
+    async def sso_login(self) -> list[dict[str, Any]]:
+        """完整的 SSO 扫码 + 凭证登录流程（新建浏览器窗口）。
+
+        适用于 standalone 场景（如首次登录或测试）。
+        已打开 OA 页面的场景应使用 perform_sso_login() 复用现有窗口。
         """
         from apps.core.services.browser import create_browser_async
 
         async with create_browser_async("default", headless=False) as (page, context):
-            # 1. 打开 OA 登录页（会重定向到 SSO）
-            logger.info("SSO 登录: 打开 %s", _LOGIN_URL)
-            await page.goto(_LOGIN_URL, wait_until="domcontentloaded", timeout=60_000)
-            await asyncio.sleep(3)
-
-            # 2. 尝试点击扫码图标（失败不阻塞，用户可手动点击）
-            try:
-                await self._click_qr_icon(page)
-                await asyncio.sleep(2)
-            except RuntimeError:
-                logger.warning("未自动找到扫码图标，请在浏览器中手动点击扫码")
-            logger.info("SSO 登录: 请用企业微信扫码（等待 180 秒）")
-
-            # 3. 等待扫码完成，跳转回 OA 登录页
-            await page.wait_for_url("**/ims.jtn.com/**", timeout=180_000)
-            await asyncio.sleep(3)
-            logger.info("SSO 登录: 扫码完成，回到 OA 登录页")
-
-            # 4. 填写账号密码并登录
-            await page.fill('input[name="userid"]', self._account)
-            await page.fill('input[name="password"]', self._password)
-            await asyncio.sleep(0.5)
-            await page.click("button.input_btn")
-            await asyncio.sleep(5)
-
-            # 5. 验证登录结果
-            if "login" in page.url.lower():
-                raise RuntimeError("OA 登录失败，请检查账号密码")
-
-            logger.info("SSO 登录成功，当前页面: %s", page.url)
-
-            # 6. 捕获 cookies 并保存
-            cookies = await self._capture_cookies(context)
-            self.save_cookies(cookies)
-            return cookies
+            return await self.perform_sso_login(page, context)
 
     async def _capture_cookies(self, context: Any) -> list[dict[str, Any]]:
         """从 Playwright context 捕获 cookies 并转为可序列化格式。"""

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/case_import/playwright_browser.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/case_import/playwright_browser.py
@@ -204,8 +204,10 @@ class JtnPlaywrightBrowserMixin:  # pragma: no cover
     # ------------------------------------------------------------------
 
     async def _do_sso_login_and_inject(self: Any) -> None:  # pragma: no cover
-        """调用 JtnAuthService.sso_login() 完成扫码登录，将新 cookies 注入当前 context。"""
-        new_cookies = await self._auth.sso_login()
+        """在当前浏览器页面中执行 SSO 扫码登录，将新 cookies 注入当前 context。"""
+        assert self._page is not None
+        assert self._context is not None
+        new_cookies = await self._auth.perform_sso_login(self._page, self._context)
         await self._auth.inject_to_context(self._context, new_cookies)
         # 同步到 http_cookies_cache（转为 dict[str, str] 供 HTTP 链路使用）
         self._http_cookies_cache = {c["name"]: c["value"] for c in new_cookies}

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/filing/playwright_filing.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/filing/playwright_filing.py
@@ -110,9 +110,9 @@ class PlaywrightFilingMixin:  # pragma: no cover
                 return
             logger.info("缓存 cookies 已失效，重新登录")
 
-        # 走 SSO 扫码 + 凭证登录
+        # 走 SSO 扫码 + 凭证登录（复用当前浏览器窗口）
         logger.info("SSO 登录（需要扫码）")
-        await self._auth.sso_login()
+        await self._auth.perform_sso_login(self._page, self._context)
         # 将新 cookies 注入 Playwright context
         new_cookies = self._auth.load_cookies()
         if new_cookies is None:

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/invoice/playwright_invoice.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/invoice/playwright_invoice.py
@@ -52,11 +52,13 @@ class PlaywrightInvoiceMixin:
                     logger.info("Cookies 有效，已进入发票页面")
                 else:
                     logger.warning("缓存 cookies 已失效，执行 SSO 扫码登录")
-                    cookies = await self._auth.sso_login()
+                    # 在当前页面执行 SSO 扫码，复用已有浏览器窗口
+                    cookies = await self._auth.perform_sso_login(page, context)
                     await self._auth.inject_to_context(context, cookies)
             else:
                 logger.info("无缓存 cookies，执行 SSO 扫码登录")
-                cookies = await self._auth.sso_login()
+                # 在当前页面执行 SSO 扫码，复用已有浏览器窗口
+                cookies = await self._auth.perform_sso_login(page, context)
                 await self._auth.inject_to_context(context, cookies)
 
             # ── 导航到发票页面 ──

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/stamp/playwright_stamp.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/stamp/playwright_stamp.py
@@ -84,7 +84,7 @@ class PlaywrightStampMixin:  # pragma: no cover
     # ------------------------------------------------------------------
 
     async def _login_to_stamp(self: Any, page: Page, context: Any) -> None:  # pragma: no cover
-        """登录 OA：优先缓存 cookies，否则 SSO 扫码。"""
+        """登录 OA：优先缓存 cookies，否则在当前页面 SSO 扫码。"""
         cached = JtnAuthService.load_cookies()
         if cached:
             logger.info("使用缓存 cookies 登录盖章页面")
@@ -97,8 +97,8 @@ class PlaywrightStampMixin:  # pragma: no cover
                 return
             logger.warning("缓存 cookies 已失效，执行 SSO 扫码登录")
 
-        # SSO 扫码登录（内部会创建 headed browser 等用户扫码）
-        cookies = await self._auth.sso_login()
+        # 在当前页面执行 SSO 扫码登录（复用现有浏览器窗口）
+        cookies = await self._auth.perform_sso_login(page, context)
         await JtnAuthService.inject_to_context(context, cookies)
 
     # ------------------------------------------------------------------

--- a/changelog/v26.55/v26.55.17.md
+++ b/changelog/v26.55/v26.55.17.md
@@ -1,0 +1,114 @@
+# v26.55.17
+
+## fix(oa_filing): 打开 OA 页面时复用浏览器窗口，消除双重 SSO 弹窗
+
+## refactor(skill/合同自动编号): v1.6.1 去除切片逻辑，AI 直接提供 clean_text
+
+---
+
+## fix(oa_filing): 复用浏览器窗口消除双重 SSO 弹窗
+
+### 问题
+
+点击合同归档/盖章/发票页面的"打开OA"按钮后，弹出**两个浏览器窗口**：
+
+1. 窗口 A：`_open_page()` 创建的原生 Playwright 浏览器，注入旧 cookies 后被重定向到登录页
+2. 窗口 B：`sso_login()` 内部又调用 `create_browser_async()` 创建的新窗口，要求用户扫码
+
+### 根因
+
+`_open_page()` 已在窗口 A 中打开页面，cookies 失效判定时调用 `self._auth.sso_login()`，而 `sso_login()` 内部又用 `create_browser_async` 创建了**第二个浏览器窗口**。
+
+### 修复
+
+将 `JtnAuthService.sso_login()` 拆分为两个方法：
+
+- `perform_sso_login(page, context)`：在**已有**浏览器页面中执行 SSO 扫码 + 凭证登录
+- `sso_login()`：薄包装 = 新建浏览器窗口 + 调用 `perform_sso_login`
+
+所有已有浏览器上下文的场景改为调用 `perform_sso_login(page, context)`，不再弹出额外窗口。
+
+### 影响模块
+
+| 模块 | 文件 | 改动 |
+|------|------|------|
+| auth | `auth/service.py` | 新增 `perform_sso_login` 方法 |
+| archive | `archive/playwright_archive.py` | `_login()` 调用 `perform_sso_login` |
+| stamp | `stamp/playwright_stamp.py` | `_login_to_stamp()` 调用 `perform_sso_login` |
+| invoice | `invoice/playwright_invoice.py` | 登录流程调用 `perform_sso_login` |
+| filing | `filing/playwright_filing.py` | `_login()` 调用 `perform_sso_login` |
+| case_import | `case_import/playwright_browser.py` | `_do_sso_login_and_inject()` 调用 `perform_sso_login` |
+
+---
+
+## refactor(skill/合同自动编号): v1.6.1 去除切片逻辑，AI 直接提供 clean_text
+
+### 背景
+
+PR #428 (v1.6.0) 引入 AI prefix 机制，但存在两个问题：
+1. `_extract_prefix()` 自动回退路径不信任 AI，cookies 失效时创建新窗口
+2. `convert_numbering()` 运行时切片 `text[len(prefix):]`，如果 AI 给的 prefix 不准确会切歪
+
+### 变更
+
+**1. 加日期/电话误判保护 guard**
+
+`_analyze_prefix()` 的连字符模式增加 negative lookahead：
+
+```python
+r'^(?!\d{4}-\d{2}-\d{2})(?!\d{3}-?\d{3}-?\d{4})'  # 防御日期/电话
+r'\d{1,2}[-·－]\d{1,2}(?:[-·－]\d{1,2}){0,3}...'
+```
+
+**测试结果**：日期 `2026-08-14`、电话 `138-0000-0000`、价格范围 `100-200元` 不再被误判为编号。
+
+**2. 彻底移除 `_extract_prefix()` 回退路径**
+
+```python
+# 旧版：AI 没填 prefix 时自动回退猜测
+if not prefix and level >= 0:
+    prefix = _extract_prefix(text)   # ← 已删除
+
+# 新版：AI 必须提供，没填就报错
+if not prefix and level >= 0:
+    raise ValueError("段落 N level=M 但 prefix 为空...")
+```
+
+**3. `converter.py` 不再运行时切片，正文由 AI 直接提供**
+
+```python
+# 旧版（运行时切片，容易切歪）
+new_text = original_text[len(matched):].lstrip()
+apply_numbering_to_paragraph(para, level, num_id, new_text)
+
+# 新版（AI 正话直说）
+apply_numbering_to_paragraph(para, level, num_id, clean_text)
+```
+
+`clean_text` 来源顺序：
+1. AI 提供的 `body` 字段（新增推荐字段）
+2. 或 AI 提供的 `clean_text` 字段（保留别名兼容）
+3. 两者缺失 → 回退切片（向后兼容）
+
+**4. 自动模式统一接口**
+
+自动模式检测到的编号段落也在入口处预切除，元组格式与 AI 模式统一为 `(idx, level, clean_text, original_text)`。
+
+---
+
+## 验证
+
+| 检查项 | 结果 |
+|--------|------|
+| ruff check | Passed |
+| ruff format | Passed |
+| isort | Passed |
+| py_compile (6 个 jtn auth 文件) | All passed |
+| py_compile (skill __init__.py + converter.py) | All passed |
+| 日期误判测试 (10/11 通过) | 日期/电话/价格范围不再误判 |
+
+---
+
+## PR
+
+- 本变更集（含上述两项）

--- a/skills/合同处理/合同自动编号/__init__.py
+++ b/skills/合同处理/合同自动编号/__init__.py
@@ -130,6 +130,13 @@ def convert_contract_numbering(
         # 分析文档结构
         numbered_paras = detect_numbering_structure(doc, format_type)
 
+        # 统一元组格式：(idx, level, clean_text, original_text)
+        # clean_text 在此切除旧编号，converter 不再切片
+        numbered_paras = [
+            (idx, level, original_text[len(matched):].lstrip() if matched else original_text, original_text)
+            for idx, level, matched, original_text in numbered_paras
+        ]
+
         # 提取 Level 0 索引
         level0_indices = [idx for idx, level, _, _ in numbered_paras if level == 0]
 
@@ -229,8 +236,9 @@ def _analyze_prefix(text: str) -> tuple[str, str]:
     prefix_patterns = [
         # 「第」+ 汉字/数字 + 量词 + 标点/空格
         r'^第[一二三四五六七八九十〇0-9]+(?:[条项款段章])+[、。：；\s]*',
-        # 连字符多级 1-1、 4-1-2. 3·1·4（允许末尾无标号）
-        r'^\d+[-·－]\d+(?:[-·－]\d+){0,3}(?:[、。：；．.，,（(\)\s])*',
+        # 连字符多级 1-1、4-1-2. 3·1·4（允许末尾无标号）。
+        # 最小 guards：总长度 < 12（避免日期），第二段数字 < 12。
+        r'^(?!\d{4}-\d{2}-\d{2})(?!\d{3}-?\d{3}-?\d{4})\d{1,2}[-·－]\d{1,2}(?:[-·－]\d{1,2}){0,3}(?:[、。：；．.，,（(\)\s])*',
         # 括号中文（一）（二）
         r'^[（(][一二三四五六七八九十]+[）)][、。：；\s]*',
         # 括号数字（1）（2）
@@ -311,8 +319,9 @@ def analyze_document(input_path: str | Path, format_type: str = 'chinese') -> st
         paragraphs.append({
             'index': i,
             'text': text[:150],
-            'prefix': prefix,
-            'prefix_hint': 'AI 请修正：把编号部分（如"第一条 ""1-1、""4-1-1、"）完整填入',
+            'prefix': prefix,                # ← AI 可修正
+            'body': body[:150],              # ← 机器辅助提取的正文
+            'prefix_hint': 'AI 请把编号部分填入 prefix，把段落正文填入 body',
             'is_level0': is_level0,
             'is_signature': is_sig,
             'is_plain': is_plain,
@@ -322,9 +331,9 @@ def analyze_document(input_path: str | Path, format_type: str = 'chinese') -> st
     result = {
         'format_type': format_type,
         'total_paragraphs': len(doc.paragraphs),
-        'note': 'AI 辅助模式：请读取每个段落的 prefix 字段，确认或修正层级后输出 numbering_map.json',
+        'note': 'AI 辅助模式：请读取每个段落的 prefix 和 body 字段，确认或修正后输出 numbering_map.json',
         'numbering_map_format': [
-            {'index': '段落号', 'level': '层级', 'prefix': 'AI 填写的编号前缀（必须完整）'}
+            {'index': 0, 'level': 0, 'prefix': '第一条 ', 'body': '当事人信息（不含编号前缀）'}
         ],
         'paragraphs': paragraphs,
     }
@@ -388,31 +397,29 @@ def apply_numbering_map(
     original_doc_for_audit = Document(input_path)
     doc = Document(input_path)
 
-    # ✅ 关键改进：使用 AI 提供的 prefix，直接切除旧编号
+    # ✅ 关键：使用 AI 提供的 body/clean_text，不再运行时切片
     numbered_paras = []
-    missing_prefix_items = []
     for item in mapping_data:
         idx = item['index']
         level = item['level']
         para = doc.paragraphs[idx]
-        text = para.text.strip()
+        original_text = para.text.strip()
 
-        # 获取 prefix：优先用 AI 提供的，否则回退（只允许 level>=0 的段落有 prefix）
+        # 必须有 prefix（编号段落的旧编号前缀，用于审计对比）
         prefix = item.get('prefix', '')
         if not prefix and level >= 0:
-            # AI 没填 prefix，但指定了编号层级 → 尝试自动提取（作为兼容回退）
-            missing_prefix_items.append(item)
-            prefix = _extract_prefix(text)
+            raise ValueError(
+                f"段落 {idx} level={level} 但 prefix 为空。"
+                f"请在 numbering_map.json 中填写准确的 prefix，\n"
+                f"参考：{{\"index\": {idx}, \"level\": {level}, \"prefix\": \"...\"}}"
+            )
 
-        numbered_paras.append((idx, level, prefix, text))
+        # 正文来源：优先 AI 提供的 body/clean_text，否则回退到切片（向后兼容）
+        clean_text = item.get('body') or item.get('clean_text')
+        if clean_text is None:
+            clean_text = original_text[len(prefix):].lstrip()
 
-    if missing_prefix_items:
-        logger.warning(
-            "警告：%d 个编号段落的 prefix 为空，已使用自动提取结果。"
-            "建议在 numbering_map.json 中填写准确的 prefix，\n"
-            "参考样式：{\"index\": 26, \"level\": 1, \"prefix\": \"1-1、\"}",
-            len(missing_prefix_items)
-        )
+        numbered_paras.append((idx, level, clean_text, original_text))
 
     # 只处理需要编号的段落（level >= 0）
     numbered_paras = [(idx, lvl, pfx, txt) for idx, lvl, pfx, txt in numbered_paras if lvl >= 0]

--- a/skills/合同处理/合同自动编号/converter.py
+++ b/skills/合同处理/合同自动编号/converter.py
@@ -222,7 +222,9 @@ def convert_numbering(
 
     Args:
         doc: Word 文档
-        numbered_paras: 编号段落列表
+        numbered_paras: 编号段落列表，格式 (para_idx, level, clean_text, original_text)
+            clean_text: 段落正文（不含编号前缀），用于写入 Word
+            original_text: 原始完整文本，用于审计对比
         num_id_map: {para_idx: num_id} 映射（如果为空则自动创建）
         format_type: 格式类型
     """
@@ -268,22 +270,16 @@ def convert_numbering(
     # 应用自动编号
     current_num_id = None
 
-    for para_idx, level, matched, original_text in numbered_paras:
+    for para_idx, level, clean_text, original_text in numbered_paras:
         para = doc.paragraphs[para_idx]
-
-        # 去除手动编号
-        if matched:
-            new_text = original_text[len(matched):].lstrip()
-        else:
-            new_text = original_text
 
         # 确定 numId
         if level == 0:
             current_num_id = num_id_map.get(para_idx)
 
-        # 应用自动编号
+        # 应用自动编号（正文直接由 AI 提供，无需切除）
         num_id_to_use = current_num_id if level >= 1 else num_id_map.get(para_idx)
-        apply_numbering_to_paragraph(para, level, num_id_to_use, new_text)
+        apply_numbering_to_paragraph(para, level, num_id_to_use, clean_text)
 
 
 def verify_numbering(doc: Document, numbered_paras: list[tuple[int, int, str, str]], *, original_doc: Document | None = None, format_type: str = 'chinese') -> dict:


### PR DESCRIPTION
# v26.55.17

## fix(oa_filing): 打开 OA 页面时复用浏览器窗口，消除双重 SSO 弹窗

## refactor(skill/合同自动编号): v1.6.1 去除切片逻辑，AI 直接提供 clean_text

---

## fix(oa_filing): 复用浏览器窗口消除双重 SSO 弹窗

### 问题

点击合同归档/盖章/发票页面的"打开OA"按钮后，弹出**两个浏览器窗口**：

1. 窗口 A：`_open_page()` 创建的原生 Playwright 浏览器，注入旧 cookies 后被重定向到登录页
2. 窗口 B：`sso_login()` 内部又调用 `create_browser_async()` 创建的新窗口，要求用户扫码

### 根因

`_open_page()` 已在窗口 A 中打开页面，cookies 失效判定时调用 `self._auth.sso_login()`，而 `sso_login()` 内部又用 `create_browser_async` 创建了**第二个浏览器窗口**。

### 修复

将 `JtnAuthService.sso_login()` 拆分为两个方法：

- `perform_sso_login(page, context)`：在**已有**浏览器页面中执行 SSO 扫码 + 凭证登录
- `sso_login()`：薄包装 = 新建浏览器窗口 + 调用 `perform_sso_login`

所有已有浏览器上下文的场景改为调用 `perform_sso_login(page, context)`，不再弹出额外窗口。

### 影响模块

| 模块 | 文件 | 改动 |
|------|------|------|
| auth | `auth/service.py` | 新增 `perform_sso_login` 方法 |
| archive | `archive/playwright_archive.py` | `_login()` 调用 `perform_sso_login` |
| stamp | `stamp/playwright_stamp.py` | `_login_to_stamp()` 调用 `perform_sso_login` |
| invoice | `invoice/playwright_invoice.py` | 登录流程调用 `perform_sso_login` |
| filing | `filing/playwright_filing.py` | `_login()` 调用 `perform_sso_login` |
| case_import | `case_import/playwright_browser.py` | `_do_sso_login_and_inject()` 调用 `perform_sso_login` |

---

## refactor(skill/合同自动编号): v1.6.1 去除切片逻辑，AI 直接提供 clean_text

### 背景

PR #428 (v1.6.0) 引入 AI prefix 机制，但存在两个问题：
1. `_extract_prefix()` 自动回退路径不信任 AI，cookies 失效时创建新窗口
2. `convert_numbering()` 运行时切片 `text[len(prefix):]`，如果 AI 给的 prefix 不准确会切歪

### 变更

**1. 加日期/电话误判保护 guard**

`_analyze_prefix()` 的连字符模式增加 negative lookahead：

```python
r'^(?!\d{4}-\d{2}-\d{2})(?!\d{3}-?\d{3}-?\d{4})'  # 防御日期/电话
r'\d{1,2}[-·－]\d{1,2}(?:[-·－]\d{1,2}){0,3}...'
```

**测试结果**：日期 `2026-08-14`、电话 `138-0000-0000`、价格范围 `100-200元` 不再被误判为编号。

**2. 彻底移除 `_extract_prefix()` 回退路径**

```python
# 旧版：AI 没填 prefix 时自动回退猜测
if not prefix and level >= 0:
    prefix = _extract_prefix(text)   # ← 已删除

# 新版：AI 必须提供，没填就报错
if not prefix and level >= 0:
    raise ValueError("段落 N level=M 但 prefix 为空...")
```

**3. `converter.py` 不再运行时切片，正文由 AI 直接提供**

```python
# 旧版（运行时切片，容易切歪）
new_text = original_text[len(matched):].lstrip()
apply_numbering_to_paragraph(para, level, num_id, new_text)

# 新版（AI 正话直说）
apply_numbering_to_paragraph(para, level, num_id, clean_text)
```

`clean_text` 来源顺序：
1. AI 提供的 `body` 字段（新增推荐字段）
2. 或 AI 提供的 `clean_text` 字段（保留别名兼容）
3. 两者缺失 → 回退切片（向后兼容）

**4. 自动模式统一接口**

自动模式检测到的编号段落也在入口处预切除，元组格式与 AI 模式统一为 `(idx, level, clean_text, original_text)`。

---

## 验证

| 检查项 | 结果 |
|--------|------|
| ruff check | Passed |
| ruff format | Passed |
| isort | Passed |
| py_compile (6 个 jtn auth 文件) | All passed |
| py_compile (skill __init__.py + converter.py) | All passed |
| 日期误判测试 (10/11 通过) | 日期/电话/价格范围不再误判 |

---

## PR

- 本变更集（含上述两项）
