### PR TITLE
fix(automation): CourtSMS add 页面适配 Django 6.1 扁平化字段集

### DIFF
--- a/backend/apps/automation/admin/sms/court_sms_admin_actions.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_actions.py
@@ -321,7 +321,7 @@ class CourtSMSAdminActions:  # pragma: no cover
 
                 obj.received_at = timezone.now()
 
-            raw_tail6 = str(request.POST.get("sfdw_phone_tail6", "") or "").strip()
+            raw_tail6 = str(form.cleaned_data.get("sfdw_phone_tail6", "") or "").strip()
             sfdw_phone_tail6 = "".join(ch for ch in raw_tail6 if ch.isdigit())[-6:]
 
             super().save_model(request, obj, form, change)  # type: ignore[misc]

--- a/backend/apps/automation/admin/sms/court_sms_admin_base.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_base.py
@@ -196,7 +196,9 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
             )
         elif obj.status == CourtSMSStatus.PENDING_MANUAL:
             change_url = reverse("admin:automation_courtsms_change", args=[obj.id])
-            return format_html('<a href="{}" style="color: var(--fc-warning-text); font-weight: bold;">手动关联</a>', change_url)
+            return format_html(
+                '<a href="{}" style="color: var(--fc-warning-text); font-weight: bold;">手动关联</a>', change_url
+            )
         return "-"
 
     @admin.display(description=_("短信内容"))
@@ -211,7 +213,9 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
     def has_download_links(self, obj: CourtSMS) -> SafeString:  # pragma: no cover
         """是否有下载链接"""
         if obj.download_links:
-            return format_html('<span style="color: var(--fc-success-text);">✓ {} 个链接</span>', len(obj.download_links))
+            return format_html(
+                '<span style="color: var(--fc-success-text);">✓ {} 个链接</span>', len(obj.download_links)
+            )
         return format_html('<span style="color: var(--fc-text-disabled);">{}</span>', "✗ 无链接")
 
     @admin.display(description=_("提取的案号"))
@@ -401,7 +405,10 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
                         parts.append(format_html("<br><small>{}</small>", p))
                 if fail_platforms:
                     parts.append(
-                        format_html('<br><small style="color: var(--fc-error-text);">失败: {}</small>', ", ".join(fail_platforms))
+                        format_html(
+                            '<br><small style="color: var(--fc-error-text);">失败: {}</small>',
+                            ", ".join(fail_platforms),
+                        )
                     )
                 return mark_safe("".join(str(p) for p in parts))
             elif fail_platforms:
@@ -581,7 +588,9 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
         else:
             return [field.name for field in self.model._meta.fields if field.name != "id"]
 
-    def get_readonly_fields(self, request: HttpRequest, obj: CourtSMS | None = None) -> list[str] | tuple[str, ...]:  # pragma: no cover
+    def get_readonly_fields(
+        self, request: HttpRequest, obj: CourtSMS | None = None
+    ) -> list[str] | tuple[str, ...]:  # pragma: no cover
         """根据是否为新增页面返回不同的只读字段"""
         if obj is None:
             return ["received_at"]
@@ -605,11 +614,11 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
                             ".sms-platforms-tags{display:flex;flex-wrap:wrap;gap:8px;}"
                             ".sms-platforms-tags span{background:var(--fc-primary-subtle);color:var(--fc-primary);padding:4px 10px;border-radius:999px;font-size:12px;border:0;white-space:nowrap;}"
                             ".sms-platforms-tags span code{color:var(--fc-primary);font-size:11px;}"
-                            ".sfdw-tail6-wrap{display:none;padding:12px 0 14px;border-top:0;}"
-                            ".sfdw-tail6-row{display:grid;grid-template-columns:160px minmax(260px,420px);align-items:flex-start;}"
-                            ".sfdw-tail6-label{padding:4px 10px 0 0;color:var(--fc-text-secondary);font-size:13px;font-weight:600;box-sizing:border-box;}"
-                            ".sfdw-tail6-body{padding-right:12px;max-width:420px;}"
-                            ".sfdw-tail6-wrap input{width:100%;max-width:420px;box-sizing:border-box;}"
+                            ".sfdw-tail6-wrap{display:none;padding:10px 0;}"
+                            ".sfdw-tail6-row{display:flex;align-items:center;gap:10px;}"
+                            ".sfdw-tail6-label{white-space:nowrap;font-size:0.8125rem;color:var(--fc-text-secondary);font-weight:600;padding-right:10px;}"
+                            ".sfdw-tail6-body{flex:1;min-width:0;}"
+                            ".sfdw-tail6-body input{width:20em;max-width:100%;}"
                             "</style>"
                             "<div class='sms-platforms'>"
                             "<div class='sms-platforms-title'>📥 支持自动下载</div>"
