### PR TITLE
fix(core, automation): core P2 清理 + 法院短信案号提取修复

### DIFF
--- a/backend/apps/automation/services/sms/case_number_extractor_service.py
+++ b/backend/apps/automation/services/sms/case_number_extractor_service.py
@@ -238,11 +238,17 @@ class CaseNumberExtractorService:
 
             for i, case_number in enumerate(case_numbers):
                 normalized = self._normalize_single(case_number, i, case_number_svc)
-                if normalized and normalized not in seen:
-                    valid_numbers.append(normalized)
-                    seen.add(normalized)
-                elif normalized:
+                if not normalized:
+                    continue
+                if normalized in seen:
                     logger.debug(f"案号重复，跳过: {normalized}")
+                    continue
+                # 简式案号若已有对应的带年份完整案号，则视为重复，保留完整版
+                if self._is_yearless_subset(normalized, seen):
+                    logger.debug(f"简式案号已有完整年份版本，跳过: {normalized}")
+                    continue
+                valid_numbers.append(normalized)
+                seen.add(normalized)
 
             logger.info(f"案号验证完成: 输入 {len(case_numbers)} 个，有效 {len(valid_numbers)} 个")
             return valid_numbers
@@ -250,6 +256,17 @@ class CaseNumberExtractorService:
         except Exception as e:
             logger.error(f"案号验证和规范化失败: {e!s}")
             return []
+
+    def _is_yearless_subset(self, candidate: str, existing: set[str]) -> bool:
+        """判断候选简式案号是否已存在其带年份的完整版本。"""
+        if "（" in candidate or "(" in candidate:
+            return False
+        # 完整版去掉年份前缀后应包含该简式（简式可能缺省省市前缀字符）
+        for num in existing:
+            m = re.match(r"^[（(]\d{4}[）)](.+)$", num)
+            if m and m.group(1).endswith(candidate):
+                return True
+        return False
 
     def _normalize_single(self, case_number: str, idx: int, case_number_svc: Any) -> str | None:
         """规范化单个案号，返回规范化结果或 None"""
@@ -265,6 +282,11 @@ class CaseNumberExtractorService:
             if not original:
                 return None
 
+            # 极大文本不可能是案号，直接截断拒绝（防正则贪婪匹配误吞整段）
+            if len(original) > 60:
+                logger.warning(f"案号过长，跳过: 长度={len(original)}，开头={original[:40]}...")
+                return None
+
             try:
                 normalized = case_number_svc.normalize_case_number(original)
             except Exception as e:
@@ -275,8 +297,15 @@ class CaseNumberExtractorService:
                 logger.warning(f"案号规范化后为空，跳过: {original}")
                 return None
 
+            # 规范化后再检查长度（换行会被压缩，仍需保护）
+            if len(normalized) > 60:
+                logger.warning(f"案号过长，跳过: 长度={len(normalized)}，开头={normalized[:40]}...")
+                return None
+
             try:
-                is_valid = re.match(standard_pattern, normalized) or re.match(simple_pattern, normalized)
+                is_valid = (re.match(standard_pattern, normalized) or re.match(simple_pattern, normalized)) and (
+                    len(re.findall(r"\d+", normalized)) >= 2
+                )
             except re.error as e:
                 logger.warning(f"案号格式验证失败: {normalized}, 正则错误: {e!s}")
                 return None
@@ -405,22 +434,16 @@ class CaseNumberExtractorService:
     def _regex_extract_numbers(self, text: str) -> list[str]:
         """使用正则从文本中提取候选案号"""
         patterns = [
-            # 匹配全角括号（2026）粤0606民初7856号
-            r"[（](\d{4})[）]([^）]*?\w+\d+[^0-9]*?\d+号)",
-            # 匹配半角括号 (2026)粤0606民初7856号
-            r"\((\d{4})\)([^)]*?\w+\d+[^0-9]*?\d+号)",
-            # 匹配无括号的案号 粤0606民初7856号
-            r"([^（）()\s]*?[0-9]+[^0-9]*?[0-9]+号)",
-            r"(\w*\d+\w*\d+号)",
+            # 标准格式：(2026)粤0606民初88888号  —— 精确锚定数字+号，避免贪吃后续文字
+            r"[（(](\d{4})[）)][^（()\n]{2,40}?\d{1,7}号",
+            # 简化格式（无年份）：粤0606民初88888号 —— 法院代码数字组+案由字+序号数字组，紧凑捕获
+            r"\d{2,5}[^0-9（）()\s]{1,15}\d{1,7}号",
         ]
         found: list[str] = []
         for i, pattern in enumerate(patterns):
             try:
-                for match in re.findall(pattern, text):
-                    if isinstance(match, tuple):
-                        case_number = f"（{match[0]}）{match[1]}" if len(match) == 2 else match[0]
-                    else:
-                        case_number = match
+                for match in re.finditer(pattern, text):
+                    case_number = match.group(0)
                     if case_number and case_number.strip():
                         found.append(case_number.strip())
                 logger.debug(f"正则模式 {i + 1} 匹配到 {len(found)} 个结果")

--- a/backend/apps/core/admin/mixins/import_export_mixin.py
+++ b/backend/apps/core/admin/mixins/import_export_mixin.py
@@ -117,6 +117,9 @@ class AdminImportExportMixin:  # pragma: no cover
 
     def _extract_files(self, zf: zipfile.ZipFile) -> None:  # pragma: no cover
         """把 ZIP 内 files/ 目录下的文件写入 MEDIA_ROOT。"""
+        from django.core.files.base import ContentFile
+        from django.core.files.storage import default_storage
+
         from apps.core.services.storage_service import _get_media_root
 
         media_root = _get_media_root()
@@ -126,22 +129,24 @@ class AdminImportExportMixin:  # pragma: no cover
         for name in zf.namelist():
             if not name.startswith("files/") or name.endswith("/"):
                 continue
-            rel = name[len("files/") :]  # 去掉 files/ 前缀
-            dest = (root / rel).resolve()
+            # rel 为相对 MEDIA_ROOT 的 storage 键（zip 内统一使用 / 分隔符）
+            rel = name[len("files/") :]
             # 防止 Zip Slip 路径遍历攻击（relative_to 抛异常即拒绝）
             try:
-                dest.relative_to(root)
+                (root / rel).resolve().relative_to(root)
             except ValueError:
                 logger.warning("跳过可疑路径", extra={"path": name})
                 continue
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            if not dest.exists():  # 已存在则不覆盖
-                dest.write_bytes(zf.read(name))
-                logger.info("还原文件", extra={"path": str(dest)})
+            if default_storage.exists(rel):  # 已存在则不覆盖
+                continue
+            default_storage.save(rel, ContentFile(zf.read(name)))
+            logger.info("还原文件", extra={"path": rel})
 
     # ── 导出 actions ──────────────────────────────────────────────
 
-    def export_selected_as_json(self, request: HttpRequest, queryset: QuerySet[Any]) -> HttpResponse:  # pragma: no cover
+    def export_selected_as_json(
+        self, request: HttpRequest, queryset: QuerySet[Any]
+    ) -> HttpResponse:  # pragma: no cover
         count = queryset.count()
         filename = f"{self.export_model_name}_selected_{count}_export_{date.today().strftime('%Y%m%d')}.zip"
         return self._build_zip_response(queryset, filename)

--- a/backend/apps/core/infrastructure/logging.py
+++ b/backend/apps/core/infrastructure/logging.py
@@ -221,10 +221,10 @@ class JsonFormatter:
 
     def format(self, record: Any) -> str:
         import traceback
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         log_data: dict[str, Any] = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
             "level": record.levelname,
             "logger": record.name,
             "module": record.module,

--- a/backend/apps/core/middleware/token_rate_limit.py
+++ b/backend/apps/core/middleware/token_rate_limit.py
@@ -83,6 +83,10 @@ class TokenRateLimitMiddleware:
 
     @staticmethod
     async def _async_check_rate(bucket_key: str) -> int:
+        # NOTE: Redis 后端下 aget/aset 分两步执行，无原子比较-递增。
+        # 生产优先使用 Redis（见 infrastructure.cache.get_cache_config），
+        # 在 Gunicorn 多 worker / 多实例下绕过窗口比同步版更大。
+        # 如需严格原子性，应改用 Redis INCR + 过期策略。
         try:
             if await cache.aget(bucket_key) is None:
                 await cache.aset(bucket_key, 1, timeout=_TOKEN_RATE_WINDOW + 5)

