### PR TITLE
fix(contracts): 详情页隐藏 admin 标题适配 Django 6.1 DOM

### DIFF
--- a/backend/apps/contracts/static/contracts/css/contract_detail_layout.css
+++ b/backend/apps/contracts/static/contracts/css/contract_detail_layout.css
@@ -1,8 +1,9 @@
 /* 合同详情页 — 页面布局、头部、状态徽章、响应式 */
 
-/* 隐藏 Django admin 自动生成的页面标题 */
+/* 隐藏 Django admin 自动生成的页面标题（Django 6.1 起 H1 渲染到 .titles-and-tools 容器内） */
 #content > h1:first-child,
-#content > h2:first-child {
+#content > h2:first-child,
+#content > .titles-and-tools {
     display: none;
 }
 


### PR DESCRIPTION
## 问题
`/admin/contracts/contract/{id}/detail/` 详情页的 admin 自动生成 H1 标题在升级到 Django 6.1 后重新出现（域内选择器 `//*[@id="content"]/div[1]/div/h1`）。

## 根因
`contract_detail_layout.css` 用 `#content > h1:first-child` 隐藏该标题，但 Django 6.1 把页面标题从 `#content > h1` 迁移到 `#content > .titles-and-tools > .titles > h1`，H1 不再是 `#content` 的直接子元素，原有选择器失效。

## 修复
在 `contract_detail_layout.css` 补充隐藏 `.titles-and-tools` 容器（该元素是 `#content` 的直接子元素，能稳定命中 6.1 结构）。此规则仅在该详情页模板加载，不影响页面自定义的 `<h1 class="contract-title">`（位于 `block content`，与 `.titles-and-tools` 为兄弟节点）。

已通过渲染 Django admin base 模板验证 6.1 实际 DOM 为 `#content > .titles-and-tools > .titles > h1`。