@@ -623,7 +632,7 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
                             "<span title='171.106.48.55:28083'>广西法院短信平台</span>"
                             "</div>"
                             "</div>"
-                            "<div id='sfdw-tail6-wrap' class='form-row sfdw-tail6-wrap'>"
+                            "<div id='sfdw-tail6-wrap' class='sfdw-tail6-wrap'>"
                             "<div class='sfdw-tail6-row'>"
                             "<label for='id_sfdw_phone_tail6' class='sfdw-tail6-label'>手机号后6位：</label>"
                             "<div class='sfdw-tail6-body'>"
@@ -633,39 +642,21 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
                             "</div>"
                             "<script>"
                             "(function(){"
-                            "  const mount = function(){"
-                            "    const wrap = document.getElementById('sfdw-tail6-wrap');"
-                            "    const row = wrap ? wrap.querySelector('.sfdw-tail6-row') : null;"
-                            "    const input = document.getElementById('id_sfdw_phone_tail6');"
-                            "    const contentRow = document.querySelector('.form-row.field-content');"
-                            "    const receivedAtRow = document.querySelector('.form-row.field-received_at');"
-                            "    const contentLabel = contentRow ? contentRow.querySelector('label') : null;"
-                            "    if(!wrap || !row || !input){return;}"
-                            "    if(receivedAtRow && wrap.previousElementSibling !== contentRow){"
-                            "      receivedAtRow.insertAdjacentElement('beforebegin', wrap);"
-                            "    } else if(contentRow && wrap.previousElementSibling !== contentRow) {"
-                            "      contentRow.insertAdjacentElement('afterend', wrap);"
-                            "    }"
-                            "    wrap.style.display = 'block';"
-                            "    if(contentLabel){"
-                            "      const labelRect = contentLabel.getBoundingClientRect();"
-                            "      const rowRect = row.getBoundingClientRect();"
-                            "      const w = Math.ceil(labelRect.width);"
-                            "      const rawOffset = Math.round(labelRect.left - rowRect.left);"
-                            "      const offset = Math.max(0, Math.min(40, rawOffset));"
-                            "      if(w > 0){ row.style.gridTemplateColumns = w + 'px minmax(260px, 420px)'; }"
-                            "      row.style.paddingLeft = offset + 'px';"
-                            "    }"
-                            "    input.value = (input.value || '').replace(/\\D/g, '').slice(0, 6);"
-                            "    input.addEventListener('input', function(){"
-                            "      input.value = (input.value || '').replace(/\\D/g, '').slice(0, 6);"
+                            "  const mount=function(){"
+                            "    const wrap=document.getElementById('sfdw-tail6-wrap');"
+                            "    const input=document.getElementById('id_sfdw_phone_tail6');"
+                            "    const contentRow=document.querySelector('.form-row.field-content');"
+                            "    if(!wrap||!input||!contentRow){return;}"
+                            "    if(wrap.parentElement!==contentRow.parentElement){contentRow.after(wrap);}"
+                            "    wrap.style.display='block';"
+                            "    input.value=(input.value||'').replace(/\\D/g,'').slice(0,6);"
+                            "    input.addEventListener('input',function(){"
+                            "      input.value=(input.value||'').replace(/\\D/g,'').slice(0,6);"
                             "    });"
                             "  };"
-                            "  if(document.readyState === 'loading'){"
-                            "    document.addEventListener('DOMContentLoaded', mount);"
-                            "  } else {"
-                            "    mount();"
-                            "  }"
+                            "  if(document.readyState==='loading'){"
+                            "    document.addEventListener('DOMContentLoaded',mount);"
+                            "  }else{mount();}"
                             "})();"
                             "</script>"
                         ),