--- a/backend/apps/core/services/conversation_service.py
+++ b/backend/apps/core/services/conversation_service.py
@@ -12,6 +12,9 @@ from typing import Any
 from django.db import models
 from django.utils import timezone
 
+from apps.core.models import ConversationHistory
+from apps.core.repositories.conversation_repository import ConversationHistoryRepository
+
 
 @dataclass
 class _HumanMessage:  # pragma: no cover
@@ -31,9 +34,6 @@ class _SystemMessage:  # pragma: no cover
 HumanMessage = _HumanMessage
 AIMessage = _AIMessage
 SystemMessage = _SystemMessage
-
-from apps.core.models import ConversationHistory
-from apps.core.repositories.conversation_repository import ConversationHistoryRepository
 
 
 class _SimpleChatMemory:  # pragma: no cover
@@ -133,7 +133,9 @@ class ConversationService:  # pragma: no cover
             # 添加到记忆中
             self._memory.chat_memory.add_message(message)
 
-    def add_user_message(self, content: str, metadata: dict[str, Any] | None = None) -> ConversationHistory:  # pragma: no cover
+    def add_user_message(
+        self, content: str, metadata: dict[str, Any] | None = None
+    ) -> ConversationHistory:  # pragma: no cover
         """
         添加用户消息
 
@@ -158,7 +160,9 @@ class ConversationService:  # pragma: no cover
 
         return record
 
-    def add_assistant_message(self, content: str, metadata: dict[str, Any] | None = None) -> ConversationHistory:  # pragma: no cover
+    def add_assistant_message(
+        self, content: str, metadata: dict[str, Any] | None = None
+    ) -> ConversationHistory:  # pragma: no cover
         """
         添加助手消息
 
@@ -183,7 +187,9 @@ class ConversationService:  # pragma: no cover
 
         return record
 
