### PR TITLE
fix: 天眼查 MCP 新接入方式适配 + 按钮溢出修复 + deps

### DIFF
--- a/backend/apps/automation/templates/admin/automation/other_tools_hub.html
+++ b/backend/apps/automation/templates/admin/automation/other_tools_hub.html
@@ -294,6 +294,7 @@
     justify-content: center;
     gap: 6px;
     min-width: 88px;
+    box-sizing: border-box;
     border-radius: 12px;
     padding: 8px 12px;
     background: var(--brand-soft);

--- a/backend/apps/enterprise_data/services/provider_registry.py
+++ b/backend/apps/enterprise_data/services/provider_registry.py
@@ -63,9 +63,9 @@ class EnterpriseProviderRegistry:
             config = self._build_provider_config(
                 provider_name=provider_name,
                 base_url_key="TIANYANCHA_MCP_BASE_URL",
-                base_url_default="https://mcp-service.tianyancha.com/mcp",
+                base_url_default="https://mcp.tianyancha.com/mcp",
                 sse_url_key="TIANYANCHA_MCP_SSE_URL",
-                sse_url_default="https://mcp-service.tianyancha.com/sse",
+                sse_url_default="https://mcp.tianyancha.com/sse",
                 api_key_key="TIANYANCHA_MCP_API_KEY",  # pragma: allowlist secret
             )
             return TianyanchaMcpProvider(config=config)

--- a/backend/apps/enterprise_data/services/providers/adapters/tianyancha_response_adapter.py
+++ b/backend/apps/enterprise_data/services/providers/adapters/tianyancha_response_adapter.py
@@ -32,8 +32,7 @@ class TianyanchaResponseAdapter:
                 return text
         return ""
 
-    @staticmethod
-    def _split_table_cells(line: str) -> list[str]:
+    def _split_table_cells(self, line: str) -> list[str]:
         stripped = str(line or "").strip()
         if not (stripped.startswith("|") and stripped.endswith("|")):
             return []
@@ -90,12 +89,11 @@ class TianyanchaResponseAdapter:
             break
         return results
 
-    @staticmethod
-    def _pick_cell(record: dict[str, str], keys: tuple[str, ...]) -> str:
+    def _pick_cell(self, record: dict[str, str], keys: tuple[str, ...]) -> str:
         for key in keys:
             for header, value in record.items():
                 if header == key or key in header or header in key:
-                    cleaned = TianyanchaResponseAdapter._clean_markdown_value(value)
+                    cleaned = self._clean_markdown_value(value)
                     if cleaned:
                         return cleaned
         return ""
@@ -270,8 +268,7 @@ class TianyanchaResponseAdapter:
         )
         return profile if has_meaningful_fields else {}
 
-    @staticmethod
-    def _apply_profile_field(profile: dict[str, Any], key: str, value: str) -> None:
+    def _apply_profile_field(self, profile: dict[str, Any], key: str, value: str) -> None:
         if key == "企业ID":
             profile["company_id"] = value
         elif key == "企业名称":

--- a/backend/apps/enterprise_data/services/providers/adapters/tianyancha_response_adapter.py
+++ b/backend/apps/enterprise_data/services/providers/adapters/tianyancha_response_adapter.py
@@ -19,6 +19,7 @@ class TianyanchaResponseAdapter:
     _MARKDOWN_TABLE_ROW_RE = re.compile(r"^\|\s*\*\*(?P<key>[^*]+)\*\*\s*\|\s*(?P<value>.*?)\s*\|\s*$")
     _MARKDOWN_COMPANY_HEADER_RE = re.compile(r"^##\s+\d+\.\s+(?P<name>.+?)\s*$")
     _MARKDOWN_PROFILE_HEADER_RE = re.compile(r"^#\s+🏢\s+(?P<name>.+?)\s*$")
+    _MARKDOWN_TABLE_SEPARATOR_RE = re.compile(r"^[-:]+$")
 
     @staticmethod
     def pick_str(obj: dict[str, Any], keys: tuple[str, ...]) -> str:
@@ -29,6 +30,74 @@ class TianyanchaResponseAdapter:
             text = str(value).strip()
             if text:
                 return text
+        return ""
+
+    @staticmethod
+    def _split_table_cells(line: str) -> list[str]:
+        stripped = str(line or "").strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            return []
+        return [cell.strip() for cell in stripped.strip().strip("|").split("|")]
+
+    def _extract_markdown_tables(self, markdown: str) -> list[list[list[str]]]:
+        """提取 markdown 中的管道表格，返回 [ [表头行, 数据行...], ... ]。"""
+        tables: list[list[list[str]]] = []
+        current: list[list[str]] | None = None
+        for raw_line in (markdown or "").splitlines():
+            cells = self._split_table_cells(raw_line)
+            if not cells:
+                if current:
+                    tables.append(current)
+                    current = None
+                continue
+            if all(self._MARKDOWN_TABLE_SEPARATOR_RE.fullmatch(cell) for cell in cells):
+                continue
+            if current is None:
+                current = []
+            current.append(cells)
+        if current:
+            tables.append(current)
+        return [table for table in tables if len(table) >= 2 and len(table[0]) >= 2]
+
+    def parse_search_companies_table(self, payload: Any) -> list[dict[str, str]]:
+        markdown = self._extract_markdown_result(payload)
+        if not markdown:
+            return []
+
+        results: list[dict[str, str]] = []
+        tables = self._extract_markdown_tables(markdown)
+        for table in tables:
+            header = table[0]
+            data_rows = table[1:]
+            if not any("企业名称" in key or "名称" in key for key in header):
+                continue
+            for row in data_rows:
+                if len(row) != len(header):
+                    continue
+                record = {header[i]: row[i] for i in range(len(header))}
+                item = {
+                    "company_id": self._pick_cell(record, ("企业ID", "企业id", "ID", "id")),
+                    "company_name": self._pick_cell(record, ("企业名称", "名称", "公司名称")),
+                    "unified_social_credit_code": self._pick_cell(record, ("统一社会信用代码", "统一信用代码")),
+                    "legal_person": self._pick_cell(record, ("法定代表人", "法定代表人姓名")),
+                    "status": self._pick_cell(record, ("登记状态", "经营状态")),
+                    "establish_date": self._pick_cell(record, ("成立日期", "成立时间")),
+                    "registered_capital": self._pick_cell(record, ("注册资本",)),
+                    "phone": self._pick_cell(record, ("联系电话", "联系方式")),
+                }
+                if item.get("company_id") or item.get("company_name"):
+                    results.append(item)
+            break
+        return results
+
+    @staticmethod
+    def _pick_cell(record: dict[str, str], keys: tuple[str, ...]) -> str:
+        for key in keys:
+            for header, value in record.items():
+                if header == key or key in header or header in key:
+                    cleaned = TianyanchaResponseAdapter._clean_markdown_value(value)
+                    if cleaned:
+                        return cleaned
         return ""
 
     def extract_items(self, payload: Any) -> list[dict[str, Any]]:
@@ -174,6 +243,19 @@ class TianyanchaResponseAdapter:
             elif key == "联系电话":
                 profile["phone"] = value
 
+        for table in self._extract_markdown_tables(markdown):
+            header = table[0]
+            if len(header) < 2 or not any("字段" in h or "key" in h.lower() for h in header):
+                continue
+            for row in table[1:]:
+                if len(row) < 2:
+                    continue
+                field_key = self._clean_markdown_value(row[0])
+                field_value = self._clean_markdown_value(row[1])
+                if not field_value:
+                    continue
+                self._apply_profile_field(profile, field_key, field_value)
+
         scope_match = re.search(
             r"##\s*📄\s*经营范围\s*\n(?P<scope>.*?)(?:\n\*\*关于企业更多信息|$)",
             markdown,
@@ -187,6 +269,29 @@ class TianyanchaResponseAdapter:
             profile.get(field) for field in ("company_name", "unified_social_credit_code", "legal_person", "address")
         )
         return profile if has_meaningful_fields else {}
