### PR TITLE
feat: v26.56.0 — django-q spawn 修复 + 一张网验证码选择器适配

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -370,21 +370,23 @@ collectstatic: ## 收集静态文件
 # 后台任务
 # ============================================================
 
+# OBJC_DISABLE_INITIALIZE_FORK_SAFETY 必须在解释器启动前设置（libobjc 在 main 前读取），
+# 运行时设置无效；作为 apps/core/apps.py spawn patch 的兜底
 qcluster: migrate ## 启动 Django-Q 任务队列（与 Django Web 启动顺序不限）
 	@pkill -9 -f 'python.*manage.py qcluster' 2>/dev/null || true
 	@sleep 1
-	$(MANAGE) qcluster
+	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES $(MANAGE) qcluster
 
 qcluster-start: migrate ## 启动 Django-Q 并处理待处理任务（与 Django Web 启动顺序不限）
 	@pkill -9 -f 'python.*manage.py qcluster' 2>/dev/null || true
 	@sleep 1
 	$(MANAGE) process_pending_tasks --reset
-	$(MANAGE) qcluster
+	OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES $(MANAGE) qcluster
 
 qcluster-dev: migrate ## 启动 Django-Q（文件变化自动重启）
 	@echo "$(GREEN)启动 qcluster-dev: 检测 Python 文件变化后自动重启 qcluster$(NC)"
 	@echo "$(YELLOW)监听目录: $(QCLUSTER_WATCH_PATHS)$(NC)"
-	@WATCHFILES_FORCE_POLLING=$(QCLUSTER_DEV_FORCE_POLLING) WATCHFILES_POLL_DELAY_MS=$(QCLUSTER_DEV_POLL_DELAY_MS) $(WATCHFILES) --target-type command --filter python --ignore-paths ".venv,node_modules,.git,__pycache__,media,staticfiles,logs,htmlcov,.pytest_cache" "$(MANAGE) qcluster" $(QCLUSTER_WATCH_PATHS)
+	@WATCHFILES_FORCE_POLLING=$(QCLUSTER_DEV_FORCE_POLLING) WATCHFILES_POLL_DELAY_MS=$(QCLUSTER_DEV_POLL_DELAY_MS) OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES $(WATCHFILES) --target-type command --filter python --ignore-paths ".venv,node_modules,.git,__pycache__,media,staticfiles,logs,htmlcov,.pytest_cache" "$(MANAGE) qcluster" $(QCLUSTER_WATCH_PATHS)
 
 process-tasks: ## 处理待处理的爬虫任务
 	$(MANAGE) process_pending_tasks

--- a/backend/apiSystem/manage.py
+++ b/backend/apiSystem/manage.py
@@ -7,15 +7,15 @@ import sys
 from pathlib import Path
 
 # macOS 上 fork() 可能因 Objective-C 运行时冲突导致子进程 crash。
-# 1. 设置 spawn 为默认 start method（通用最佳实践）。
-# 2. OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES 是 Apple 官方方案，
-#    让 fork 后的子进程跳过 ObjC 运行时安全检查。
-#    django-q 内部硬编码 get_context("fork")，仅靠 spawn 不够，必须加此变量。
+# 1. 设置 spawn 为默认 start method（影响未显式指定 context 的 multiprocessing 用法）。
+# 2. django-q 内部硬编码 get_context("fork")，绕过本设置，由
+#    apps/core/apps.py 的 ready() 单独 patch 为 spawn。
+# 3. OBJC_DISABLE_INITIALIZE_FORK_SAFETY 由 libobjc 在进程启动早期读取，
+#    Python 运行时设置无效（对当前进程），兜底在 Makefile 的 qcluster 目标前置。
 try:
     multiprocessing.set_start_method("spawn")
 except RuntimeError:
     pass
-os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
 
 _project_root = Path(__file__).resolve().parent.parent
 _project_root_str = str(_project_root)
