### PR TITLE
fix(oa-filing): 修复 OA 弹窗 iframe 等待、案件选择校验、浏览器清理和 worker fork 崩溃

### DIFF
--- a/backend/apiSystem/manage.py
+++ b/backend/apiSystem/manage.py
@@ -6,12 +6,16 @@ import os
 import sys
 from pathlib import Path
 
-# macOS 上 fork() 可能因 Objective-C 运行时冲突导致子进程 crash，
-# 使用 spawn 替代 fork 避免 django-q worker 崩溃重生。
+# macOS 上 fork() 可能因 Objective-C 运行时冲突导致子进程 crash。
+# 1. 设置 spawn 为默认 start method（通用最佳实践）。
+# 2. OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES 是 Apple 官方方案，
+#    让 fork 后的子进程跳过 ObjC 运行时安全检查。
+#    django-q 内部硬编码 get_context("fork")，仅靠 spawn 不够，必须加此变量。
 try:
     multiprocessing.set_start_method("spawn")
 except RuntimeError:
-    pass  # 已设置过则忽略
+    pass
+os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
 
 _project_root = Path(__file__).resolve().parent.parent
 _project_root_str = str(_project_root)

--- a/backend/apiSystem/manage.py
+++ b/backend/apiSystem/manage.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
+import multiprocessing
 import os
 import sys
 from pathlib import Path
+
+# macOS 上 fork() 可能因 Objective-C 运行时冲突导致子进程 crash，
+# 使用 spawn 替代 fork 避免 django-q worker 崩溃重生。
+try:
+    multiprocessing.set_start_method("spawn")
+except RuntimeError:
+    pass  # 已设置过则忽略
 
 _project_root = Path(__file__).resolve().parent.parent
 _project_root_str = str(_project_root)

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/adapter.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/adapter.py
@@ -15,6 +15,13 @@ from django.apps import apps as django_apps
 # 每个元素是 (playwright, browser) 元组。
 _active_browser_sessions: list[tuple[Any, Any]] = []
 
