### PR TITLE
fix(ci): 修复 CI statement_timeout 超时与 logging request_id KeyError

### DIFF
--- a/backend/apiSystem/apiSystem/settings.py
+++ b/backend/apiSystem/apiSystem/settings.py
@@ -254,9 +254,12 @@ elif DB_ENGINE in ("", "postgres", "postgresql", "django.db.backends.postgresql"
     # 测试/开发环境下添加数据库超时，防止 flaky test 在 psycopg socket wait 中 hang 住
     # 导致 CI 60 分钟超时。statement_timeout 让长时间 SQL 自动失败，
     # idle_in_transaction_session_timeout 让持有事务不释放的连接自动取消。
+    # 可通过 DB_STATEMENT_TIMEOUT_MS 环境变量覆盖（单位：毫秒），
+    # 默认 120000（2 分钟），避免 Django flush（TRUNCATE 所有表）在 CI 中超时。
     _pg_options: dict[str, object] = {"connect_timeout": 10}
     if DEBUG:
-        _pg_options["options"] = "-c statement_timeout=30000 -c idle_in_transaction_session_timeout=60000"
+        _stmt_timeout = os.environ.get("DB_STATEMENT_TIMEOUT_MS", "120000")
+        _pg_options["options"] = f"-c statement_timeout={_stmt_timeout} -c idle_in_transaction_session_timeout=60000"
 
     DATABASES = {
         "default": {

--- a/backend/apps/core/infrastructure/logging.py
+++ b/backend/apps/core/infrastructure/logging.py
@@ -72,6 +72,27 @@ class RequestContextFilter(logging.Filter):
         return True
 
 
+class VerboseFormatter(logging.Formatter):
+    """安全格式化器：确保 request_id / trace_id / span_id / task_name 始终存在。
+
+    当 RequestContextFilter 未运行时（如测试环境），为缺失字段提供默认值，
+    避免 format 字符串中的 {request_id} 等字段抛出 KeyError。
+    """
+
+    _DEFAULTS: ClassVar[dict[str, str]] = {
+        "request_id": "",
+        "trace_id": "",
+        "span_id": "",
+        "task_name": "",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        for attr, default in self._DEFAULTS.items():
+            if not hasattr(record, attr):
+                setattr(record, attr, default)
+        return super().format(record)
+
+
 class SensitiveDataFilter(logging.Filter):
     """敏感数据过滤器，自动脱敏日志中的敏感信息"""
 
@@ -285,6 +306,7 @@ def get_logging_config(base_dir: Any, debug: bool = True) -> dict[str, Any]:
         "disable_existing_loggers": False,
         "formatters": {
             "verbose": {
+                "()": "apps.core.infrastructure.logging.VerboseFormatter",
                 "format": "[{asctime}] {levelname} [{request_id}] {name} {module}.{funcName}:{lineno} - {message}",
                 "style": "{",
                 "datefmt": "%Y-%m-%d %H:%M:%S",


### PR DESCRIPTION
## Summary
- 修复 `backend-unit-coverage` CI 失败的两个根因
- `statement_timeout` 从 30s 提高到 120s，避免 flush 超时
- 新增 `VerboseFormatter` 防止 `request_id` KeyError

## 问题详情

### 1. psycopg.errors.QueryCanceled（flush 超时）
`DEBUG=True` 时 `statement_timeout=30000`（30s），Django 测试 teardown 时的 `flush`（TRUNCATE 所有表）超过 30s 被 PostgreSQL 取消。

**修复**: 提高到 120s，支持 `DB_STATEMENT_TIMEOUT_MS` 环境变量覆盖。

### 2. KeyError: 'request_id'（日志格式化器）
`verbose` 格式化器使用 `{request_id}` 占位符，依赖 `RequestContextFilter` 设置该字段。当 filter 未运行时，`LogRecord` 缺少该属性导致 `KeyError`。

**修复**: 新增 `VerboseFormatter`，在 `format()` 时为缺失字段填充默认值。

## Test plan
- [ ] GitHub CI `backend-unit-coverage` 通过
- [ ] ruff / pre-commit 通过