@@ -26,6 +26,25 @@ if _project_root_str not in sys.path:
 _plugins_dir = _project_root / "plugins"
 if _plugins_dir.is_dir():
     os.environ.setdefault("RUNPY_EXTRA_WATCH_DIRS", str(_plugins_dir))
+
+
+def _bootstrap_django() -> None:
+    """在模块顶层初始化 Django（而非仅在 main() 内）。
+
+    multiprocessing spawn 子进程的 prepare 阶段会先 re-import 本模块、
+    再 unpickle Process 对象（后者触发 import django_q.cluster）。若不在
+    顶层完成 setup，django_q.cluster 会在模块级自行 setup，导致
+    apps.core.ready() 里的 spawn patch 撞上半初始化的 cluster 模块
+    （get_mp_context 未定义）而崩溃。
+    """
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apiSystem.settings")
+
+    import django
+
+    django.setup()
+
+
+_bootstrap_django()
 
 
 def main() -> None:

--- a/backend/apps/core/apps.py
+++ b/backend/apps/core/apps.py
@@ -14,6 +14,8 @@ class CoreConfig(AppConfig):
     verbose_name = "核心系统"
 
     def ready(self) -> None:  # pragma: no cover
+        self._patch_django_q_mp_context_for_macos()
+
         # 恢复因 runserver auto-reload 中断的 OAuth device code 轮询
         try:
             from .cloud_storage.admin import resume_pending_device_code_polls
@@ -35,6 +37,40 @@ class CoreConfig(AppConfig):
         from django.db.models.signals import post_migrate
 
         post_migrate.connect(self._on_post_migrate, sender=self)
+
+    @staticmethod
+    def _patch_django_q_mp_context_for_macos() -> None:
+        """macOS 上将 django-q 子进程创建方式从 fork 切换为 spawn。
+
+        django-q 的 cluster.py 硬编码 get_context("fork")，会绕过
+        manage.py 里设置的全局 set_start_method("spawn")。fork 在 macOS 上
+        会触发 ObjC 运行时竞态崩溃（+[NSNumber initialize] may have been
+        in progress in another thread when fork() was called）。
+        而 OBJC_DISABLE_INITIALIZE_FORK_SAFETY 由 libobjc 在进程启动早期
+        读取，Python 运行时设置无效，因此必须直接替换 context 工厂函数。
+        django-q 的 sentinel/worker/pusher/monitor 入口均自带 django.setup()，
+        spawn 模式完全兼容。
+        """
+        if sys.platform != "darwin":
+            return
+        try:
+            import multiprocessing
+
+            from django_q import cluster as django_q_cluster
+        except ImportError:
+            logger.debug("django_q 不可用，跳过 spawn patch")
+            return
+
+        original = django_q_cluster.get_mp_context
+        if getattr(original, "_fachuan_spawn_patched", False):
+            return
+
+        def _spawn_context() -> "multiprocessing.context.BaseContext":
+            return multiprocessing.get_context("spawn")
+
+        _spawn_context._fachuan_spawn_patched = True  # type: ignore[attr-defined]
+        django_q_cluster.get_mp_context = _spawn_context
+        logger.info("macOS 检测：django-q 子进程改用 spawn 启动，规避 fork ObjC 崩溃")
 
     def _on_post_migrate(self, sender, **kwargs):  # type: ignore[no-untyped-def]
         """数据库迁移完成后自动加载种子数据(仅表为空时)."""

--- a/backend/apps/core/apps.py
+++ b/backend/apps/core/apps.py
@@ -14,7 +14,12 @@ class CoreConfig(AppConfig):
     verbose_name = "核心系统"
 
     def ready(self) -> None:  # pragma: no cover
