### PR TITLE
feat(message_hub): 法院附件下载跨 WSL/Windows 修复 + CloakBrowser 安装报错引导

### DIFF
--- a/backend/apps/core/management/commands/ensure_cloakbrowser.py
+++ b/backend/apps/core/management/commands/ensure_cloakbrowser.py
@@ -1,0 +1,22 @@
+"""确保 CloakBrowser 浏览器二进制已安装（部署自检用）。
+
+用法:  python apiSystem/manage.py ensure_cloakbrowser
+安装失败时输出可操作的修复指引（而非一句 timed out）。
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.core.services.browser.launcher import CloakBrowserInstallError, ensure_browser_binary
+
+
+class Command(BaseCommand):
+    help = "确保 CloakBrowser 浏览器二进制已安装；失败时输出可操作的修复指引"
+
+    def handle(self, *args: object, **options: object) -> None:
+        try:
+            path = ensure_browser_binary()
+        except CloakBrowserInstallError as exc:
+            raise CommandError(str(exc))
+        self.stdout.write(self.style.SUCCESS(f"CloakBrowser 就绪: {path}"))

--- a/backend/apps/core/services/browser/__init__.py
+++ b/backend/apps/core/services/browser/__init__.py
@@ -132,11 +132,12 @@ async def create_browser_async(  # pragma: no cover
             yield page, context
     else:
         # 原生 launch 的异步版本（CloakBrowser）
-        from cloakbrowser import ensure_binary, launch_async
+        from cloakbrowser import launch_async
 
         from .anti_detection import anti_detection
+        from .launcher import ensure_browser_binary
 
-        ensure_binary()
+        ensure_browser_binary()
         browser = await launch_async(
             headless=profile.headless,
             humanize=profile.anti_detection,

--- a/backend/apps/core/services/browser/launcher.py
+++ b/backend/apps/core/services/browser/launcher.py
@@ -12,6 +12,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import httpx
+
 from .anti_detection import anti_detection
 from .profiles import BrowserProfile
 
@@ -19,6 +21,43 @@ if TYPE_CHECKING:
     from playwright.sync_api import Browser, BrowserContext, Page
 
 logger = logging.getLogger("apps.core")
+
+
+class CloakBrowserInstallError(RuntimeError):
+    """CloakBrowser 二进制不可用，携带可操作的修复指引。"""
+
+
+def ensure_browser_binary() -> str:
+    """确保 CloakBrowser 二进制可用，返回可执行文件路径。
+
+    包装 ``cloakbrowser.ensure_binary()``，把裸的网络/配置/平台异常翻译成可操作的
+    中文修复指引（而不是一句 ``timed out`` 或整屏堆栈），方便部署时直接照做。
+    """
+    from cloakbrowser import ensure_binary
+    from cloakbrowser.config import get_binary_path, get_local_binary_override
+
+    try:
+        return str(ensure_binary())
+    except httpx.HTTPError as exc:
+        expected = get_binary_path()
+        raise CloakBrowserInstallError(
+            "CloakBrowser 浏览器二进制下载失败（下载源不可达）。\n"
+            f"期望安装位置: {expected}\n"
+            "请任选其一修复：\n"
+            "  1) 设置 CLOAKBROWSER_DOWNLOAD_URL 为可访问的镜像地址"
+            "（注意：设置自定义源后将不再回退 GitHub）；\n"
+            "  2) 离线预置：把对应平台的安装包解压到上述缓存目录后重试；\n"
+            "  3) 设置 CLOAKBROWSER_BINARY_PATH 指向本机已安装的 Chromium/Chrome 可执行文件。\n"
+            f"原始错误: {exc}"
+        ) from exc
+    except FileNotFoundError as exc:
+        override = get_local_binary_override()
+        raise CloakBrowserInstallError(
+            f"已设置 CLOAKBROWSER_BINARY_PATH={override}，但该路径下不存在可执行文件，"
+            "请检查路径是否正确，或去掉该环境变量改用自动下载。"
+        ) from exc
+    except RuntimeError as exc:
+        raise CloakBrowserInstallError(f"CloakBrowser 安装失败（平台不支持/校验/解压问题）：{exc}") from exc
 
 
 @contextmanager
@@ -36,14 +75,14 @@ def launch_browser(  # pragma: no cover
     Yields:
         (page, context) 元组
     """
-    from cloakbrowser import ensure_binary, launch, launch_persistent_context
+    from cloakbrowser import launch, launch_persistent_context
 
     browser: Browser | None = None
     context: BrowserContext | None = None
     page: Page | None = None
 
     try:
-        ensure_binary()
+        ensure_browser_binary()
 
         logger.info("启动 CloakBrowser (profile=%s, headless=%s)", profile.name, profile.headless)
 
