### PR TITLE
chore(plugins): 更新子模块指针，修复插件 doc_convert 面包屑

### DIFF
--- a/changelog/v26.56/v26.56.6.md
+++ b/changelog/v26.56/v26.56.6.md
@@ -1,0 +1,23 @@
+# v26.56.6
+
+> 分支：`fix/plugins-doc-convert-breadcrumb-submodule`（插件子模块 doc_convert 面包屑修复及相关指针更新）
+
+## 后端
+
+### 修复
+
+#### fix(admin): 适配 Django 6.1 语义化面包屑结构（插件 doc_convert 模板）
+
+**问题**：v26.56.5 已迁移主仓库内 `backend/apps/doc_convert` 的面包屑为 `<ol>`，但 `/admin/doc_convert/docconverttool/` 实际渲染的模板来自插件子模块 `backend/plugins/doc_convert`（其 templates 目录经插件机制追加到 `TEMPLATE_DIRS`，优先级高于 app_directories），该模板此前仍为旧的 `<div class="breadcrumbs">`，升级后页面面包屑渲染异常。
+
+**修复**：在插件仓库 FachuanPlugins PR #19 中将 `doc_convert/templates/admin/doc_convert/workbench.html` 迁移为 Django 6.1 语义化 `<ol>` 结构（每项 `<li>` + 当前页 `aria-current="page"`），并同步更新 `plugins` 子模块指针。
+
+---
+
+### 改动文件
+
+| 文件 | 改动 |
+|------|------|
+| `backend/plugins`（子模块指针） | 随插件 PR #19（`8d13ff1` → `20c7ae4`）更新 doc_convert 面包屑修复 |
+
+> 说明：本次改动为后端（子模块指针），无前端代码变更。


### PR DESCRIPTION
## Summary
修复 `/admin/doc_convert/docconverttool/` 页面在 Django 6.1 下面包屑仍为旧版的问题，并同步更新 `plugins` 子模块指针。

### 背景
v26.56.5（PR #450）已迁移主仓库内 `backend/apps/doc_convert` 的面包屑为 `<ol>`，但该页面实际渲染的是插件子模块 `backend/plugins/doc_convert` 的模板（其 templates 经插件机制追加到 `TEMPLATE_DIRS`，优先级高于 app_directories），此前仍为旧的 `<div class="breadcrumbs">`，故用户侧仍显示异常。

### 改动
- `plugins` 子模块指针 `8d13ff1` → `20c7ae4`：插件仓库 FachuanPlugins PR #19 将 `doc_convert/templates/admin/doc_convert/workbench.html` 迁移为 Django 6.1 语义化 `<ol>` 结构（每项 `<li>` + 当前页 `aria-current="page"`）。
- 新增 changelog `v26.56.6`。

## Test plan
- 本地 CI quick：仅 pip-audit 因网络瞬时故障失败（非依赖漏洞），其余 10 项通过；重试后推送成功。
- 模板迁移后，`/admin/doc_convert/docconverttool/` 面包屑按 Django 6.1 语义正确渲染 `<li>` 列表。