-    def add_system_message(self, content: str, metadata: dict[str, Any] | None = None) -> ConversationHistory:  # pragma: no cover
+    def add_system_message(
+        self, content: str, metadata: dict[str, Any] | None = None
+    ) -> ConversationHistory:  # pragma: no cover
         """
         添加系统消息
 
@@ -228,7 +234,9 @@ class ConversationService:  # pragma: no cover
 
         return messages
 
-    async def aadd_user_message(self, content: str, metadata: dict[str, Any] | None = None) -> ConversationHistory:  # pragma: no cover
+    async def aadd_user_message(
+        self, content: str, metadata: dict[str, Any] | None = None
+    ) -> ConversationHistory:  # pragma: no cover
         """异步添加用户消息"""
         record = await self._repository.acreate(
             session_id=self.session_id,
@@ -241,7 +249,9 @@ class ConversationService:  # pragma: no cover
         self.memory.chat_memory.add_user_message(content)
         return record
 
-    async def aadd_assistant_message(self, content: str, metadata: dict[str, Any] | None = None) -> ConversationHistory:  # pragma: no cover
+    async def aadd_assistant_message(
+        self, content: str, metadata: dict[str, Any] | None = None
+    ) -> ConversationHistory:  # pragma: no cover
         """异步添加助手消息"""
         record = await self._repository.acreate(
             session_id=self.session_id,
@@ -254,7 +264,9 @@ class ConversationService:  # pragma: no cover
         self.memory.chat_memory.add_ai_message(content)
         return record
 
-    async def aadd_system_message(self, content: str, metadata: dict[str, Any] | None = None) -> ConversationHistory:  # pragma: no cover
+    async def aadd_system_message(
+        self, content: str, metadata: dict[str, Any] | None = None
+    ) -> ConversationHistory:  # pragma: no cover
         """异步添加系统消息"""
         record = await self._repository.acreate(
             session_id=self.session_id,
@@ -284,9 +296,7 @@ class ConversationService:  # pragma: no cover
 
         history = [
             (record.role, record.content)
-            async for record in self._repository.get_by_session_id(
-                self.session_id
-            ).order_by("created_at")[:20]
+            async for record in self._repository.get_by_session_id(self.session_id).order_by("created_at")[:20]
         ]
 
         for role, content in history:

--- a/backend/apps/core/services/material_classification_service.py
+++ b/backend/apps/core/services/material_classification_service.py
@@ -922,8 +922,8 @@ class MaterialClassificationService:
         for part in p.parent.parts:
             # 去掉编号前缀：1- / 2_ / 3. 等
             cleaned = re.sub(r"^[\d]+[\s.\-_]*[\)）]?\s*", "", part).strip()
-            if (cleaned and cleaned != part) or len(cleaned) > 0:
-                parts.append(cleaned if cleaned else part)
+            if cleaned:
+                parts.append(cleaned)
         return parts
 
     def _get_archive_item_name(self, archive_category: str, code: str) -> str:

--- a/backend/tests/ci/unit/automation/sms/test_case_number_extractor.py
+++ b/backend/tests/ci/unit/automation/sms/test_case_number_extractor.py
@@ -33,9 +33,9 @@ class TestCaseNumberExtractorService:
     def test_extract_from_content_with_provider(self) -> None:
         """使用 extraction_provider 提取案号。"""
         self.extraction_provider.extract.return_value = json.dumps(
-            {"case_numbers": ["（2025）粤0604民初12345号"]}
+            {"case_numbers": ["（2025）粤0606民初12345号"]}
         )
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
 
         result = self.service.extract_from_content("文书内容包含案号")
         assert len(result) >= 1
@@ -49,16 +49,16 @@ class TestCaseNumberExtractorService:
 
     def test_parse_ollama_response_valid_json(self) -> None:
         """解析有效 JSON 响应。"""
-        response = '{"case_numbers": ["（2025）粤0604民初12345号"]}'
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        response = '{"case_numbers": ["（2025）粤0606民初12345号"]}'
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
 
         result = self.service._parse_ollama_response(response)
         assert len(result) >= 1
 
     def test_parse_ollama_response_invalid_json(self) -> None:
         """解析无效 JSON 响应，使用降级方案。"""
-        response = "案号：（2025）粤0604民初12345号"
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        response = "案号：（2025）粤0606民初12345号"
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
 
         result = self.service._parse_ollama_response(response)
         # 降级方案可能提取到也可能提取不到
@@ -66,8 +66,8 @@ class TestCaseNumberExtractorService:
 
     def test_parse_ollama_response_with_markdown(self) -> None:
         """解析包含 markdown 包裹的 JSON 响应。"""
-        response = '```json\n{"case_numbers": ["（2025）粤0604民初12345号"]}\n```'
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        response = '```json\n{"case_numbers": ["（2025）粤0606民初12345号"]}\n```'
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
 
         result = self.service._parse_ollama_response(response)
         assert isinstance(result, list)
@@ -78,10 +78,10 @@ class TestCaseNumberExtractorService:
 
     def test_validate_and_normalize_deduplicate(self) -> None:
         """去重案号。"""
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
 
         result = self.service.validate_and_normalize(
-            ["（2025）粤0604民初12345号", "（2025）粤0604民初12345号"]
+            ["（2025）粤0606民初12345号", "（2025）粤0606民初12345号"]
         )
         # 应该只有一个
         assert len(result) == 1
@@ -93,9 +93,34 @@ class TestCaseNumberExtractorService:
         result = self.service.validate_and_normalize(["invalid"])
         assert result == []
 
+    def test_validate_and_normalize_rejects_overlong_text(self) -> None:
+        """超长文本（正则贪婪匹配的文书段落）被拒绝，避免误吞整段。"""
+        # 实际事故案例：PDF 正文被当作案号提取（含换行、多数字、尾部带"号"）
+        long_payload = "（2026）粤0606民初88888号\n某市某公司和某特钢公司：" + "（单位）起诉至本院。" * 20 + "\n本院地址：某市某区某路140号"
+
+        result = self.service.validate_and_normalize([long_payload])
+        assert result == []
+
+    def test_validate_and_normalize_rejects_single_digit_group(self) -> None:
+        """仅一个数字组的地址文本不被当作案号（案号需法院代码+序号至少两组数字）。"""
+        self.case_number_service.normalize_case_number.side_effect = lambda n: n.replace(" ", "")
+
+        result = self.service.validate_and_normalize(["某市某区某路140号", "本院地址：某市某区某路140号"])
+        assert result == []
+
+    def test_validate_and_normalize_accepts_real_case_number(self) -> None:
+        """真实案号（含两组及以上数字）仍通过校验。"""
+        self.case_number_service.normalize_case_number.side_effect = lambda n: n.replace(" ", "")
+
+        result = self.service.validate_and_normalize(
+            ["（2026）粤0606民初88888号", "（2024）粤0606执12345号", "粤0606民初88888号"]
+        )
+        # 简式「粤0606民初88888号」是「（2026）粤0606民初88888号」的年份缺失版，应被去重，只保留完整版
+        assert result == ["（2026）粤0606民初88888号", "（2024）粤0606执12345号"]
+
     def test_sync_to_case_empty_case_id(self) -> None:
         """空 case_id 返回 0。"""
-        result = self.service.sync_to_case(0, ["（2025）粤0604民初12345号"], 1)
+        result = self.service.sync_to_case(0, ["（2025）粤0606民初12345号"], 1)
         assert result == 0
 
     def test_sync_to_case_empty_numbers(self) -> None:
@@ -105,26 +130,56 @@ class TestCaseNumberExtractorService:
 
     def test_sync_to_case_success(self) -> None:
         """成功同步案号到案件。"""
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
         self.case_service.get_case_numbers_by_case_internal.return_value = []
 
-        result = self.service.sync_to_case(1, ["（2025）粤0604民初12345号"], 1)
+        result = self.service.sync_to_case(1, ["（2025）粤0606民初12345号"], 1)
         assert result == 1
         self.case_number_service.create_number.assert_called_once()
 
     def test_sync_to_case_already_exists(self) -> None:
         """案号已存在，跳过。"""
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
-        self.case_service.get_case_numbers_by_case_internal.return_value = ["（2025）粤0604民初12345号"]
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
+        self.case_service.get_case_numbers_by_case_internal.return_value = ["（2025）粤0606民初12345号"]
 
-        result = self.service.sync_to_case(1, ["（2025）粤0604民初12345号"], 1)
+        result = self.service.sync_to_case(1, ["（2025）粤0606民初12345号"], 1)
         assert result == 0
 
     def test_regex_extract_numbers(self) -> None:
         """正则提取案号。"""
-        text = "案号：（2025）粤0604民初12345号"
+        text = "案号：（2025）粤0606民初12345号"
         result = self.service._regex_extract_numbers(text)
         assert isinstance(result, list)
+
+    def test_regex_extract_preserves_year_when_full_case_number(self) -> None:
+        """标准格式案号应保留完整年份，且不贪吃后续正文。"""
+        text = "（2026）粤0606民初88888号南海公司和某不锈钢业有限公司与你单位之间买卖合同纠纷一案你起诉至本院。本院地址：某市某区某路140号"
+        result = self.service._regex_extract_numbers(text)
+        assert "（2026）粤0606民初88888号" in result
+        assert all("买卖" not in c and "地址" not in c for c in result)
+
+    def test_validate_and_normalize_full_chain_keeps_full_case_number(self) -> None:
+        """完整链路：正则提取→验证，应产出完整带年份案号而非残段。"""
+        from unittest.mock import MagicMock
+
+        from apps.cases.utils import normalize_case_number as real_normalize
+
+        mock = MagicMock()
+        mock.normalize_case_number.side_effect = lambda n: real_normalize(n.replace(" ", ""))
+
+        service = CaseNumberExtractorService(
+            document_processing_service=self.document_processing_service,
+            case_service=self.case_service,
+            case_number_service=mock,
+            extraction_provider=self.extraction_provider,
+            llm_service=self.llm_service,
+        )
+        content = "（2026）粤0606民初88888号南海公司起诉至本院。本院地址：某市某区某路140号".replace(" ", "")
+        raw = service._regex_extract_numbers(content)
+        validated = service.validate_and_normalize(raw)
+        assert "（2026）粤0606民初88888号" in validated
+        # 完整带年份案号必须优先产出，且不应混入地址残段
+        assert not any("地址" in n for n in validated)
 
     def test_extract_fallback_empty(self) -> None:
         """降级方案空文本返回空列表。"""
@@ -138,12 +193,12 @@ class TestCaseNumberExtractorService:
     def test_extract_from_document_success(self) -> None:
         """成功从文书提取案号。"""
         self.document_processing_service.extract_document_content_by_path_internal.return_value = {
-            "text": "案号：（2025）粤0604民初12345号"
+            "text": "案号：（2025）粤0606民初12345号"
         }
         self.extraction_provider.extract.return_value = json.dumps(
-            {"case_numbers": ["（2025）粤0604民初12345号"]}
+            {"case_numbers": ["（2025）粤0606民初12345号"]}
         )
-        self.case_number_service.normalize_case_number.return_value = "（2025）粤0604民初12345号"
+        self.case_number_service.normalize_case_number.return_value = "（2025）粤0606民初12345号"
 
         result = self.service.extract_from_document("/path/to/doc.pdf")
         assert isinstance(result, list)

--- a/backend/tests/ci/unit/core/test_import_export_mixin.py
+++ b/backend/tests/ci/unit/core/test_import_export_mixin.py
@@ -1,0 +1,76 @@
+"""apps/core/admin/mixins/import_export_mixin.py 文件解压逻辑单元测试。
+
+聚焦校验：
+- 正常 files/ 成员走 default_storage.save() 还原；
+- Zip Slip 恶意路径（..）被拒绝且不落盘；
+- 已存在的 storage 键不会覆盖（保持原语义）。
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apps.core.admin.mixins.import_export_mixin import AdminImportExportMixin
+
+
+@pytest.fixture
+def mixin() -> AdminImportExportMixin:
+    return AdminImportExportMixin()
+
+
+def _make_zip(members: list[tuple[str, bytes]]) -> zipfile.ZipFile:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in members:
+            zf.writestr(name, content)
+    buf.seek(0)
+    return zipfile.ZipFile(buf)
+
+
+def test_extract_files_saves_through_default_storage(mixin: AdminImportExportMixin) -> None:
+    zf = _make_zip([("files/client_docs/a.pdf", b"pdf-bytes")])
+
+    with patch(
+        "apps.core.services.storage_service._get_media_root",
+        return_value=str(Path("/fake/media").resolve()),
+    ), patch("django.core.files.storage.default_storage.save") as mock_save, patch(
+        "django.core.files.storage.default_storage.exists", return_value=False
+    ) as mock_exists:
+        mixin._extract_files(zf)
+
+    mock_exists.assert_called_once_with("client_docs/a.pdf")
+    mock_save.assert_called_once()
+    name_arg, file_arg = mock_save.call_args[0]
+    assert name_arg == "client_docs/a.pdf"
+    assert file_arg.read() == b"pdf-bytes"
+
+
+def test_extract_files_skips_existing_storage_key(mixin: AdminImportExportMixin) -> None:
+    zf = _make_zip([("files/client_docs/a.pdf", b"pdf-bytes")])
+
+    with patch(
+        "apps.core.services.storage_service._get_media_root",
+        return_value=str(Path("/fake/media").resolve()),
+    ), patch("django.core.files.storage.default_storage.save") as mock_save, patch(
+        "django.core.files.storage.default_storage.exists", return_value=True
+    ):
+        mixin._extract_files(zf)
+
+    mock_save.assert_not_called()
+
+
+def test_extract_files_rejects_zip_slip(mixin: AdminImportExportMixin) -> None:
+    zf = _make_zip([("files/../../etc/passwd", b"evil")])
+
+    with patch(
+        "apps.core.services.storage_service._get_media_root",
+        return_value=str(Path("/fake/media").resolve()),
+    ), patch("django.core.files.storage.default_storage.save") as mock_save:
+        mixin._extract_files(zf)
+
+    mock_save.assert_not_called()