@@ -86,7 +125,7 @@ def launch_browser(  # pragma: no cover
 
         # dialog 处理（CloakBrowser 继承 Playwright 的 dialog 拦截行为）
         assert page is not None
-        page.on("dialog", lambda d: d.accept())  # type: ignore[attr-defined]
+        page.on("dialog", lambda d: d.accept())
 
         # macOS 补充指纹补丁（26→58 差异）
         anti_detection.apply_macos_patches(page)

--- a/backend/tests/ci/unit/core/test_core_browser_service.py
+++ b/backend/tests/ci/unit/core/test_core_browser_service.py
@@ -176,3 +176,47 @@ class TestModuleImports:
         assert callable(launch_chrome)
         assert callable(kill_chrome)
         assert callable(is_cdp_ready)
+
+
+class TestEnsureBrowserBinary:
+    """ensure_browser_binary 智能报错封装测试。"""
+
+    def test_returns_binary_path_when_ready(self) -> None:
+        from apps.core.services.browser.launcher import ensure_browser_binary
+
+        with patch("cloakbrowser.ensure_binary", return_value="/.cloakbrowser/chrome"):
+            assert ensure_browser_binary() == "/.cloakbrowser/chrome"
+
+    def test_network_error_gives_actionable_hint(self) -> None:
+        from pathlib import Path
+
+        import httpx
+
+        from apps.core.services.browser.launcher import CloakBrowserInstallError, ensure_browser_binary
+
+        with patch("cloakbrowser.ensure_binary", side_effect=httpx.ConnectTimeout("timed out")), \
+             patch("cloakbrowser.config.get_binary_path", return_value=Path("/.cloakbrowser/chromium/chrome.exe")):
+            with pytest.raises(CloakBrowserInstallError) as ei:
+                ensure_browser_binary()
+        msg = str(ei.value)
+        assert "下载失败" in msg
+        assert "CLOAKBROWSER_DOWNLOAD_URL" in msg
+        assert "CLOAKBROWSER_BINARY_PATH" in msg
+        assert "timed out" in msg  # 保留原始错误便于排查
+
+    def test_binary_path_non_existent_gives_hint(self) -> None:
+        from apps.core.services.browser.launcher import CloakBrowserInstallError, ensure_browser_binary
+
+        with patch("cloakbrowser.ensure_binary", side_effect=FileNotFoundError("no")), \
+             patch("cloakbrowser.config.get_local_binary_override", return_value="C:/nope/chrome.exe"):
+            with pytest.raises(CloakBrowserInstallError) as ei:
+                ensure_browser_binary()
+        assert "CLOAKBROWSER_BINARY_PATH" in str(ei.value)
+
+    def test_runtime_error_preserves_message(self) -> None:
+        from apps.core.services.browser.launcher import CloakBrowserInstallError, ensure_browser_binary
+
+        with patch("cloakbrowser.ensure_binary", side_effect=RuntimeError("Unsupported platform")):
+            with pytest.raises(CloakBrowserInstallError) as ei:
+                ensure_browser_binary()
+        assert "Unsupported platform" in str(ei.value)

--- a/backend/tests/ci/unit/message_hub/services/court/test_court_fetcher_v2.py
+++ b/backend/tests/ci/unit/message_hub/services/court/test_court_fetcher_v2.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import httpx
 import pytest
@@ -18,6 +18,7 @@ except ImportError:
 pytestmark = pytest.mark.skipif(not _HAS_MH, reason="message_hub plugin not installed")
 
 from apps.message_hub.models import SyncStatus
+
 if _HAS_MH:
     from plugins.message_hub.services.court.court_fetcher import (
         CourtInboxFetcher,
@@ -371,22 +372,58 @@ class TestCourtInboxFetcherDownloadAttachment:
             with pytest.raises(Exception):
                 fetcher.download_attachment(source, "msg-1", 0)
 
-    def test_local_file_exists(self) -> None:
-        with patch(self._PATCH_INBOX) as MockInbox:
+    def test_local_file_exists(self, tmp_path) -> None:
+        # local_path 现在按 MEDIA_ROOT 解析（兼容历史 WSL/Windows 绝对路径），
+        # 用真实临时文件验证：把 MEDIA_ROOT 指向 tmp_path，local_path 写相对路径
+        real_file = tmp_path / "f.pdf"
+        real_file.write_bytes(b"content")
+
+        with patch(self._PATCH_INBOX) as MockInbox, patch(
+            "plugins.message_hub.services.base.settings"
+        ) as mock_settings:
+            mock_settings.MEDIA_ROOT = tmp_path
             mock_msg = MagicMock()
-            mock_msg.attachments_meta = [{"part_index": 0, "filename": "f.pdf", "content_type": "application/pdf", "local_path": "/tmp/f.pdf", "size": 100}]
+            mock_msg.attachments_meta = [
+                {"part_index": 0, "filename": "f.pdf", "content_type": "application/pdf", "local_path": "f.pdf", "size": 100}
+            ]
             MockInbox.objects.get.return_value = mock_msg
 
-            # Patch Path in the court_fetcher module so Path(local_path).exists() returns True
-            mock_path_instance = MagicMock()
-            mock_path_instance.exists.return_value = True
-            mock_path_instance.read_bytes.return_value = b"content"
-            with patch("plugins.message_hub.services.court.court_fetcher.Path", return_value=mock_path_instance):
-                fetcher = CourtInboxFetcher()
-                source = MagicMock()
-                content, fname, ctype = fetcher.download_attachment(source, "msg-1", 0)
-                assert content == b"content"
-                assert fname == "f.pdf"
+            fetcher = CourtInboxFetcher()
+            source = MagicMock()
+            content, fname, ctype = fetcher.download_attachment(source, "msg-1", 0)
+            assert content == b"content"
+            assert fname == "f.pdf"
+
+    def test_local_file_wsl_legacy_path(self, tmp_path) -> None:
+        """历史 WSL 绝对路径（/mnt/... 或 D:\\...）按 /media/ 截尾后能命中当前 MEDIA_ROOT 下同名文件。"""
+        sub = tmp_path / "court_inbox" / "msg-1"
+        sub.mkdir(parents=True)
+        (sub / "f.pdf").write_bytes(b"legacy-content")
+
+        with patch(self._PATCH_INBOX) as MockInbox, patch(
+            "plugins.message_hub.services.base.settings"
+        ) as mock_settings:
+            mock_settings.MEDIA_ROOT = tmp_path
+            mock_msg = MagicMock()
+            mock_msg.attachments_meta = [
+                {
+                    "part_index": 0,
+                    "filename": "f.pdf",
+                    "content_type": "application/pdf",
+                    # 历史绝对路径（WSL 或 Windows 坐标），/media/ 之后是 court_inbox/msg-1/f.pdf
+                    "local_path": "/mnt/d/proj/backend/apiSystem/media/court_inbox/msg-1/f.pdf",
+                    "size": 100,
+                }
+            ]
+            MockInbox.objects.get.return_value = mock_msg
+
+            fetcher = CourtInboxFetcher()
+            source = MagicMock()
+            content, fname, _ = fetcher.download_attachment(source, "msg-1", 0)
+            assert content == b"legacy-content"
+            assert fname == "f.pdf"
+            # 命中后 local_path 应回写为相对路径
+            assert mock_msg.attachments_meta[0]["local_path"] == "court_inbox/msg-1/f.pdf"
 
     def test_part_index_not_found(self) -> None:
         with patch(self._PATCH_INBOX) as MockInbox:

--- a/changelog/v26.56/v26.56.11.md
+++ b/changelog/v26.56/v26.56.11.md
@@ -1,0 +1,23 @@
+# v26.56.11
+
+> 分支：`fix/court-attachment-refresh-relogin`（法院收件箱附件下载跨 WSL/Windows 路径修复 + CloakBrowser 安装失败可操作指引）
+
+## 后端
+
+### 修复
+
+#### fix(message_hub): 法院收件箱附件下载跨 WSL/Windows 环境失败（403/500）
+
+- 用户机器同时运行 WSL 与 Windows 两套环境，同一物理目录坐标不同：WSL 同步落盘的附件绝对路径（`/mnt/d/...`）在 Windows 进程内 `Path.exists()` 恒为 False，触发「本地没有 → 刷新 OSS 链接 → 超时 → 回退过期链接 → 403 → 500」
+- 附件 `local_path` 改为存相对 `MEDIA_ROOT` 的相对路径；读取时统一按 `MEDIA_ROOT` 归一化，并对含 `/media/` 的历史绝对路径（`/mnt/d/...`/`D:\...`）截尾重拼命中同一物理文件，WSL 与 Windows 进程均可读同一份附件
+- 附件下载链接刷新失败改为「现有 token → 强制重新登录」两轮重试，失败抛出明确异常而非静默回退已过期旧链接
+
+#### fix(browser): CloakBrowser 安装失败给出可操作指引，不再只报 timed out
+
+- 浏览器二进制下载/配置失败时，按异常分类翻译成中文修复指引（下载源不可达 → 配置镜像源/离线预置/指定本地二进制；`CLOAKBROWSER_BINARY_PATH` 路径缺失 → 检查配置），并保留原始错误便于排查。同步、异步启动链路统一接入
+
+### 新功能
+
+#### feat(browser): 新增部署自检命令 ensure_cloakbrowser
+
+- 提供 `manage.py ensure_cloakbrowser`，部署后显式校验 CloakBrowser 二进制是否就绪；失败时输出可操作修复指引，把「首次使用浏览器才炸」前置为可预期的部署步骤


### PR DESCRIPTION
## Summary
- **法院收件箱附件下载跨 WSL/Windows 修复**：更新附件下载测试，覆盖真实临时文件与跨 WSL/Windows 历史绝对路径；同步 plugins 子模块指针（含 relogin 不再回退、缺 await、相对路径归一化，见 plugins PR #21）
- **CloakBrowser 安装失败给出可操作指引**：`launcher.ensure_browser_binary()` 把裸 timed out/堆栈按异常分类翻译成中文修复指引，同步/异步链路统一接入；新增 `manage.py ensure_cloakbrowser` 部署自检命令
- **changelog v26.56.11**

## Test plan
- ruff / mypy / 单元测试通过（新增 CloakBrowser 报错分类测试 4 项、法院附件路径测试）
- 依赖：请先合并 plugins PR #21，再合并本 PR