-        self._patch_django_q_mp_context_for_macos()
+        try:
+            from .tasking.qcluster_spawn import patch_django_q_mp_context_for_macos
+
+            patch_django_q_mp_context_for_macos()
+        except Exception:
+            logger.debug("django-q spawn patch 跳过（未就绪）")
 
         # 恢复因 runserver auto-reload 中断的 OAuth device code 轮询
         try:
@@ -37,40 +42,6 @@ class CoreConfig(AppConfig):
         from django.db.models.signals import post_migrate
 
         post_migrate.connect(self._on_post_migrate, sender=self)
-
-    @staticmethod
-    def _patch_django_q_mp_context_for_macos() -> None:
-        """macOS 上将 django-q 子进程创建方式从 fork 切换为 spawn。
-
-        django-q 的 cluster.py 硬编码 get_context("fork")，会绕过
-        manage.py 里设置的全局 set_start_method("spawn")。fork 在 macOS 上
-        会触发 ObjC 运行时竞态崩溃（+[NSNumber initialize] may have been
-        in progress in another thread when fork() was called）。
-        而 OBJC_DISABLE_INITIALIZE_FORK_SAFETY 由 libobjc 在进程启动早期
-        读取，Python 运行时设置无效，因此必须直接替换 context 工厂函数。
-        django-q 的 sentinel/worker/pusher/monitor 入口均自带 django.setup()，
-        spawn 模式完全兼容。
-        """
-        if sys.platform != "darwin":
-            return
-        try:
-            import multiprocessing
-
-            from django_q import cluster as django_q_cluster
-        except ImportError:
-            logger.debug("django_q 不可用，跳过 spawn patch")
-            return
-
-        original = django_q_cluster.get_mp_context
-        if getattr(original, "_fachuan_spawn_patched", False):
-            return
-
-        def _spawn_context() -> "multiprocessing.context.BaseContext":
-            return multiprocessing.get_context("spawn")
-
-        _spawn_context._fachuan_spawn_patched = True  # type: ignore[attr-defined]
-        django_q_cluster.get_mp_context = _spawn_context
-        logger.info("macOS 检测：django-q 子进程改用 spawn 启动，规避 fork ObjC 崩溃")
 
     def _on_post_migrate(self, sender, **kwargs):  # type: ignore[no-untyped-def]
         """数据库迁移完成后自动加载种子数据(仅表为空时)."""

--- a/backend/apps/core/tasking/qcluster_spawn.py
+++ b/backend/apps/core/tasking/qcluster_spawn.py
@@ -40,6 +40,6 @@ def patch_django_q_mp_context_for_macos() -> None:
     def _spawn_context() -> multiprocessing.context.BaseContext:
         return multiprocessing.get_context("spawn")
 
-    _spawn_context._fachuan_spawn_patched = True  # type: ignore[attr-defined]
+    _spawn_context._fachuan_spawn_patched = True
     django_q_cluster.get_mp_context = _spawn_context
     logger.info("macOS 检测：django-q 子进程改用 spawn 启动，规避 fork ObjC 崩溃")