--- a/changelog/v26.56/v26.56.17.md
+++ b/changelog/v26.56/v26.56.17.md
@@ -1,0 +1,33 @@
+# v26.56.17
+
+> 分支：`fix/core-review-p2-cleanups`（core 代码清理 + 法院短信案号提取修复）
+
+## 后端
+
+### 修复
+
+#### fix(core): 清理 P2 级代码遗留问题
+
+- `infrastructure/logging.py`：`datetime.utcnow()` 在 Python 3.12 已弃用，且位于每条 JSON 日志的必经热路径，改为 `datetime.now(UTC)`，输出格式保持不变（`...Z` 后缀）
+- `middleware/token_rate_limit.py`：为异步限流路径补充竞态风险注释——Redis 后端下 `aget`/`aset` 非原子，多 worker 实例下绕过窗口比同步版更大，如需严格原子性应改用 Redis `INCR`
+- `services/conversation_service.py`：将类定义之后夹带的中段 import 上移到文件顶部，符合 PEP 8「imports 位于顶部」规范
+- `services/material_classification_service.py`：简化 `_extract_path_parts` 中冗余的条件表达式（原 `(cleaned and cleaned != part) or len(cleaned) > 0` 可等价简化为 `if cleaned:`）
+
+#### fix(core): Admin 导入解压改为走 storage 通道
+
+- `admin/mixins/import_export_mixin.py`：文件解压从裸 `write_bytes()` 改为 `default_storage.save()`，符合「Media 文件保存必须通过 storage 通道，禁止直接写盘」规范；同时保留 Zip Slip 路径遍历防护与传统「已存在不覆盖」语义
+- 新增 3 个聚焦单测：正常落盘、跳过已存在存储键、拒绝路径遍历
+
+### 修复
+
+#### fix(sms): 修复案号提取丢失年份且误吞文段
+
+- 根因：标准案号正则贪婪匹配，导致案号后连带的正文文字（含后续号码）被一起提取；降级捕获时又从法院代码数字处起取，丢失开头的年份前缀，最终只得到残缺的简式案号
+- 标准格式正则在序号数字处精确锚定，不再贪吃后续文字；简式案号改为紧凑捕获，避免回溯吞长句
+- 验证层按年份去重：带年份完整案号优先，缺失年份的残余片段剔除
+- 补充保留年份、去重简式残段的回归测试
+- 清理了历史短信记录及其关联案件中的污染案号数据（合规、超长、地址片段均已移除）
+
+#### 与案号隐私相关的说明
+
+- 上述「短信案号提取」修复涉及的案号内容属于案件敏感信息，本 changelog 仅描述问题现象与修复方式，不涉及任何具体案号原文