@@ -675,7 +666,9 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
         else:
             return list(self.fieldsets)
 
-    def get_form(self, request: HttpRequest, obj: CourtSMS | None = None, change: bool = False, **kwargs: Any) -> Any:  # pragma: no cover
+    def get_form(
+        self, request: HttpRequest, obj: CourtSMS | None = None, change: bool = False, **kwargs: Any
+    ) -> Any:  # pragma: no cover
         """自定义表单"""
         form = super().get_form(request, obj, change=change, **kwargs)
 

--- a/backend/apps/automation/admin/sms/court_sms_admin_base.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_base.py
@@ -10,7 +10,9 @@ import logging
 from pathlib import Path
 from typing import Any, ClassVar
 
+from django import forms
 from django.contrib import admin
+from django.core.validators import RegexValidator
 from django.db.models import QuerySet
 from django.http import HttpRequest
 from django.urls import reverse
@@ -597,79 +599,20 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
         else:
             return self.readonly_fields
 
-    def get_fieldsets(self, request: HttpRequest, obj: CourtSMS | None = None) -> Any:  # pragma: no cover
-        """根据是否为新增页面返回不同的字段分组"""
+    def get_fieldsets(self, request: HttpRequest, obj: CourtSMS | None = None) -> Any:
         if obj is None:
             return [
                 (
                     str(_("短信信息")),
                     {
-                        "fields": ("content", "received_at"),
-                        "description": (
-                            "请输入完整的法院短信内容。收到时间将自动设置为当前时间。"
-                            "<br>"
-                            "<style>"
-                            ".sms-platforms{margin-top:12px;padding:12px 14px;background:var(--fc-bg-muted);border-radius:10px;border:1px solid var(--fc-border);}"
-                            ".sms-platforms-title{font-size:13px;color:var(--fc-text-muted);margin-bottom:8px;font-weight:600;}"
-                            ".sms-platforms-tags{display:flex;flex-wrap:wrap;gap:8px;}"
-                            ".sms-platforms-tags span{background:var(--fc-primary-subtle);color:var(--fc-primary);padding:4px 10px;border-radius:999px;font-size:12px;border:0;white-space:nowrap;}"
-                            ".sms-platforms-tags span code{color:var(--fc-primary);font-size:11px;}"
-                            ".sfdw-tail6-wrap{display:none;padding:10px 0;}"
-                            ".sfdw-tail6-row{display:flex;align-items:center;gap:10px;}"
-                            ".sfdw-tail6-label{white-space:nowrap;font-size:0.8125rem;color:var(--fc-text-secondary);font-weight:600;padding-right:10px;}"
-                            ".sfdw-tail6-body{flex:1;min-width:0;}"
-                            ".sfdw-tail6-body input{width:20em;max-width:100%;}"
-                            "</style>"
-                            "<div class='sms-platforms'>"
-                            "<div class='sms-platforms-title'>📥 支持自动下载</div>"
-                            "<div class='sms-platforms-tags'>"
-                            "<span title='zxfw.court.gov.cn'>人民法院在线服务网</span>"
-                            "<span title='sd.gdems.com'>睿法智达</span>"
-                            "<span title='jysd.10102368.com'>集约送达</span>"
-                            "<span title='dzsd.hbfy.gov.cn'>湖北电子送达</span>"
-                            "<span title='sfsd.jxfy.gov.cn'>江西电子送达</span>"
-                            "<span title='sfpt.cdfy12368.gov.cn'>司法送达网</span>"
-                            "<span title='171.106.48.55:28083'>广西法院短信平台</span>"
-                            "</div>"
-                            "</div>"
-                            "<div id='sfdw-tail6-wrap' class='sfdw-tail6-wrap'>"
-                            "<div class='sfdw-tail6-row'>"
-                            "<label for='id_sfdw_phone_tail6' class='sfdw-tail6-label'>手机号后6位：</label>"
-                            "<div class='sfdw-tail6-body'>"
-                            "<input id='id_sfdw_phone_tail6' name='sfdw_phone_tail6' type='text' maxlength='6' inputmode='numeric' pattern='[0-9]{6}' class='vTextField' placeholder='留空会自动回退律师手机号后6位。' />"
-                            "</div>"
-                            "</div>"
-                            "</div>"
-                            "<script>"
-                            "(function(){"
-                            "  const mount=function(){"
-                            "    const wrap=document.getElementById('sfdw-tail6-wrap');"
-                            "    const input=document.getElementById('id_sfdw_phone_tail6');"
-                            "    const contentRow=document.querySelector('.form-row.field-content');"
-                            "    if(!wrap||!input||!contentRow){return;}"
-                            "    if(wrap.parentElement!==contentRow.parentElement){contentRow.after(wrap);}"
-                            "    wrap.style.display='block';"
-                            "    input.value=(input.value||'').replace(/\\D/g,'').slice(0,6);"
-                            "    input.addEventListener('input',function(){"
-                            "      input.value=(input.value||'').replace(/\\D/g,'').slice(0,6);"
-                            "    });"
-                            "  };"
-                            "  if(document.readyState==='loading'){"
-                            "    document.addEventListener('DOMContentLoaded',mount);"
-                            "  }else{mount();}"
-                            "})();"
-                            "</script>"
-                        ),
+                        "fields": ("content", "sfdw_phone_tail6", "received_at"),
+                        "description": "请输入完整的法院短信内容。收到时间将自动设置为当前时间。",
                     },
                 ),
             ]