--- a/backend/apps/core/tasking/qcluster_spawn.py
+++ b/backend/apps/core/tasking/qcluster_spawn.py
@@ -1,0 +1,45 @@
+"""macOS 上 django-q 子进程启动方式从 fork 切换为 spawn。
+
+django-q 的 cluster.py 硬编码 get_context("fork")，在 macOS 上会触发
+ObjC 运行时竞态崩溃（+[NSNumber initialize] may have been in progress
+in another thread when fork() was called）。OBJC_DISABLE_INITIALIZE_FORK_SAFETY
+由 libobjc 在进程启动早期读取，Python 运行时设置无效，因此必须直接替换
+context 工厂函数。
+
+django-q 的 sentinel/worker/pusher/monitor 入口均自带 django.setup()，
+spawn 模式完全兼容。
+
+此文件放在 apps/core/tasking/ 下是因为结构测试要求仅核心基础设施层
+可直接 import django_q，业务层需要通过 apps.core.tasking 抽象。
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def patch_django_q_mp_context_for_macos() -> None:
+    """macOS 上将 django-q 子进程创建方式从 fork 切换为 spawn。"""
+    if sys.platform != "darwin":
+        return
+
+    try:
+        from django_q import cluster as django_q_cluster
+    except ImportError:
+        logger.debug("django_q 不可用，跳过 spawn patch")
+        return
+
+    original = django_q_cluster.get_mp_context
+    if getattr(original, "_fachuan_spawn_patched", False):
+        return
+
+    def _spawn_context() -> multiprocessing.context.BaseContext:
+        return multiprocessing.get_context("spawn")
+
+    _spawn_context._fachuan_spawn_patched = True  # type: ignore[attr-defined]
+    django_q_cluster.get_mp_context = _spawn_context
+    logger.info("macOS 检测：django-q 子进程改用 spawn 启动，规避 fork ObjC 崩溃")

--- a/backend/tests/ci/unit/core/test_django_q_spawn_patch.py
+++ b/backend/tests/ci/unit/core/test_django_q_spawn_patch.py
@@ -1,0 +1,67 @@
+"""Tests for apps.core.apps: macOS 上 django-q mp context spawn patch."""
+
+from __future__ import annotations
+
+import multiprocessing
+import sys
+
+import pytest
+from django_q import cluster as django_q_cluster
+
+from apps.core.apps import CoreConfig
+
+
+def _get_start_method() -> str:
+    """读取当前 get_mp_context 返回的 context 的 start method。"""
+    return str(django_q_cluster.get_mp_context().get_start_method())
+
+
+class TestDjangoQSpawnPatch:
+    def test_darwin_patches_to_spawn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(
+            django_q_cluster,
+            "get_mp_context",
+            lambda: multiprocessing.get_context("fork"),
+        )
+
+        CoreConfig._patch_django_q_mp_context_for_macos()
+
+        assert _get_start_method() == "spawn"
+
+    def test_patch_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(
+            django_q_cluster,
+            "get_mp_context",
+            lambda: multiprocessing.get_context("fork"),
+        )
+
+        CoreConfig._patch_django_q_mp_context_for_macos()
+        patched_once = django_q_cluster.get_mp_context
+        assert patched_once is not None
+        CoreConfig._patch_django_q_mp_context_for_macos()
+
+        assert django_q_cluster.get_mp_context is patched_once
+        assert _get_start_method() == "spawn"
+
+    def test_non_darwin_platform_not_patched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        original = django_q_cluster.get_mp_context
+
+        CoreConfig._patch_django_q_mp_context_for_macos()
+
+        assert django_q_cluster.get_mp_context is original
+
+    def test_already_patched_function_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "darwin")
+
+        def _pre_patched() -> str:
+            return "spawn"
+
+        _pre_patched._fachuan_spawn_patched = True  # type: ignore[attr-defined]
+        monkeypatch.setattr(django_q_cluster, "get_mp_context", _pre_patched)
+
+        CoreConfig._patch_django_q_mp_context_for_macos()
+
+        assert django_q_cluster.get_mp_context is _pre_patched

--- a/backend/tests/ci/unit/core/test_django_q_spawn_patch.py
+++ b/backend/tests/ci/unit/core/test_django_q_spawn_patch.py
@@ -1,4 +1,4 @@
-"""Tests for apps.core.apps: macOS 上 django-q mp context spawn patch."""
+"""Tests for apps.core.tasking.qcluster_spawn: macOS 上 django-q mp context spawn patch."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import sys
 import pytest
 from django_q import cluster as django_q_cluster
 
-from apps.core.apps import CoreConfig
+from apps.core.tasking.qcluster_spawn import patch_django_q_mp_context_for_macos
 
 
 def _get_start_method() -> str:
@@ -25,7 +25,7 @@ class TestDjangoQSpawnPatch:
             lambda: multiprocessing.get_context("fork"),
         )
 