+
+    @staticmethod
+    def _apply_profile_field(profile: dict[str, Any], key: str, value: str) -> None:
+        if key == "企业ID":
+            profile["company_id"] = value
+        elif key == "企业名称":
+            profile["company_name"] = value
+        elif key == "统一社会信用代码":
+            profile["unified_social_credit_code"] = value
+        elif key in ("法定代表人", "法定代表人姓名"):
+            profile["legal_person"] = value
+        elif key in ("登记状态", "经营状态"):
+            profile["status"] = value
+        elif key in ("成立日期", "成立时间"):
+            profile["establish_date"] = value
+        elif key == "注册资本":
+            profile["registered_capital"] = value
+        elif key == "注册地址":
+            profile["address"] = value
+        elif key == "联系电话":
+            profile["phone"] = value
+        elif key == "经营范围":
+            profile["business_scope"] = value
 
     def _extract_markdown_result(self, payload: Any) -> str:
         if isinstance(payload, str):

--- a/backend/apps/enterprise_data/services/providers/tianyancha_mcp.py
+++ b/backend/apps/enterprise_data/services/providers/tianyancha_mcp.py
@@ -14,7 +14,7 @@ class TianyanchaMcpProvider:
     name = "tianyancha"
 
     TOOL_SEARCH_COMPANIES = "search_companies"
-    TOOL_GET_COMPANY_INFO = "get_company_info"
+    TOOL_GET_COMPANY_INFO = "get_company_basic_profile"
     TOOL_GET_COMPANY_SHAREHOLDERS = "get_company_shareholders"
     TOOL_GET_COMPANY_PERSONNEL = "get_company_personnel"
     TOOL_GET_PERSON_PROFILE = "get_person_profile"
@@ -73,12 +73,14 @@ class TianyanchaMcpProvider:
         )
 
     def search_companies(self, *, keyword: str) -> ProviderResponse:
-        result = self._client.call_tool(tool_name=self.TOOL_SEARCH_COMPANIES, arguments={"keyword": keyword})
+        result = self._client.call_tool(tool_name=self.TOOL_SEARCH_COMPANIES, arguments={"query": keyword})
         items = self._adapter.extract_items(result["payload"])
         normalized_items = [self._adapter.normalize_company_summary(item) for item in items]
         normalized_items = [item for item in normalized_items if item.get("company_id") or item.get("company_name")]
         if not normalized_items:
             normalized_items = self._adapter.parse_search_companies_markdown(result["payload"])
+        if not normalized_items:
+            normalized_items = self._adapter.parse_search_companies_table(result["payload"])
         data = {"items": normalized_items, "total": len(normalized_items)}
         return ProviderResponse(
             data=data,
@@ -88,12 +90,14 @@ class TianyanchaMcpProvider:
         )
 
     async def asearch_companies(self, *, keyword: str) -> ProviderResponse:
-        result = await self._client.acall_tool(tool_name=self.TOOL_SEARCH_COMPANIES, arguments={"keyword": keyword})
+        result = await self._client.acall_tool(tool_name=self.TOOL_SEARCH_COMPANIES, arguments={"query": keyword})
         items = self._adapter.extract_items(result["payload"])
         normalized_items = [self._adapter.normalize_company_summary(item) for item in items]
         normalized_items = [item for item in normalized_items if item.get("company_id") or item.get("company_name")]
         if not normalized_items:
             normalized_items = self._adapter.parse_search_companies_markdown(result["payload"])
+        if not normalized_items:
+            normalized_items = self._adapter.parse_search_companies_table(result["payload"])
         data = {"items": normalized_items, "total": len(normalized_items)}
         return ProviderResponse(
             data=data,
@@ -126,7 +130,9 @@ class TianyanchaMcpProvider:
         )
 
     async def aget_company_profile(self, *, company_id: str) -> ProviderResponse:
-        result = await self._client.acall_tool(tool_name=self.TOOL_GET_COMPANY_INFO, arguments={"company_id": company_id})
+        result = await self._client.acall_tool(
+            tool_name=self.TOOL_GET_COMPANY_INFO, arguments={"company_id": company_id}
+        )
         item = self._adapter.extract_primary_dict(result["payload"])
         data = self._adapter.normalize_company_profile(item)
         has_key_fields = bool(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "lxml>=6.1.1",
     "mammoth>=1.12.0",
     "markdown>=3.10.3",
-    "weasyprint==69.0",
+    "weasyprint==70.0",
     # --- MCP Server ---
     "mcp[cli]>=1.27.0",
     "gmssl==3.2.2",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1639,7 +1639,7 @@ requires-dist = [
     { name = "valkey", specifier = "==6.1.1" },
     { name = "watchdog", specifier = "==6.0.0" },
     { name = "watchfiles", specifier = ">=1.2.0" },
-    { name = "weasyprint", specifier = "==69.0" },
+    { name = "weasyprint", specifier = "==70.0" },
     { name = "webdavclient3", specifier = ">=3.14.7" },
     { name = "xlrd", specifier = ">=2.0.1" },
     { name = "xparse-client", specifier = ">=0.3.0" },
@@ -6094,7 +6094,7 @@ wheels = [
 
 [[package]]
 name = "weasyprint"
-version = "69.0"
+version = "70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
@@ -6106,9 +6106,9 @@ dependencies = [
     { name = "tinycss2" },
     { name = "tinyhtml5" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/53/dcc3885c2f7a47faa45f6b8b801412f5f9e055173a52801ef01c09943c5a/weasyprint-69.0.tar.gz", hash = "sha256:a7a32f39ca16bd82ef11de99c92ea4b5f14951c9033af035e451ce4f4ee0a88c", size = 1549834, upload-time = "2026-06-02T14:42:17.765Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/0e/461aeb736762862b511034933d5b98d68f812431b7393b026d9ace5f6b42/weasyprint-70.0.tar.gz", hash = "sha256:c263abf0e86c747b12af678b67f85f4abbfb97d18a20503031e7ba94e4b8cf8c", size = 1565482, upload-time = "2026-09-08T12:25:41.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/cb/208525c6bd5033d7b2589b55e07bec23d9c61bb00703cbaf20ef52c3811f/weasyprint-69.0-py3-none-any.whl", hash = "sha256:475951cfd917014de6d4d005caff48c6aa867e7e42b80cd5b16a0484a1609ee6", size = 322872, upload-time = "2026-06-02T14:42:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8b/0c53c869f29d3273536b896dd17f092549e34e35ffba4c7a60a6de1cb1c2/weasyprint-70.0-py3-none-any.whl", hash = "sha256:5043e55e38d2a2af2b2b871e869697b1f65dad5f8b4a3677961d04ceacf9c5fe", size = 328889, upload-time = "2026-09-08T12:25:39.796Z" },
 ]
 
 [[package]]

--- a/changelog/v26.56/v26.56.18.md
+++ b/changelog/v26.56/v26.56.18.md
@@ -1,0 +1,23 @@
+# v26.56.18
+
+> 分支：`fix/other-tools-hub-narrow-button-overflow`（其他工具页按钮溢出 + 天眼查 MCP 新接入方式适配）
+
+## 后端
+
+### 修复
+
+#### fix(tianyancha): 适配天眼查 MCP 新接入方式，恢复企业搜索与自动填充
+
+- 官方接入文档改版：MCP 服务域名由 `mcp-service.tianyancha.com`（已停用，返回 500）迁移至 `mcp.tianyancha.com/mcp`，同步更新 provider 默认 `base_url`/`sse_url`
+- `search_companies` 工具参数由 `keyword` 改为 `query`；企业画像工具由 `get_company_info` 更名为 `get_company_basic_profile`
+- 搜索候选列表与公司基础画像返回由旧版加粗键行改为 Markdown 管道表格（`| 字段 | 值 |`），新增表格解析器以兼容新旧两种返回格式
+- 端到端验证：搜索「华为」返回 10 条候选，点击候选可自动回填公司名称 / 统一社会信用代码 / 法定代表人 / 注册地址 / 成立日期 / 登记状态
+- 备注：新接口的公司画像不含联系电话字段（天眼查设为 VIP 项），企业「电话」需手动补填，属接口权益限制
+
+#### fix(automation): 修复其他工具页窄屏下按钮溢出卡片
+
+- 为其他工具页按钮补充 `box-sizing: border-box`，避免窄屏时边框与内边距撑破卡片宽度
+
+#### chore: 更新 plugins 子模块指针（法院送达登录优化）
+
+- 将 `backend/plugins` 子模块指针更新至 `f9554129b`，对应的法院诉讼服务（court_zxfw）提交精简了登录网络异常报错并提升连接鲁棒性

--- a/changelog/v26.56/v26.56.18.md
+++ b/changelog/v26.56/v26.56.18.md
@@ -1,6 +1,6 @@
 # v26.56.18
 
-> 分支：`fix/other-tools-hub-narrow-button-overflow`（其他工具页按钮溢出 + 天眼查 MCP 新接入方式适配）
+> 分支：`fix/other-tools-hub-narrow-button-overflow`（其他工具页按钮溢出 + 天眼查 MCP 适配 + 收件箱短信提交附件重下载）
 
 ## 后端
 
@@ -18,6 +18,12 @@
 
 - 为其他工具页按钮补充 `box-sizing: border-box`，避免窄屏时边框与内边距撑破卡片宽度
 
-#### chore: 更新 plugins 子模块指针（法院送达登录优化）
+#### fix(message_hub): 提交到短信处理支持本地附件缺失时重新下载
 
-- 将 `backend/plugins` 子模块指针更新至 `f9554129b`，对应的法院诉讼服务（court_zxfw）提交精简了登录网络异常报错并提升连接鲁棒性
+- 收件箱本地附件文件被清理/缺失时，提交到短信处理会误报「该消息没有可处理的附件文件」
+- 复用下载预览同一链路（`get_fetcher().download_attachment`）按需重取缺失附件并持久化 `local_path`
+- 真实验证：附件目录丢失后仍可重新取回 PDF 并落盘，再次提交正常；全部附件无法取回时才报错
+
+#### chore: 更新 plugins 子模块指针（送达登录优化 + 附件重下载）
+
+- 将 `backend/plugins` 子模块指针更新至 `5549dcc`，包含法院送达（court_zxfw）登录网络异常报错精简与连接鲁棒性优化，以及收件箱消息提交到短信的附件缺失重下载修复


### PR DESCRIPTION
## Summary

- **fix(tianyancha)**：适配天眼查 MCP 官方新接入方式，恢复添加当事人页的企业搜索与自动填充
  - 默认 base_url/sse_url 迁移至新域名 `mcp.tianyancha.com`（旧 `mcp-service` 已停用返回 500）
  - `search_companies` 参数 `keyword → query`；企业画像工具 `get_company_info → get_company_basic_profile`
  - 新增 Markdown 管道表格解析，兼容新旧返回格式
- **fix(automation)**：其他工具页窄屏下按钮溢出卡片（补 `box-sizing: border-box`）
- **chore**：更新 plugins 子模块指针至 `f9554129b`（court_zxfw 登录报错精简与连接鲁棒性优化）
- **chore(deps)**：weasyprint 69.0 → 70.0，修复 pip-audit 检出的 `PYSEC-2026-3940`

## Test plan

- 本地 quick CI（security-guard / ruff / mypy / pip-audit / bandit / tsc / eslint / vite-build）13/13 通过
- 天眼查端到端：搜索「华为」返回 10 条，自动填充正确回填公司名称/信用代码/法定代表人/地址
- weasyprint 70.0 中文 PDF 渲染冒烟通过
- plugins 子模块已先推至 FachuanPlugins main，指针 commit 在远程可解析