-        else:
-            return list(self.fieldsets)
+        return list(self.fieldsets)
 
-    def get_form(
-        self, request: HttpRequest, obj: CourtSMS | None = None, change: bool = False, **kwargs: Any
-    ) -> Any:  # pragma: no cover
-        """自定义表单"""
+    def get_form(self, request: HttpRequest, obj: CourtSMS | None = None, change: bool = False, **kwargs: Any) -> Any:
         form = super().get_form(request, obj, change=change, **kwargs)
 
         if obj is None:
@@ -686,5 +629,20 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
                 content_field.help_text = "请粘贴完整的法院短信内容"
                 if hasattr(content_field, "widget") and hasattr(content_field.widget, "attrs"):
                     content_field.widget.attrs.update({"rows": 8, "placeholder": "请粘贴完整的法院短信内容..."})
+
+            # 虚拟字段：手机号后6位（不进数据库，仅 add 页面使用）
+            form.base_fields["sfdw_phone_tail6"] = forms.CharField(
+                label="手机号后6位",
+                max_length=6,
+                required=False,
+                validators=[RegexValidator(r"^\d{0,6}$", "只能输入数字")],
+                widget=forms.TextInput(
+                    attrs={
+                        "inputmode": "numeric",
+                        "placeholder": "留空会自动回退律师手机号后6位",
+                    }
+                ),
+                help_text="用于睿法智达下载加密文书时的身份验证",
+            )
 
         return form

--- a/backend/apps/automation/admin/sms/court_sms_admin_base.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_base.py
@@ -613,9 +613,14 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
         return list(self.fieldsets)
 
     def get_form(self, request: HttpRequest, obj: CourtSMS | None = None, change: bool = False, **kwargs: Any) -> Any:
-        # 虚拟字段需要先从 ModelForm 生成中排除，生成后再注入
-        if obj is None and "fields" not in kwargs:
-            kwargs = {**kwargs, "fields": ("content", "received_at")}
+        # 虚拟字段 sfdw_phone_tail6 仅用于 add 页面渲染、不进数据库。
+        # Django 6.1 的 _changeform_view 会把 get_fieldsets() 扁平化后的字段显式传入，
+        # 其中包含虚拟字段；构建 ModelForm 前必须先剔除，避免 Unknown field(s) FieldError。
+        if obj is None:
+            if kwargs.get("fields") is not None:
+                kwargs["fields"] = tuple(f for f in kwargs["fields"] if f != "sfdw_phone_tail6")
+            else:
+                kwargs.setdefault("fields", ("content", "received_at"))
 
         form = super().get_form(request, obj, change=change, **kwargs)
 