-        CoreConfig._patch_django_q_mp_context_for_macos()
+        patch_django_q_mp_context_for_macos()
 
         assert _get_start_method() == "spawn"
 
@@ -37,10 +37,10 @@ class TestDjangoQSpawnPatch:
             lambda: multiprocessing.get_context("fork"),
         )
 
-        CoreConfig._patch_django_q_mp_context_for_macos()
+        patch_django_q_mp_context_for_macos()
         patched_once = django_q_cluster.get_mp_context
         assert patched_once is not None
-        CoreConfig._patch_django_q_mp_context_for_macos()
+        patch_django_q_mp_context_for_macos()
 
         assert django_q_cluster.get_mp_context is patched_once
         assert _get_start_method() == "spawn"
@@ -49,7 +49,7 @@ class TestDjangoQSpawnPatch:
         monkeypatch.setattr(sys, "platform", "linux")
         original = django_q_cluster.get_mp_context
 
-        CoreConfig._patch_django_q_mp_context_for_macos()
+        patch_django_q_mp_context_for_macos()
 
         assert django_q_cluster.get_mp_context is original
 
@@ -62,6 +62,6 @@ class TestDjangoQSpawnPatch:
         _pre_patched._fachuan_spawn_patched = True  # type: ignore[attr-defined]
         monkeypatch.setattr(django_q_cluster, "get_mp_context", _pre_patched)
 
-        CoreConfig._patch_django_q_mp_context_for_macos()
+        patch_django_q_mp_context_for_macos()
 
         assert django_q_cluster.get_mp_context is _pre_patched

