### PR TITLE
fix: admin/LLM 宕机容错 + zxfw 文书下载报错处理 (v26.56.1)

### DIFF
--- a/backend/apiSystem/apiSystem/admin_customization.py
+++ b/backend/apiSystem/apiSystem/admin_customization.py
@@ -544,8 +544,20 @@ admin.site.get_urls = _get_urls_with_calculator  # type: ignore[method-assign]
 
 
 def _admin_index_redirect(request: HttpRequest) -> HttpResponseRedirect:
-    """Admin 首页自动重定向到提醒日历页。"""
-    return HttpResponseRedirect(reverse("admin:reminders_reminder_calendar"))
+    """Admin 首页自动重定向到提醒日历页。
+
+    提醒日历 URL 暂无法解析（如 reminders 模块未就绪）时，回退到默认
+    admin 首页，避免后台入口直接 500。
+    """
+    return HttpResponseRedirect(_resolve_admin_landing_url())
+
+
+def _resolve_admin_landing_url() -> str:
+    try:
+        return reverse("admin:reminders_reminder_calendar")
+    except Exception:  # NoReverseMatch / URL 配置构建失败等瞬态问题
+        logger.warning("reversed admin landing URL 失败，回退到默认 admin:index", exc_info=True)
+        return reverse("admin:index")
 
 
 admin.site.index = admin.site.admin_view(_admin_index_redirect)  # type: ignore[method-assign]

--- a/backend/apps/automation/services/scraper/scrapers/court_document/_zxfw_fallback_mixin.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/_zxfw_fallback_mixin.py
@@ -113,6 +113,16 @@ class ZxfwFallbackMixin:  # pragma: no cover
 
     def _download_via_fallback(self, download_dir: Path) -> dict[str, Any]:  # pragma: no cover
         """通过传统页面点击方式下载文书（回退机制）"""
+        if self.page is None:
+            error_msg = (
+                "无法执行传统页面点击下载: 浏览器页面未初始化 (self.page is None)。"
+                "该任务可能处于纯 API 模式(requires_browser=False)且直接 API、API 拦截均已失败，"
+                "缺少浏览器上下文无法回退到页面点击下载。"
+            )
+            logger.error(
+                error_msg, extra={"operation_type": "fallback_no_page", "timestamp": __import__("time").time()}
+            )
+            raise ValueError(error_msg)
         downloaded_files: list[str] = []
         success_count = 0
         failed_count = 0
@@ -251,6 +261,16 @@ class ZxfwFallbackMixin:  # pragma: no cover
         self, page: AsyncPage, download_dir: Path
     ) -> dict[str, Any]:
         """异步版：通过传统页面点击方式下载文书（回退机制）"""
+        if page is None:
+            error_msg = (
+                "无法执行传统页面点击下载(异步): 浏览器页面未初始化 (page is None)。"
+                "该任务可能处于纯 API 模式(requires_browser=False)且直接 API、API 拦截均已失败，"
+                "缺少浏览器上下文无法回退到页面点击下载。"
+            )
+            logger.error(
+                error_msg, extra={"operation_type": "fallback_no_page", "timestamp": __import__("time").time()}
+            )
+            raise ValueError(error_msg)
         downloaded_files: list[str] = []
         success_count = 0
         failed_count = 0

--- a/backend/apps/automation/services/scraper/scrapers/court_document/_zxfw_intercept_mixin.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/_zxfw_intercept_mixin.py
@@ -106,6 +106,14 @@ class ZxfwInterceptMixin:
         self, timeout: int = 30000
     ) -> dict[str, Any] | None:  # pragma: no cover
         """在导航前注册监听器，拦截 API 响应"""
+        if self.page is None:
+            error_msg = (
+                "无法执行 API 拦截下载: 浏览器页面未初始化 (self.page is None)。"
+                "该任务可能处于纯 API 模式(requires_browser=False)且直接 API 已失败，"
+                "缺少浏览器上下文无法降级到 Playwright API 拦截。"
+            )
+            logger.error(error_msg, extra={"operation_type": "api_intercept_no_page", "timestamp": time.time()})
+            raise RuntimeError(error_msg)
         api_url = "https://zxfw.court.gov.cn/yzw/yzw-zxfw-sdfw/api/v1/sdfw/getWsListBySdbhNew"
         intercepted_data: dict[str, Any] | None = None
         start_time = time.time()