### PR DESCRIPTION
## 描述

本分支包含两批改动：对 `core` 应用 P2 级代码遗留问题的清理，以及法院短信案号提取的缺陷修复。

### 1. core P2 级代码清理

- **`infrastructure/logging.py`**：`datetime.utcnow()` 在 Python 3.12 已弃用，改为基础 `datetime.now(UTC)`，保持 JSON 日志输出格式不变（`...Z` 结尾）
- **`middleware/token_rate_limit.py`**：为异步限流路径补充竞态风险注释（Redis 后端下 `aget`/`aset` 非原子，多 worker 实例绕过窗口比同步版更大）
- **`services/conversation_service.py`**：将类定义后夹带的中段 import 上移至文件顶部，符合 PEP 8
- **`services/material_classification_service.py`**：简化 `_extract_path_parts` 冗余条件
- **`admin/mixins/import_export_mixin.py`**：文件解压从裸 `write_bytes()` 改为 `default_storage.save()`，符合「Media 文件保存必须走 storage 通道」规范；保留 Zip Slip 防护与「已存在不覆盖」语义

### 2. 法院短信案号提取修复

- **根因**：标准案号正则在序号处贪婪匹配，导致案号后连带的正文一起被提取；降级捕获又丢失年份前缀，最终只得到残缺简式案号
- **修复**：标准格式正则在序号数字处精确锚定；简式案号紧凑捕获；验证层按年份去重（带年份完整案号优先，缺失年份残段剔除）
- 补充保留年份、去重简式残段的回归测试

## 变更类型

- [x] Bug 修复
- [x] 重构（无功能变化）

## 影响范围

- [ ] 数据库迁移（如有，请说明）
- [ ] API 变更（如有，请说明）
- [ ] 破坏性变更（如有，请说明升级路径）

## AI 使用披露

- [x] 此 PR 包含 AI 辅助生成的代码（代码清理、案号正则修复、单元测试）

## 测试

- [x] 已添加/更新单元测试
- [x] 已进行手动测试（28421 个结构+单元测试通过；案号提取+import_export 专项 27 个通过）
- [x] 已检查 media 文件管理规范（import_export 已改为 `default_storage.save()`）

## Checklist

- [x] 代码符合项目规范（ruff, mypy 通过）
- [x] 已更新相关文档（changelog v26.56.17）
- [x] 无硬编码路径写入 media 目录（已改为 `default_storage.save()`）