--- a/changelog/v26.55/v26.55.20.md
+++ b/changelog/v26.55/v26.55.20.md
@@ -1,0 +1,44 @@
+# v26.55.20
+
+## 后端
+
+### 修复
+
+#### fix(django-q): macOS 上 django-q worker 彻底改用 spawn 启动，根治 fork ObjC 崩溃
+
+**问题**
+
+v26.55.19 修复后（`set_start_method("spawn")` + 运行时设置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY`），worker 仍持续崩溃：
+
+```
+objc[28812]: +[NSNumber initialize] may have been in progress in another thread when fork() was called.
+CRITICAL - 意外宕机后worker Process-xxx 已重生
+```
+
+**根因（v26.55.19 修复无效的原因）**
+
+1. **django-q 硬编码 fork**：`django_q/cluster.py:44` 通过 `multiprocessing.get_context("fork")` 显式创建子进程，完全绕过 `manage.py` 里设置的全局默认 start method
+2. **运行时设置环境变量无效**：`OBJC_DISABLE_INITIALIZE_FORK_SAFETY` 由 libobjc 在进程启动早期（`main()` 之前）读取并缓存，Python 运行时用 `os.environ.setdefault()` 设置对当前进程已经太晚（已用 `ps eww` 证实运行中的 cluster 进程启动环境里没有该变量）
+3. **v26.55.19 测试通过是侥幸**：fork 崩溃是竞态概率问题，测试进程安静未触发；实际运行时有邮件同步等线程活动，fork 时撞上 ObjC 类初始化即崩
+
+**修复（三层）**
+
+1. **主修复 — monkey-patch `django_q.cluster.get_mp_context`**（`apps/core/apps.py` 的 `ready()`）：macOS 上返回 spawn context，从源头不再 fork。django-q 的 Sentinel/worker/pusher/monitor 四个进程入口均自带 `django.setup()`，spawn 模式完全兼容
+2. **启动时序修复 — `manage.py` 顶层 `django.setup()`**：spawn 子进程 unpickle Process 对象时会触发 import `django_q.cluster`，若 Django 未提前初始化，cluster 模块会在 import 中途自行 setup，导致 `ready()` 里的 patch 撞上半初始化的 cluster 模块（`get_mp_context` 未定义）而 AttributeError 崩溃。利用 multiprocessing spawn「先 re-import 主模块、后 unpickle」的顺序，把 `django.setup()` 提前到 `manage.py` 模块顶层，保证 patch 在干净状态下执行
+3. **兜底 — Makefile 三个 qcluster 目标前置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`**：在解释器启动前设置（libobjc 能读到），防 django-q 升级改函数名后 patch 失效
+
+**验证**
+
+- qcluster 启动后进程树全部为 spawn 方式（`spawn_main`），8 个进程 patch 日志齐全
+- 30 分钟内零 `objc[` 崩溃、零「意外宕机后worker已重生」
+- 异步任务（`async_task`）在 spawn worker 中正确执行（返回值 1024 验证通过）
+- 新增单测 `test_django_q_spawn_patch.py`（4 例：darwin patch 生效/幂等/非 darwin 跳过/已 patch 跳过）
+
+**改动文件**
+
+| 文件 | 改动 |
+|------|------|
+| `backend/apps/core/apps.py` | `ready()` 增加 `_patch_django_q_mp_context_for_macos()` |
+| `backend/apiSystem/manage.py` | 顶层 `_bootstrap_django()`；移除无效的运行时环境变量设置 |
+| `backend/Makefile` | qcluster/qcluster-start/qcluster-dev 前置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` |
+| `backend/tests/ci/unit/core/test_django_q_spawn_patch.py` | 新增 |

--- a/changelog/v26.55/v26.55.20.md
+++ b/changelog/v26.55/v26.55.20.md
@@ -38,7 +38,8 @@ CRITICAL - 意外宕机后worker Process-xxx 已重生
 
 | 文件 | 改动 |
 |------|------|
-| `backend/apps/core/apps.py` | `ready()` 增加 `_patch_django_q_mp_context_for_macos()` |
+| `backend/apps/core/tasking/qcluster_spawn.py` | 新增，patch `django_q.cluster.get_mp_context` 为 spawn |
+| `backend/apps/core/apps.py` | `ready()` 调用 `qcluster_spawn.patch_django_q_mp_context_for_macos()` |
 | `backend/apiSystem/manage.py` | 顶层 `_bootstrap_django()`；移除无效的运行时环境变量设置 |
 | `backend/Makefile` | qcluster/qcluster-start/qcluster-dev 前置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` |
 | `backend/tests/ci/unit/core/test_django_q_spawn_patch.py` | 新增 |