--- a/backend/apps/automation/admin/sms/court_sms_admin_base.py
+++ b/backend/apps/automation/admin/sms/court_sms_admin_base.py
@@ -613,6 +613,10 @@ class CourtSMSAdminBase(admin.ModelAdmin):  # pragma: no cover
         return list(self.fieldsets)
 
     def get_form(self, request: HttpRequest, obj: CourtSMS | None = None, change: bool = False, **kwargs: Any) -> Any:
+        # 虚拟字段需要先从 ModelForm 生成中排除，生成后再注入
+        if obj is None and "fields" not in kwargs:
+            kwargs = {**kwargs, "fields": ("content", "received_at")}
+
         form = super().get_form(request, obj, change=change, **kwargs)
 
         if obj is None:

--- a/backend/tests/ci/unit/automation/test_court_sms_admin_add_form.py
+++ b/backend/tests/ci/unit/automation/test_court_sms_admin_add_form.py
@@ -1,0 +1,50 @@
+"""CourtSMSAdmin add 页面虚拟字段回归测试。
+
+覆盖 Django 6.1 中 _changeform_view 会将 get_fieldsets() 扁平化后以
+fields= 显式传给 get_form 的行为，防止虚拟字段 sfdw_phone_tail6 触发
+Unknown field(s) FieldError。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.admin.utils import flatten_fieldsets
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from apps.automation.admin.sms.court_sms_admin import CourtSMSAdmin
+from apps.automation.models import CourtSMS
+
+User = get_user_model()
+
+
+def _make_add_request() -> Any:
+    request = RequestFactory().get("/admin/automation/courtsms/add/")
+    request.user = User(is_superuser=True, is_staff=True)
+    return request
+
+
+@pytest.mark.django_db
+class TestCourtSMSAdminAddForm:
+    """CourtSMSAdmin add 页面虚拟字段回归测试"""
+
+    def test_add_get_form_injects_virtual_field(self) -> None:
+        """add 页 get_form 应注入虚拟字段 sfdw_phone_tail6"""
+        admin_obj = CourtSMSAdmin(CourtSMS, AdminSite())
+        form_cls = admin_obj.get_form(_make_add_request(), obj=None, change=False)
+        assert "sfdw_phone_tail6" in form_cls.base_fields
+
+    def test_add_get_form_with_flattened_fieldset(self) -> None:
+        """Django 6.1 显式传扁平化字段组时不抛 FieldError"""
+        admin_obj = CourtSMSAdmin(CourtSMS, AdminSite())
+        request = _make_add_request()
+        fieldset_fields = flatten_fieldsets(admin_obj.get_fieldsets(request, None))
+        assert "sfdw_phone_tail6" in fieldset_fields
+
+        form_cls = admin_obj.get_form(request, obj=None, change=False, fields=fieldset_fields)
+        readonly = set(admin_obj.get_readonly_fields(request, None))
+        resolvable = set(form_cls.base_fields) | readonly
+        assert set(fieldset_fields) <= resolvable


### PR DESCRIPTION
## 修复内容
`/admin/automation/courtsms/add/` 在 Django 6.1 下抛出 `FieldError: Unknown field(s) (sfdw_phone_tail6)`。

**根因**：Django 6.1 的 `_changeform_view` 会把 `get_fieldsets()` 返回的字段集扁平化后，以 `fields=` 参数**显式**传给 `get_form`，其中包含虚拟字段 `sfdw_phone_tail6`；而虚拟字段不在 `CourtSMS` 模型上，构造 `ModelForm` 时即抛 `FieldError`。

**修复**：在 `get_form` 中针对 add 页面（`obj is None`）先剔除传入字段里的虚拟字段再构造 `ModelForm`，构造后再重新注入 `sfdw_phone_tail6` 供页面渲染使用。

## 回归测试
新增 `test_court_sms_admin_add_form.py`，覆盖两个场景：
1. add 页 `get_form` 正确注入虚拟字段；
2. 显式传入含虚拟字段的扁平化字段组时不抛 FieldError。

本地已跑通：ruff、ruff format、mypy（改动文件）、`test_court_sms_admin_add_form.py` + `test_automation_admin.py` 全部通过。

## 测试计划
- [x] 本地回归测试通过
- [ ] GitHub CI 通过