+
+def _cleanup_stale_sessions() -> None:
+    """移除已断开连接的浏览器会话。"""
+    global _active_browser_sessions
+    _active_browser_sessions[:] = [(pw, br) for pw, br in _active_browser_sessions if br.is_connected()]
+
+
 from apps.oa_filing.services.base_firm_adapter import (
     ArchiveAdapter,
     CaseImportAdapter,
@@ -220,6 +227,7 @@ class JTNAdapter(FilingAdapter, StampAdapter, ArchiveAdapter, CaseImportAdapter,
 
         script = JtnArchiveScript(account=str(credential.account), password=str(credential.password))
         playwright, browser = await script.open_page(oa_case_number, description)
+        _cleanup_stale_sessions()
         _active_browser_sessions.append((playwright, browser))
 
     async def open_invoice_page(
@@ -232,6 +240,7 @@ class JTNAdapter(FilingAdapter, StampAdapter, ArchiveAdapter, CaseImportAdapter,
 
         script = JtnInvoiceScript(account=str(credential.account), password=str(credential.password))
         playwright, browser = await script.open_page(oa_case_number)
+        _cleanup_stale_sessions()
         _active_browser_sessions.append((playwright, browser))
 
     async def open_stamp_page(
@@ -244,6 +253,7 @@ class JTNAdapter(FilingAdapter, StampAdapter, ArchiveAdapter, CaseImportAdapter,
 
         script = JtnStampScript(account=str(credential.account), password=str(credential.password))
         playwright, browser = await script.open_page(oa_case_number)
+        _cleanup_stale_sessions()
         _active_browser_sessions.append((playwright, browser))
 
     # ==================================================================

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/archive/playwright_archive.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/archive/playwright_archive.py
@@ -15,7 +15,6 @@ from ..auth.service import JtnAuthService
 from .archive_models import ArchiveFormData
 from .constants import (
     _POPUP_IFRAME_KEYWORD,
-    AJAX_WAIT,
     ARCHIVE_PAGE_URL,
     DESCRIPTION_SELECTOR,
     IFRAME_PROJECT_NO_SELECTOR,
@@ -118,7 +117,8 @@ class PlaywrightArchiveMixin:  # pragma: no cover
         if popup_frame is None:
             raise RuntimeError("未找到案件搜索弹窗 iframe")
 
-        # 3. 在 iframe 中搜索案件
+        # 3. 等待 iframe 内容加载完成，再操作 DOM
+        await popup_frame.wait_for_selector("#project_no", timeout=10_000)
         await popup_frame.evaluate(f"""() => {{
             const el = document.getElementById("project_no");
             el.removeAttribute("readonly");
@@ -127,14 +127,36 @@ class PlaywrightArchiveMixin:  # pragma: no cover
         await asyncio.sleep(SHORT_WAIT)
 
         await popup_frame.evaluate(IFRAME_SEARCH_FN)
-        await asyncio.sleep(AJAX_WAIT)
 
-        # 4. 选择第一个结果
-        radio_count = await popup_frame.locator('input[type="radio"]').count()
-        if radio_count == 0:
-            raise RuntimeError(f"未找到案件: {case_no}")
+        # 4. 轮询等待搜索结果中出现目标案件编号，校验后选择匹配行
+        import time as _time
 
-        await popup_frame.evaluate('document.querySelectorAll("input[type=radio]")[0].click()')
+        deadline = _time.monotonic() + 30
+        while True:
+            matched = await popup_frame.evaluate(
+                """(expected) => {{
+                const radios = document.querySelectorAll('input[type="radio"]');
+                for (const radio of radios) {{
+                    const row = radio.closest('tr');
+                    if (!row) continue;
+                    const tds = row.querySelectorAll('td');
+                    if (tds.length < 2) continue;
+                    const caseNo = tds[1].textContent.trim();
+                    if (caseNo === expected) {{
+                        radio.click();
+                        return true;
+                    }}
+                }}
+                return false;
+            }}""",
+                case_no,
+            )
+            if matched:
+                break
+            if _time.monotonic() > deadline:
+                raise RuntimeError(f"搜索结果中未找到案件: {case_no}")
+            await asyncio.sleep(1)
+
         await asyncio.sleep(SHORT_WAIT)
         logger.info("已选择案件: %s", case_no)
 
@@ -237,6 +259,15 @@ class PlaywrightArchiveMixin:  # pragma: no cover
         browser = await playwright.chromium.launch(headless=False)
         context = await browser.new_context()
         page = await context.new_page()
+
+        # 用户关闭浏览器时自动清理 playwright，释放进程
+        def _cleanup(_: Any = None) -> None:
+            try:
+                asyncio.run(playwright.stop())
+            except Exception:
+                pass
+
+        browser.on("disconnected", _cleanup)
 
         try:
             await self._login(page, context)

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/invoice/playwright_invoice.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/invoice/playwright_invoice.py
@@ -40,6 +40,15 @@ class PlaywrightInvoiceMixin:
         context = await browser.new_context()
         page = await context.new_page()
 
+        # 用户关闭浏览器时自动清理 playwright，释放进程
+        def _cleanup(_: Any = None) -> None:
+            try:
+                asyncio.run(playwright.stop())
+            except Exception:
+                pass
+
+        browser.on("disconnected", _cleanup)
+
         try:
             # ── 登录 ──
             cached = self._auth.load_cookies()

--- a/backend/apps/oa_filing/services/oa_scripts/jtn/stamp/playwright_stamp.py
+++ b/backend/apps/oa_filing/services/oa_scripts/jtn/stamp/playwright_stamp.py
@@ -14,7 +14,6 @@ from apps.core.services.browser import BrowserProfile, create_browser_async
 from ..auth.service import JtnAuthService
 from .constants import (
     _POPUP_IFRAME_KEYWORD,
-    AJAX_WAIT,
     DEFAULT_STAMP_COPIES,
     FILE_TYPE_SOUHAN,
     IFRAME_PROJECT_NO_SELECTOR,
@@ -136,7 +135,8 @@ class PlaywrightStampMixin:  # pragma: no cover
         if popup_frame is None:
             raise RuntimeError("未找到案件搜索弹窗 iframe")
 
-        # 3. 在 iframe 中搜索案件
+        # 3. 等待 iframe 内容加载完成，再操作 DOM
+        await popup_frame.wait_for_selector("#project_no", timeout=10_000)
         await popup_frame.evaluate(f"""() => {{
             const el = document.getElementById("project_no");
             el.removeAttribute("readonly");
@@ -145,14 +145,36 @@ class PlaywrightStampMixin:  # pragma: no cover
         await asyncio.sleep(SHORT_WAIT)
 
         await popup_frame.evaluate(IFRAME_SEARCH_FN)
-        await asyncio.sleep(AJAX_WAIT)
 
-        # 4. 选择第一个结果
-        radio_count = await popup_frame.locator('input[type="radio"]').count()
-        if radio_count == 0:
-            raise RuntimeError(f"未找到案件: {case_no}")
+        # 4. 轮询等待搜索结果中出现目标案件编号，校验后选择匹配行
+        import time as _time
 
-        await popup_frame.evaluate('document.querySelectorAll("input[type=radio]")[0].click()')
+        deadline = _time.monotonic() + 30
+        while True:
+            matched = await popup_frame.evaluate(
+                """(expected) => {{
+                const radios = document.querySelectorAll('input[type="radio"]');
+                for (const radio of radios) {{
+                    const row = radio.closest('tr');
+                    if (!row) continue;
+                    const tds = row.querySelectorAll('td');
+                    if (tds.length < 2) continue;
+                    const caseNo = tds[1].textContent.trim();
+                    if (caseNo === expected) {{
+                        radio.click();
+                        return true;
+                    }}
+                }}
+                return false;
+            }}""",
+                case_no,
+            )
+            if matched:
+                break
+            if _time.monotonic() > deadline:
+                raise RuntimeError(f"搜索结果中未找到案件: {case_no}")
+            await asyncio.sleep(1)
+
         await asyncio.sleep(SHORT_WAIT)
         logger.info("已选择案件: %s", case_no)
 
@@ -315,6 +337,15 @@ class PlaywrightStampMixin:  # pragma: no cover
         browser = await playwright.chromium.launch(headless=False)
         context = await browser.new_context()
         page = await context.new_page()
+
+        # 用户关闭浏览器时自动清理 playwright，释放进程
+        def _cleanup(_: Any = None) -> None:
+            try:
+                asyncio.run(playwright.stop())
+            except Exception:
+                pass
+
+        browser.on("disconnected", _cleanup)
 
         try:
             await self._login_to_stamp(page, context)

--- a/changelog/v26.55/v26.55.19.md
+++ b/changelog/v26.55/v26.55.19.md
@@ -1,0 +1,157 @@
+# v26.55.19
+
+## fix(oa-filing): 修复 OA 弹窗 iframe 等待、案件选择校验和浏览器进程残留
+
+## fix(django-q): macOS 上 multiprocessing 用 spawn 替代 fork，避免 worker 崩溃
+
+---
+
+## fix(oa-filing): 修复 OA 弹窗 iframe 等待、案件选择校验和浏览器进程残留
+
+### 问题
+
+打开 OA 归档/盖章页面时，`_search_and_select_case` 方法存在三个问题：
+
+1. **iframe 加载未完成就操作 DOM**：找到弹窗 iframe 后直接 `evaluate` 操作 `#project_no`，DOM 未就绪 → `Cannot read properties of null (reading 'removeAttribute')`
+2. **搜索后固定 3s 等待不够**：律所服务器慢时搜索结果未返回就检查 radio → `未找到案件`
+3. **盲选第一条结果**：`document.querySelectorAll("input[type=radio]")[0].click()` 不校验案件编号，选中了错误的案件
+4. **用户关闭浏览器后进程残留**：`playwright` 未 stop → dock 栏出现多个 "Google Chrome for Testing"
+
+### 根因
+
+| 问题 | 根因 |
+|------|------|
+| DOM 未就绪 | 弹窗 iframe 的 `src` 加载需要时间，`evaluate` 时 `#project_no` 还是 null |
+| 搜索等待不足 | `asyncio.sleep(AJAX_WAIT)` 固定 3s，律所服务器/网络慢时结果未返回 |
+| 选错案件 | 搜索结果表格可能有默认选中行，`[0]` 盲选不检查案件编号 |
+| 进程残留 | `_open_page` 手动创建 playwright/browser 后存入 `_active_browser_sessions`，用户关闭窗口后无任何 cleanup |
+
+### 修复
+
+#### 1. iframe 加载等待（archive + stamp）
+
+```python
+# 旧版：找到 iframe 后直接操作 DOM
+popup_frame = await self._find_popup_frame(page)
+
+# 新版：等待 DOM 元素就绪
+await popup_frame.wait_for_selector("#project_no", timeout=10_000)
+```
+
+#### 2. 搜索结果等待 + 案件编号校验（archive + stamp）
+
+```python
+# 旧版：固定 sleep + 盲选 [0]
+await asyncio.sleep(AJAX_WAIT)
+radio_count = await popup_frame.locator('input[type="radio"]').count()
+await popup_frame.evaluate('document.querySelectorAll("input[type=radio]")[0].click()')
+
+# 新版：每 1s 轮询遍历表格行，匹配案件编号后点击，30s 超时
+import time as _time
+deadline = _time.monotonic() + 30
+while True:
+    matched = await popup_frame.evaluate("""(expected) => {{
+        const radios = document.querySelectorAll('input[type="radio"]');
+        for (const radio of radios) {{
+            const row = radio.closest('tr');
+            if (!row) continue;
+            const tds = row.querySelectorAll('td');
+            if (tds.length < 2) continue;
+            const caseNo = tds[1].textContent.trim();
+            if (caseNo === expected) {{ radio.click(); return true; }}
+        }}
+        return false;
+    }}""", case_no)
+    if matched: break
+    if _time.monotonic() > deadline:
+        raise RuntimeError(f"搜索结果中未找到案件: {case_no}")
+    await asyncio.sleep(1)
+```
+
+#### 3. 浏览器进程清理（archive + stamp + invoice）
+
+```python
+# 旧版：无 cleanup
+playwright = await async_playwright().start()
+browser = await playwright.chromium.launch(headless=False)
+
+# 新版：监听 browser 断开事件，自动 stop playwright
+def _cleanup(_=None):
+    try:
+        asyncio.run(playwright.stop())
+    except Exception:
+        pass
+browser.on("disconnected", _cleanup)
+```
+
+#### 4. 过期 session 清理（adapter）
+
+```python
+# 每次追加新 session 前，先过滤掉已断开的
+def _cleanup_stale_sessions():
+    _active_browser_sessions[:] = [
+        (pw, br) for pw, br in _active_browser_sessions
+        if br.is_connected()
+    ]
+```
+
+### 影响范围
+
+| 文件 | 改动 |
+|------|------|
+| `archive/playwright_archive.py` | `wait_for_selector` + 轮询校验 + disconnect 清理 |
+| `stamp/playwright_stamp.py` | 同上 |
+| `invoice/playwright_invoice.py` | disconnect 清理 |
+| `adapter.py` | `_cleanup_stale_sessions()` + 调用 |
+
+---
+
+## fix(django-q): macOS 上 multiprocessing 用 spawn 替代 fork，避免 worker 崩溃
+
+### 问题
+
+Django-Q worker 反复崩溃重生，日志出现：
+
+```
+objc[xxx]: +[NSNumber initialize] may have been in progress in another thread
+when fork() was called. We cannot safely call it or ignore it in the fork()
+child process. Crashing instead.
+[CRITICAL] - 意外宕机后worker Process-xxx 已重生
+```
+
+### 根因
+
+macOS 上 Python `multiprocessing` 默认使用 `fork()` 创建子进程。Django-Q 用 `fork()` 派生 worker 时，如果恰好有其他线程在初始化 Objective-C 类（`NSNumber` 等），子进程的 Objective-C 运行时检测到不安全状态，直接 crash。
+
+### 修复
+
+`manage.py` 最前面设置 `multiprocessing.set_start_method("spawn")`，用 `spawn` 替代 `fork`：
+
+```python
+import multiprocessing
+
+# macOS 上 fork() 可能因 Objective-C 运行时冲突导致子进程 crash，
+# 使用 spawn 替代 fork 避免 django-q worker 崩溃重生。
+try:
+    multiprocessing.set_start_method("spawn")
+except RuntimeError:
+    pass  # 已设置过则忽略
+```
+
+`spawn` 方式启动全新 Python 解释器，彻底避开 fork 后 Objective-C 状态不一致的问题。
+
+### 影响范围
+
+| 文件 | 改动 |
+|------|------|
+| `manage.py` | 新增 `multiprocessing.set_start_method("spawn")` |
+
+---
+
+## 验证
+
+| 检查项 | 结果 |
+|--------|------|
+| ruff check | Passed |
+| ruff format | Passed |
+| pre-commit hooks | All passed |

--- a/changelog/v26.55/v26.55.19.md
+++ b/changelog/v26.55/v26.55.19.md
@@ -106,7 +106,7 @@ def _cleanup_stale_sessions():
 
 ---
 
-## fix(django-q): macOS 上 multiprocessing 用 spawn 替代 fork，避免 worker 崩溃
+## fix(django-q): macOS 上修复 worker fork 崩溃（双重保险）
 
 ### 问题
 
@@ -121,30 +121,34 @@ child process. Crashing instead.
 
 ### 根因
 
-macOS 上 Python `multiprocessing` 默认使用 `fork()` 创建子进程。Django-Q 用 `fork()` 派生 worker 时，如果恰好有其他线程在初始化 Objective-C 类（`NSNumber` 等），子进程的 Objective-C 运行时检测到不安全状态，直接 crash。
+macOS 上 Python `multiprocessing` 默认使用 `fork()` 创建子进程。Django-Q 内部 `django_q/cluster.py` 硬编码 `get_context("fork")`，即使设置了 `set_start_method("spawn")` 也会被覆盖。`fork()` 时如果其他线程在初始化 `NSNumber` 等 Objective-C 类，子进程 crash。
 
-### 修复
+### 修复（双重保险）
 
-`manage.py` 最前面设置 `multiprocessing.set_start_method("spawn")`，用 `spawn` 替代 `fork`：
+**第一层：`set_start_method("spawn")`** — 设置默认 start method 为 spawn，处理非 django-q 的多进程调用。
+
+**第二层：`OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`** — Apple 官方环境变量，让 fork 子进程跳过 ObjC 运行时安全检查。这是真正的修复，因为 django-q 内部硬编码了 `fork`，仅靠 spawn 不够。
 
 ```python
 import multiprocessing
+import os
 
-# macOS 上 fork() 可能因 Objective-C 运行时冲突导致子进程 crash，
-# 使用 spawn 替代 fork 避免 django-q worker 崩溃重生。
+# 1. 默认 spawn（通用最佳实践）
 try:
     multiprocessing.set_start_method("spawn")
 except RuntimeError:
-    pass  # 已设置过则忽略
-```
+    pass
 
-`spawn` 方式启动全新 Python 解释器，彻底避开 fork 后 Objective-C 状态不一致的问题。
+# 2. Apple 官方方案：让 fork 子进程跳过 ObjC 安全校验
+#    django-q 内部硬编码 get_context("fork")，仅靠 spawn 不够
+os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
+```
 
 ### 影响范围
 
 | 文件 | 改动 |
 |------|------|
-| `manage.py` | 新增 `multiprocessing.set_start_method("spawn")` |
+| `manage.py` | `set_start_method("spawn")` + `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` |
 
 ---
 


### PR DESCRIPTION
## Summary

- **OA 弹窗 iframe 等待**：fill 案件号前 `wait_for_selector("#project_no")`，防止 DOM 未就绪报 null
- **搜索结果等待 + 校验**：触发搜索后轮询遍历表格行匹配案件编号，替代固定 sleep 和盲选 [0]
- **浏览器进程清理**：`browser.on("disconnected")` 自动 stop playwright，防止 dock 栏残留 Chrome 图标
- **django-q worker fork 崩溃**：`OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` 解决 macOS 上 ObjC 运行时冲突

## 改动文件

| 文件 | 改动 |
|------|------|
| `archive/playwright_archive.py` | wait_for_selector + 轮询校验 + disconnect 清理 |
| `stamp/playwright_stamp.py` | 同上 |
| `invoice/playwright_invoice.py` | disconnect 清理 |
| `adapter.py` | _cleanup_stale_sessions() |
| `manage.py` | set_start_method("spawn") + OBJC_DISABLE_INITIALIZE_FORK_SAFETY |

## Test plan

- [x] ruff check passed
- [x] ruff format passed
- [x] pre-commit hooks passed
- [x] mypy-curated passed (no issues in 7 files)
- [ ] 手动测试 OA 归档页面打开（iframe 等待 + 案件选择）
- [ ] 手动测试 OA 盖章页面打开
- [ ] 重启 qcluster 后确认无 worker fork 崩溃

## 注意

合并后需重启 qcluster 服务，`OBJC_DISABLE_INITIALIZE_FORK_SAFETY` 才会生效。