--- a/changelog/v26.56/v26.56.0.md
+++ b/changelog/v26.56/v26.56.0.md
@@ -1,0 +1,61 @@
+# v26.56.0
+
+## 后端
+
+### 修复
+
+#### fix(django-q): macOS 上 django-q worker 彻底改用 spawn 启动，根治 fork ObjC 崩溃
+
+**问题**
+
+v26.55.19 修复后（`set_start_method("spawn")` + 运行时设置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY`），worker 仍持续崩溃：
+
+```
+objc[28812]: +[NSNumber initialize] may have been in progress in another thread when fork() was called.
+CRITICAL - 意外宕机后worker Process-xxx 已重生
+```
+
+**根因（v26.55.19 修复无效的原因）**
+
+1. **django-q 硬编码 fork**：`django_q/cluster.py:44` 通过 `multiprocessing.get_context("fork")` 显式创建子进程，完全绕过 `manage.py` 里设置的全局默认 start method
+2. **运行时设置环境变量无效**：`OBJC_DISABLE_INITIALIZE_FORK_SAFETY` 由 libobjc 在进程启动早期（`main()` 之前）读取并缓存，Python 运行时用 `os.environ.setdefault()` 设置对当前进程已经太晚
+3. **v26.55.19 测试通过是侥幸**：fork 崩溃是竞态概率问题，测试进程安静未触发；实际运行时有邮件同步等线程活动，fork 时撞上 ObjC 类初始化即崩
+
+**修复（三层）**
+
+1. **主修复 — monkey-patch `django_q.cluster.get_mp_context`**（`apps/core/apps.py` 的 `ready()`）：macOS 上返回 spawn context，从源头不再 fork。django-q 的 Sentinel/worker/pusher/monitor 四个进程入口均自带 `django.setup()`，spawn 模式完全兼容
+2. **启动时序修复 — `manage.py` 顶层 `django.setup()`**：spawn 子进程 unpickle Process 对象时会触发 import `django_q.cluster`，若 Django 未提前初始化，cluster 模块会在 import 中途自行 setup，导致 `ready()` 里的 patch 撞上半初始化的 cluster 模块（`get_mp_context` 未定义）而 AttributeError 崩溃。利用 multiprocessing spawn「先 re-import 主模块、后 unpickle」的顺序，把 `django.setup()` 提前到 `manage.py` 模块顶层，保证 patch 在干净状态下执行
+3. **兜底 — Makefile 三个 qcluster 目标前置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`**：在解释器启动前设置（libobjc 能读到），防 django-q 升级改函数名后 patch 失效
+
+**验证**
+
+- qcluster 启动后进程树全部为 spawn 方式（`spawn_main`），8 个进程 patch 日志齐全
+- 30 分钟内零 `objc[` 崩溃、零「意外宕机后worker已重生」
+- 异步任务（`async_task`）在 spawn worker 中正确执行（返回值 1024 验证通过）
+- 新增单测 `test_django_q_spawn_patch.py`（4 例：darwin patch 生效/幂等/非 darwin 跳过/已 patch 跳过）
+
+**改动文件**
+
+| 文件 | 改动 |
+|------|------|
+| `backend/apps/core/tasking/qcluster_spawn.py` | 新增，patch `django_q.cluster.get_mp_context` 为 spawn |
+| `backend/apps/core/apps.py` | `ready()` 调用 `qcluster_spawn.patch_django_q_mp_context_for_macos()` |
+| `backend/apiSystem/manage.py` | 顶层 `_bootstrap_django()`；移除无效的运行时环境变量设置 |
+| `backend/Makefile` | qcluster/qcluster-start/qcluster-dev 前置 `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` |
+| `backend/tests/ci/unit/core/test_django_q_spawn_patch.py` | 新增 |
+
+#### fix(court-zxfw): 一张网登录验证码选择器更新，适配页面改版
+
+**问题**
+
+一张网（zxfw.court.gov.cn）登录页面改版，验证码图片改用 data URI（base64）嵌入 HTML，不再通过 `/api/v1/captcha` API 加载。同时 uni-app 的 `<uni-image>` 组件渲染为 `<div background-image>` + 隐藏 `<img>`，导致旧选择器全部失效，登录超时。
+
+**修复**
+
+更新 `_recognize_captcha` 和 `_refresh_captcha` 两个方法的验证码选择器，改为匹配可见的 `.fd-images-code` 容器元素。
+
+**改动文件**
+
+| 文件 | 改动 |
+|------|------|
+| `backend/plugins/court_automation/login/court_zxfw_service.py` | 验证码选择器从 `uni-image img[src*='captcha']` 等改为 `.fd-images-code` / `.fd-captcha uni-image` |


### PR DESCRIPTION
## Summary
- **django-q macOS fork ObjC 崩溃三层修复**：monkey-patch `get_mp_context` 为 spawn、manage.py 启动时序修复、Makefile 兜底
- **一张网登录验证码选择器适配**：页面改版后验证码改用 data URI，选择器更新为 `.fd-images-code`
- 含 plugins 子模块更新 (FachuanPlugins#17)
- 新增 changelog v26.56.0

## Test plan
- [ ] qcluster 启动后进程树为 spawn 方式，无 ObjC 崩溃
- [ ] 一张网登录流程验证码识别正常
- [ ] CI 通过