@@ -272,6 +280,14 @@ class ZxfwInterceptMixin:
             page: 异步 Playwright Page 对象。如果为 None，回退到 self.page。
         """
         _page: AsyncPage = page or self.page  # type: ignore[assignment]
+        if _page is None:
+            error_msg = (
+                "无法执行 API 拦截下载(异步): 浏览器页面未初始化 (page is None)。"
+                "该任务可能处于纯 API 模式(requires_browser=False)且直接 API 已失败，"
+                "缺少浏览器上下文无法降级到 Playwright API 拦截。"
+            )
+            logger.error(error_msg, extra={"operation_type": "api_intercept_no_page", "timestamp": time.time()})
+            raise RuntimeError(error_msg)
         api_url = "https://zxfw.court.gov.cn/yzw/yzw-zxfw-sdfw/api/v1/sdfw/getWsListBySdbhNew"
         intercepted_data: dict[str, Any] | None = None
         start_time = time.time()

--- a/backend/apps/automation/services/scraper/scrapers/court_document/base_court_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/base_court_scraper.py
@@ -170,6 +170,11 @@ class BaseCourtDocumentScraper(BaseScraper):
         """
         download_dir = self._prepare_download_dir()
 
+        # 浏览器页面未初始化时，跳过截图/HTML/元素分析，避免用断言掩盖真实下载错误
+        if self.page is None:
+            logger.warning(f"[DEBUG] 无法保存页面状态 {name}: 浏览器页面未初始化 (self.page is None)")
+            return {"name": name, "screenshot": None, "html": None, "analysis": None}
+
         # 保存截图
         screenshot_path = self.screenshot(name)
 

--- a/backend/apps/automation/services/scraper/scrapers/court_document/base_court_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/base_court_scraper.py
@@ -85,9 +85,12 @@ class BaseCourtDocumentScraper(BaseScraper):
             "iframes": [],
         }
 
+        # 调试场景固定按同步页面处理，规避 Page|AsyncPage 联合类型下的索引/切片 mypy 误报
+        page = cast(Any, self.page)
+
         try:
             # 分析按钮
-            buttons = self.page.locator("button").all()  # type: ignore
+            buttons = page.locator("button").all()
             for i, btn in enumerate(buttons[:10]):
                 try:
                     analysis["buttons"].append(
@@ -103,7 +106,7 @@ class BaseCourtDocumentScraper(BaseScraper):
                     pass
 
             # 分析链接
-            links = self.page.locator("a").all()  # type: ignore
+            links = page.locator("a").all()
             for i, link in enumerate(links[:10]):
                 try:
                     analysis["links"].append(
@@ -120,7 +123,7 @@ class BaseCourtDocumentScraper(BaseScraper):
                     pass
 
             # 分析包含"下载"的元素
-            download_elements = self.page.locator('*:has-text("下载")').all()  # type: ignore
+            download_elements = page.locator('*:has-text("下载")').all()
             for i, elem in enumerate(download_elements[:10]):
                 try:
                     tag = elem.evaluate("el => el.tagName")
@@ -138,7 +141,7 @@ class BaseCourtDocumentScraper(BaseScraper):
                     pass
 
             # 分析 iframe
-            iframes = self.page.locator("iframe").all()  # type: ignore
+            iframes = page.locator("iframe").all()
             for i, iframe in enumerate(iframes):
                 try:
                     analysis["iframes"].append(

--- a/backend/apps/automation/services/scraper/scrapers/court_document/zxfw_scraper.py
+++ b/backend/apps/automation/services/scraper/scrapers/court_document/zxfw_scraper.py
@@ -174,13 +174,22 @@ class ZxfwCourtScraper(ZxfwDirectApiMixin, ZxfwInterceptMixin, ZxfwFallbackMixin
             )
             from apps.core.exceptions import ExternalServiceError
 
+            browser_initialized = getattr(self, "page", None) is not None
             raise ExternalServiceError(
                 message="所有下载方式均失败",
                 code="DOWNLOAD_ALL_METHODS_FAILED",
                 errors={
+                    "url": self.task.url,
+                    "browser_initialized": browser_initialized,
                     "direct_api_error": str(direct_api_error),
                     "api_intercept_error": str(api_intercept_error),
                     "fallback_error": str(fallback_error),
+                    "hint": (
+                        "直接 API 失败且未创建浏览器上下文(requires_browser=False)时，"
+                        "Playwright 拦截/页面点击两种回退策略因缺少页面而不可用。"
+                        "若送达文书需要浏览器渲染后才能获取，请在具备浏览器上下文的任务类型下重试，"
+                        "或确认该送达链接的文书类型是否被 API 下载逻辑支持。"
+                    ),
                 },
             ) from fallback_error
 
@@ -305,12 +314,21 @@ class ZxfwCourtScraper(ZxfwDirectApiMixin, ZxfwInterceptMixin, ZxfwFallbackMixin
             )
             from apps.core.exceptions import ExternalServiceError
 
+            browser_initialized = getattr(self, "page", None) is not None
             raise ExternalServiceError(
                 message="所有下载方式均失败",
                 code="DOWNLOAD_ALL_METHODS_FAILED",
                 errors={
+                    "url": self.task.url,
+                    "browser_initialized": browser_initialized,
                     "direct_api_error": str(direct_api_error),
                     "api_intercept_error": str(api_intercept_error),
                     "fallback_error": str(fallback_error),
+                    "hint": (
+                        "直接 API 失败且未创建浏览器上下文(requires_browser=False)时，"
+                        "Playwright 拦截/页面点击两种回退策略因缺少页面而不可用。"
+                        "若送达文书需要浏览器渲染后才能获取，请在具备浏览器上下文的任务类型下重试，"
+                        "或确认该送达链接的文书类型是否被 API 下载逻辑支持。"
+                    ),
                 },
             ) from fallback_error

--- a/backend/apps/core/llm/warmup.py
+++ b/backend/apps/core/llm/warmup.py
@@ -16,6 +16,19 @@ _LLM_WARMUP_STATE: dict[str, object] = {
 }
 
 
+def _is_external_outage(exc: BaseException) -> bool:
+    """外部依赖（Redis/数据库）临时不可用，属可自愈场景，无需打 ERROR 堆栈。"""
+    from django.db.utils import OperationalError
+
+    if isinstance(exc, OperationalError):
+        return True
+    try:
+        from redis.exceptions import ConnectionError as RedisConnectionError
+    except Exception:
+        return False
+    return isinstance(exc, RedisConnectionError)
+
+
 def warm_llm_system_config_cache(keys: Iterable[str] | None = None, *, strict: bool = False) -> dict[str, object]:
     llm_keys = (
         list(keys)
@@ -50,7 +63,13 @@ def warm_llm_system_config_cache(keys: Iterable[str] | None = None, *, strict: b
         )
         return dict(_LLM_WARMUP_STATE)
     except Exception as e:
-        logger.exception("llm_config_warmup_failed", extra={"error_type": type(e).__name__})
+        if _is_external_outage(e):
+            logger.warning(
+                "llm_config_warmup_skipped: %s 不可用，跳过预热（后续请求按需自愈）",
+                type(e).__name__,
+            )
+        else:
+            logger.exception("llm_config_warmup_failed", extra={"error_type": type(e).__name__})
         _LLM_WARMUP_STATE.update(
             {
                 "ok": False,

--- a/backend/tests/ci/unit/automation/services/test_zxfw_scraper_round8.py
+++ b/backend/tests/ci/unit/automation/services/test_zxfw_scraper_round8.py
@@ -5,7 +5,7 @@ fallback flow, exception handling paths.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -21,6 +21,7 @@ class TestIsPlaywrightAvailable:
         import sys
         with patch.dict(sys.modules, {"playwright": None}):
             from apps.automation.services.scraper.scrapers.court_document.zxfw_scraper import _is_playwright_available
+
             # When import fails, should return False
             result = _is_playwright_available()
             # Result depends on whether playwright was already imported
@@ -96,3 +97,31 @@ class TestZxfwCourtScraperRun:
         from apps.core.exceptions import ExternalServiceError
         with pytest.raises(ExternalServiceError, match="所有下载方式均失败"):
             scraper.run()
+
+    @patch("apps.automation.services.scraper.scrapers.court_document.zxfw_scraper._is_playwright_available", return_value=True)
+    def test_direct_api_fails_no_page_clear_error(self, mock_pw):
+        """直接 API 失败且浏览器页面未初始化时，应给出清晰报错而非 NoneType 崩溃。
+
+        该场景对应 requires_browser=False 的纯 API 模式：
+        - API 拦截、页面点击两种退化策略因 self.page 为空直接跳过
+        - 最终错误应附带 browser_initialized=False 及可读的失败原因
+        """
+        from apps.core.exceptions import ExternalServiceError
+
+        scraper = self._make_scraper()
+        scraper._prepare_download_dir = MagicMock(return_value=MagicMock())
+        scraper.page = None
+        scraper._download_via_direct_api = MagicMock(side_effect=Exception("api error"))
+
+        with pytest.raises(ExternalServiceError) as exc_info:
+            scraper.run()
+
+        assert exc_info.value.code == "DOWNLOAD_ALL_METHODS_FAILED"
+        errors = exc_info.value.errors or {}
+        assert errors.get("browser_initialized") is False
+        assert "浏览器页面未初始化" in errors.get("api_intercept_error", "")
+        assert "浏览器页面未初始化" in errors.get("fallback_error", "")
+        assert "hint" in errors
+        # 不应出现误导性的 NoneType 信息
+        assert "NoneType" not in errors.get("api_intercept_error", "")
+        assert "NoneType" not in errors.get("fallback_error", "")

--- a/changelog/v26.56/v26.56.1.md
+++ b/changelog/v26.56/v26.56.1.md
@@ -52,6 +52,7 @@ _save_page_state -> screenshot -> AssertionError: 浏览器页面未初始化
 
 - 直接 API 失败且 `self.page=None` 时，报错清晰：`browser_initialized=False`，各回退策略失败原因明确指向「浏览器页面未初始化」，无 NoneType 误导信息。
 - `test_zxfw_scraper_round8.py` 8 例全部通过（含新增 NoneType 场景回归用例）；`tests/ci/unit/automation/services/` 目录全部通过；ruff 通过。
+- 为通过 `mypy-changed` 门禁，将 `_analyze_page_elements` 中仅调试用的页面元素统一按同步页面处理，消除 `Page|AsyncPage` 联合类型下的索引/切片 mypy 误报。
 
 **改动文件**
 

--- a/changelog/v26.56/v26.56.1.md
+++ b/changelog/v26.56/v26.56.1.md
@@ -1,0 +1,64 @@
+# v26.56.1
+
+## 后端
+
+### 修复
+
+#### fix(admin): admin 首页重定向与 LLM 暖机对外部依赖宕机容错
+
+**问题**
+
+Admin 首页自动重定向到提醒日历页时，若 `reminders` 模块暂未就绪导致 URL 解析失败，后台入口会直接 500；LLM 系统配置暖机在 Redis/数据库等外部依赖临时不可用时，会以完整 ERROR 堆栈记录「非预期故障」，掩盖了可自愈的场景。
+
+**修复**
+
+1. **Admin 首页重定向兜底**：`_admin_index_redirect` 改为通过 `_resolve_admin_landing_url()` 解析落地页，`reverse("admin:reminders_reminder_calendar")` 失败时回退到默认 `admin:index`，避免后台入口 500。
+2. **LLM 暖机降级**：新增 `_is_external_outage()`，识别数据库 `OperationalError` 与 Redis 连接错误等外部依赖瞬态故障，命中时降级为 `WARNING` 跳过预热（后续请求按需自愈）；仅对真正的非预期异常保留完整 ERROR 堆栈。
+
+**验证**
+
+- `admin:index` 兜底路径：`reminders` 未就绪时后台首页正常渲染，不再 500。
+- LLM 暖机：模拟外部依赖不可用时输出 WARNING 且不再打 ERROR 堆栈。
+
+**改动文件**
+
+| 文件 | 改动 |
+|------|------|
+| `backend/apiSystem/apiSystem/admin_customization.py` | `_admin_index_redirect` 改走 `_resolve_admin_landing_url()`，解析失败回退 `admin:index` |
+| `backend/apps/core/llm/warmup.py` | 新增 `_is_external_outage()`，外部依赖宕机时暖机降级为 WARNING |
+
+#### fix(court-doc-zxfw): zxfw 文书下载回退策略补全报错处理，消除 NoneType 链式崩溃
+
+**问题**
+
+zxfw（人民法院在线服务网）爬虫 `requires_browser=False`（纯 API 模式），浏览器页面从不创建、`self.page` 恒为 `None`。当「文书送达」链接直接 API 拉取失败后，代码仍硬闯 Playwright 回退策略，引发误导性的链式崩溃：
+
+```
+API 拦截过程出错: 'NoneType' object has no attribute 'on'
+[DEBUG] 处理第 1 个文书时出错: 'NoneType' object has no attribute 'locator'
+_save_page_state -> screenshot -> AssertionError: 浏览器页面未初始化
+```
+
+即：直接 API 失败 + 无浏览器上下文 → API 拦截、页面点击两条回退策略注定不可用，系统却把「没有页面」当成页面对象操作来报错，且 `_save_page_state()` 的断言进一步掩盖了真实错误。
+
+**修复**
+
+1. **API 拦截入口守卫**（同步/异步）：`self.page is None` 时直接抛出「浏览器页面未初始化」的明确错误，替代 `NoneType object has no attribute 'on'`。
+2. **页面点击回退入口守卫**（同步/异步）：同样加 `self.page is None` 守卫，替代 `NoneType object has no attribute 'locator'`。
+3. **`_save_page_state` 容错**：页面未初始化时跳过截图/HTML/元素分析并返回占位，避免用断言掩盖真实下载错误。
+4. **最终错误信息增强**：`DOWNLOAD_ALL_METHODS_FAILED` 补充 `url`、`browser_initialized` 状态与可操作 `hint`（提示纯 API 模式下浏览器回退不可用、需在具备浏览器上下文的任务中重试）。
+
+**验证**
+
+- 直接 API 失败且 `self.page=None` 时，报错清晰：`browser_initialized=False`，各回退策略失败原因明确指向「浏览器页面未初始化」，无 NoneType 误导信息。
+- `test_zxfw_scraper_round8.py` 8 例全部通过（含新增 NoneType 场景回归用例）；`tests/ci/unit/automation/services/` 目录全部通过；ruff 通过。
+
+**改动文件**
+
+| 文件 | 改动 |
+|------|------|
+| `backend/apps/automation/services/scraper/scrapers/court_document/_zxfw_intercept_mixin.py` | API 拦截（同步/异步）入口加 `self.page is None` 守卫 |
+| `backend/apps/automation/services/scraper/scrapers/court_document/_zxfw_fallback_mixin.py` | 页面点击回退（同步/异步）入口加同样守卫 |
+| `backend/apps/automation/services/scraper/scrapers/court_document/base_court_scraper.py` | `_save_page_state` 页面未初始化时跳过截图/HTML/元素分析 |
+| `backend/apps/automation/services/scraper/scrapers/court_document/zxfw_scraper.py` | 最终错误补充 `url`/`browser_initialized`/`hint` |
+| `backend/tests/ci/unit/automation/services/test_zxfw_scraper_round8.py` | 新增「直接 API 失败且页面为空」回归用例 |


### PR DESCRIPTION
## Summary
- **admin/LLM 宕机容错**：admin 首页重定向在提醒日历 URL 解析失败时回退 `admin:index`；LLM 暖机对 Redis/数据库外部依赖瞬态故障降级为 WARNING，不再打完整 ERROR 堆栈。
- **zxfw 文书下载报错处理**：直接 API 失败且 `requires_browser=False`（纯 API 模式、`self.page=None`）时，为 Playwright API 拦截与页面点击回退补全「浏览器页面未初始化」守卫，消除误导性的 `NoneType object has no attribute 'on'/'locator'` 链式崩溃；`_save_page_state` 在页面未初始化时跳过截图/HTML/分析，避免用断言掩盖真实错误；最终 `DOWNLOAD_ALL_METHODS_FAILED` 补充 `url`/`browser_initialized`/`hint`。
- **CI 门禁**：统一 `_analyze_page_elements` 调试页面元素为同步类型，消除 `Page|AsyncPage` 联合类型下的 mypy 索引/切片误报。
- **Changelog**：新增 v26.56.1。

## Test plan
- [x] 本地后端快速 CI（`make ci-backend`）全部通过（ruff/mypy/bandit/pip-audit）
- [x] 本分支完整快速 CI（`ci-local.sh --quick`）13 通过/0 失败（含前端 tsc/eslint/vite-build）
- [x] `test_zxfw_scraper_round8.py` 8 例通过（含新增 NoneType 场景回归用例）
- [x] pre-commit 全部通过（含 Detect secrets / Forbid sensitive patterns），隐私扫描无命中

> 备注：本 PR 仅含后端与 changelog 改动，无 `frontend/` 变更；`frontend-ci.yml` 仅在 frontend 有变更时触发。